### PR TITLE
fix: type 'BaseAdapter' <Redis.Redis> to <Redis>

### DIFF
--- a/src/queueAdapters/base.ts
+++ b/src/queueAdapters/base.ts
@@ -48,5 +48,5 @@ export abstract class BaseAdapter {
 
   public abstract getName(): string
 
-  public abstract getClient(): Promise<Redis.Redis>
+  public abstract getClient(): Promise<Redis>
 }


### PR DESCRIPTION
Fixing for the Issue #271 (Type 'BullMQAdapter' is not assignable to type 'BaseAdapter' (Wrong Types))