### PR TITLE
Display stacktrace on delayed status page

### DIFF
--- a/packages/ui/src/components/JobCard/Details/Details.tsx
+++ b/packages/ui/src/components/JobCard/Details/Details.tsx
@@ -13,7 +13,10 @@ interface DetailsProps {
 }
 
 export const Details = ({ status, job, actions }: DetailsProps) => {
-  const { tabs, selectedTab } = useDetailsTabs(job.isFailed ? STATUSES.failed : status);
+  const { tabs, selectedTab } = useDetailsTabs(
+    job.isFailed ? STATUSES.failed : status,
+    job.stacktrace.length > 0
+  );
 
   if (tabs.length === 0) {
     return null;

--- a/packages/ui/src/hooks/useDetailsTabs.tsx
+++ b/packages/ui/src/hooks/useDetailsTabs.tsx
@@ -6,13 +6,17 @@ const regularItems = ['Data', 'Options', 'Logs'] as const;
 
 export type TabsType = typeof regularItems[number] | 'Error';
 
-export function useDetailsTabs(currentStatus: Status) {
+export function useDetailsTabs(currentStatus: Status, hasStacktrace: boolean) {
   const [tabs, updateTabs] = useState<TabsType[]>([]);
   const [selectedTabIdx, setSelectedTabIdx] = useState(0);
   const selectedTab = tabs[selectedTabIdx];
 
   useEffect(() => {
-    updateTabs(currentStatus === STATUSES.failed ? ['Error', ...regularItems] : [...regularItems]);
+    updateTabs(
+      currentStatus === STATUSES.failed || (currentStatus === STATUSES.delayed && hasStacktrace)
+        ? ['Error', ...regularItems]
+        : [...regularItems]
+    );
   }, [currentStatus]);
 
   return {


### PR DESCRIPTION
This PR updates the job card to display the jobs stacktrace if the job is in the delayed status. This situation can occur if the job fails but is set to retry one or more times with a backoff strategy. Displaying the stacktrace here helps identify jobs which have been delayed due to error vs being delayed manually and ensures that we don't need to wait until all attempts have been exhausted to identify an error.

> **Note:** I've deliberately designed this to only show stacktraces for failed and delayed statuses because I feel it would be confusing/misleading for a stacktrace to be shown in other states. For example, displaying it in the active state may lead the user to believe that the current execution has failed and the job has not yet been moved to another status.

<img width="1440" alt="Screenshot 2021-06-12 at 11 33 15" src="https://user-images.githubusercontent.com/34132/121771982-f1e59f80-cb72-11eb-9ecf-bde8bc2cd880.png">
