### PR TITLE
feat: allow to pass a data & returnValue formatters

### DIFF
--- a/src/@types/app.ts
+++ b/src/@types/app.ts
@@ -1,7 +1,7 @@
 import { Job, JobOptions } from 'bull'
 import { Job as JobMq, JobsOptions } from 'bullmq'
-import React from 'react'
 import * as Redis from 'ioredis'
+import React from 'react'
 import { Status } from '../ui/components/constants'
 
 export type JobCleanStatus =
@@ -16,8 +16,9 @@ export type JobStatus = Status
 export type JobCounts = Record<JobStatus, number>
 
 export interface QueueAdapter {
-  readonly client: Promise<Redis.Redis>
   readonly readOnlyMode: boolean
+
+  getClient(): Promise<Redis.Redis>
 
   getName(): string
 
@@ -32,6 +33,13 @@ export interface QueueAdapter {
   getJobCounts(...jobStatuses: JobStatus[]): Promise<JobCounts>
 
   clean(queueStatus: JobCleanStatus, graceTimeMs: number): Promise<any>
+
+  setFormatter(
+    field: 'data' | 'returnValue',
+    formatter: (data: any) => any,
+  ): void
+
+  format(field: 'data' | 'returnValue', data: any): any
 }
 
 export interface QueueAdapterOptions {

--- a/src/queueAdapters/base.ts
+++ b/src/queueAdapters/base.ts
@@ -1,0 +1,52 @@
+import { Job } from 'bull'
+import { Job as JobMq } from 'bullmq'
+import {
+  JobCleanStatus,
+  JobCounts,
+  JobStatus,
+  QueueAdapter,
+  QueueAdapterOptions,
+} from '../@types/app'
+import * as Redis from 'ioredis'
+
+export abstract class BaseAdapter implements QueueAdapter {
+  public readonly readOnlyMode: boolean
+  private formatters: Record<string, (data: any) => any> = {}
+
+  protected constructor(options: Partial<QueueAdapterOptions> = {}) {
+    this.readOnlyMode = options.readOnlyMode === true
+  }
+
+  public setFormatter(
+    field: 'data' | 'returnValue',
+    formatter: (data: any) => any,
+  ): void {
+    this.formatters[field] = formatter
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public format(field: 'data' | 'returnValue', data: any): any {
+    return typeof this.formatters[field] === 'function'
+      ? this.formatters[field](data)
+      : data
+  }
+
+  public abstract clean(
+    queueStatus: JobCleanStatus,
+    graceTimeMs: number,
+  ): Promise<void>
+
+  public abstract getJob(id: string): Promise<Job | JobMq | undefined | null>
+
+  public abstract getJobCounts(...jobStatuses: JobStatus[]): Promise<JobCounts>
+
+  public abstract getJobs(
+    jobStatuses: JobStatus[],
+    start?: number,
+    end?: number,
+  ): Promise<(Job | JobMq)[]>
+
+  public abstract getName(): string
+
+  public abstract getClient(): Promise<Redis.Redis>
+}

--- a/src/queueAdapters/bull.ts
+++ b/src/queueAdapters/bull.ts
@@ -6,16 +6,15 @@ import {
   QueueAdapter,
   QueueAdapterOptions,
 } from '../@types/app'
+import { BaseAdapter } from './base'
 
-export class BullAdapter implements QueueAdapter {
-  public readonly readOnlyMode: boolean
-
-  public get client(): Promise<Queue['client']> {
-    return Promise.resolve(this.queue.client)
+export class BullAdapter extends BaseAdapter implements QueueAdapter {
+  constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
+    super(options)
   }
 
-  constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
-    this.readOnlyMode = options.readOnlyMode === true
+  public getClient(): Promise<Queue['client']> {
+    return Promise.resolve(this.queue.client)
   }
 
   public getName(): string {

--- a/src/queueAdapters/bullMQ.ts
+++ b/src/queueAdapters/bullMQ.ts
@@ -3,23 +3,22 @@ import {
   JobCleanStatus,
   JobCounts,
   JobStatus,
-  QueueAdapter,
   QueueAdapterOptions,
 } from '../@types/app'
+import { BaseAdapter } from './base'
 
-export class BullMQAdapter implements QueueAdapter {
-  public readonly readOnlyMode: boolean
+export class BullMQAdapter extends BaseAdapter {
   private readonly LIMIT = 1000
-
-  public get client(): Queue['client'] {
-    return this.queue.client
-  }
 
   constructor(
     private queue: Queue,
     options: Partial<QueueAdapterOptions> = {},
   ) {
-    this.readOnlyMode = options.readOnlyMode === true
+    super(options)
+  }
+
+  public getClient(): Queue['client'] {
+    return this.queue.client
   }
 
   public getName(): string {

--- a/src/routes/queues.ts
+++ b/src/routes/queues.ts
@@ -5,7 +5,7 @@ import { parse as parseRedisInfo } from 'redis-info'
 
 import * as api from '../@types/api'
 import * as app from '../@types/app'
-import { JobStatus } from '../@types/app'
+import { JobStatus, QueueAdapter } from '../@types/app'
 import { Status } from '../ui/components/constants'
 
 type MetricName = keyof app.ValidMetrics
@@ -21,7 +21,7 @@ const metrics: MetricName[] = [
 const getStats = async ({
   queue,
 }: app.BullBoardQueue): Promise<app.ValidMetrics> => {
-  const redisClient = await queue.client
+  const redisClient = await queue.getClient()
   const redisInfoRaw = await redisClient.info()
   const redisInfo = parseRedisInfo(redisInfoRaw)
 
@@ -39,7 +39,7 @@ const getStats = async ({
   return validMetrics
 }
 
-const formatJob = (job: Job | JobMq): app.AppJob => {
+const formatJob = (job: Job | JobMq, queue: QueueAdapter): app.AppJob => {
   const jobProps = job.toJSON()
 
   return {
@@ -53,9 +53,9 @@ const formatJob = (job: Job | JobMq): app.AppJob => {
     failedReason: jobProps.failedReason,
     stacktrace: jobProps.stacktrace ? jobProps.stacktrace.filter(Boolean) : [],
     opts: jobProps.opts,
-    data: jobProps.data,
+    data: queue.format('data', jobProps.data),
     name: jobProps.name,
-    returnValue: jobProps.returnvalue,
+    returnValue: queue.format('returnValue', jobProps.returnvalue),
   }
 }
 
@@ -92,7 +92,7 @@ const getDataForQueues = async (
       return {
         name,
         counts: counts as Record<Status, number>,
-        jobs: jobs.map(formatJob),
+        jobs: jobs.map((job) => formatJob(job, queue)),
         readOnlyMode: queue.readOnlyMode,
       }
     }),


### PR DESCRIPTION
@Jivings, I've added this ability with a different approach.

```js
// server.js

const Queue = require('bull')
const QueueMQ = require('bullmq')
const { setQueues, BullMQAdapter, BullAdapter } = require('bull-board')

const someQueue = new Queue()
const someOtherQueue = new Queue()
const queueMQ = new QueueMQ()

const someQueueAdapter = new BullAdapter(someQueue);

someQueueAdapter.setFormatter('data', ({ secret, ...rest }) => ({ ...rest })); // this will apply data formatter
someQueueAdapter.setFormatter('returnValue', ({ token, ...rest }) => ({ ...rest })); // this will apply returnValue formatter

setQueues([
  someQueueAdapter,
  new BullAdapter(someOtherQueue),
  new BullMQAdapter(queueMQ),
]);
```

closes #204