### PR TITLE
Custom job data formatter

### DIFF
--- a/src/@types/app.ts
+++ b/src/@types/app.ts
@@ -1,7 +1,9 @@
+import * as Redis from 'ioredis'
+
 import { Job, JobOptions } from 'bull'
 import { Job as JobMq, JobsOptions } from 'bullmq'
+
 import React from 'react'
-import * as Redis from 'ioredis'
 import { Status } from '../ui/components/constants'
 
 export type JobCleanStatus =
@@ -11,12 +13,17 @@ export type JobCleanStatus =
   | 'delayed'
   | 'failed'
 
+export type AdapterOptions = {
+  jobParser(job: Job | JobMq): AppJob
+}
+
 export type JobStatus = Status
 
 export type JobCounts = Record<JobStatus, number>
 
 export interface QueueAdapter {
   readonly client: Promise<Redis.Redis>
+  readonly options?: AdapterOptions
   getName(): string
 
   getJob(id: string): Promise<Job | JobMq | undefined | null>
@@ -64,6 +71,8 @@ export interface AppJob {
   delay: number | undefined
   returnValue: string | Record<string | number, any> | null
 }
+
+export type DataFormatter = (data: JobMq['data']) => JobMq['data']
 
 export interface AppQueue {
   name: string

--- a/src/@types/app.ts
+++ b/src/@types/app.ts
@@ -14,7 +14,7 @@ export type JobCleanStatus =
   | 'failed'
 
 export type AdapterOptions = {
-  jobParser(job: Job | JobMq): AppJob
+  dataFormatter(job: Job | JobMq): AppJob
 }
 
 export type JobStatus = Status

--- a/src/queueAdapters/bull.ts
+++ b/src/queueAdapters/bull.ts
@@ -1,17 +1,18 @@
-import { Job, Queue } from 'bull'
 import {
+  AdapterOptions,
   JobCleanStatus,
   JobCounts,
   JobStatus,
   QueueAdapter,
 } from '../@types/app'
+import { Job, Queue } from 'bull'
 
 export class BullAdapter implements QueueAdapter {
   public get client() {
     return Promise.resolve(this.queue.client)
   }
 
-  constructor(public queue: Queue) {}
+  constructor(public queue: Queue, public options: AdapterOptions) {}
 
   public getName(): string {
     return this.queue.name

--- a/src/queueAdapters/bull.ts
+++ b/src/queueAdapters/bull.ts
@@ -12,7 +12,7 @@ export class BullAdapter implements QueueAdapter {
     return Promise.resolve(this.queue.client)
   }
 
-  constructor(public queue: Queue, public options: AdapterOptions) {}
+  constructor(public queue: Queue, public options?: AdapterOptions) {}
 
   public getName(): string {
     return this.queue.name

--- a/src/queueAdapters/bullMQ.ts
+++ b/src/queueAdapters/bullMQ.ts
@@ -1,11 +1,13 @@
-import { Job, Queue } from 'bullmq'
 import * as Redis from 'ioredis'
+
 import {
+  AdapterOptions,
   JobCleanStatus,
   JobCounts,
   JobStatus,
   QueueAdapter,
 } from '../@types/app'
+import { Job, Queue } from 'bullmq'
 
 export class BullMQAdapter implements QueueAdapter {
   private readonly LIMIT = 1000
@@ -14,7 +16,7 @@ export class BullMQAdapter implements QueueAdapter {
     return (this.queue.client as unknown) as Promise<Redis.Redis>
   }
 
-  constructor(private queue: Queue) {}
+  constructor(private queue: Queue, public options?: AdapterOptions) {}
 
   public getName(): string {
     return this.queue.toKey('~')

--- a/src/routes/queues.ts
+++ b/src/routes/queues.ts
@@ -40,7 +40,7 @@ const getStats = async ({
   return validMetrics
 }
 
-const formatJob = (formatter: app.DataFormatter = (d) => d) => {
+const formatJob = (dataFormatter: app.DataFormatter = (d) => d) => {
   return (job: Job | JobMq): app.AppJob => {
     const jobProps = job.toJSON()
 
@@ -55,7 +55,7 @@ const formatJob = (formatter: app.DataFormatter = (d) => d) => {
       failedReason: jobProps.failedReason,
       stacktrace: jobProps.stacktrace,
       opts: jobProps.opts,
-      data: formatter(jobProps.data),
+      data: dataFormatter(jobProps.data),
       name: jobProps.name,
       returnValue: jobProps.returnvalue,
     }
@@ -91,11 +91,11 @@ const getDataForQueues = async (
       const status =
         query[name] === 'latest' ? statuses : (query[name] as JobStatus[])
       const jobs = await queue.getJobs(status, 0, 10)
-      const parser = formatJob(queue.options?.jobParser)
+      const formatter = formatJob(queue.options?.dataFormatter)
       return {
         name,
         counts: counts as Record<Status, number>,
-        jobs: jobs.map(parser),
+        jobs: jobs.map(formatter),
       }
     }),
   )


### PR DESCRIPTION
## Summary 

User can now specify AdapterOptions passed to the BullAdapter on creation. In this user can specify the dataFormatter, which provides an alternative way to parse job data to be displayed in the Jobs List UI.

## Rationale

I have a rather large payload that I send over my queue, and parsing that causes the UI to be very unresponsive. Using a custom data parser I can now instead show a subset of the full payload in the UI.

![image](https://user-images.githubusercontent.com/1462828/102773152-ba681880-43c3-11eb-8f9e-a6d24816c942.png)


![image](https://user-images.githubusercontent.com/1462828/102772880-3f066700-43c3-11eb-8335-54deaca64765.png)
