### PR TITLE
Fix typo (bullMQAdapter to BullMQAdapter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const Queue = require('bull')
 const QueueMQ = require('bullmq')
 const { createBullBoard } = require('bull-board')
 const { BullAdapter } = require('bull-board/bullAdapter')
-const { bullMQAdapter } = require('bull-board/bullMQAdapter')
+const { BullMQAdapter } = require('bull-board/bullMQAdapter')
 
 const someQueue = new Queue('someQueueName')
 const someOtherQueue = new Queue('someOtherQueueName')


### PR DESCRIPTION
According to this file:

https://github.com/felixmosh/bull-board/blob/master/bullMQAdapter.d.ts

The correct name should be `BullMQAdapter`  (with uppercase B).