### PR TITLE
Move React development dependencies to devDependecies

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,12 +27,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@bull-board/api": "3.5.0",
-    "@radix-ui/react-alert-dialog": "^0.0.19",
-    "@radix-ui/react-dropdown-menu": "^0.0.22"
+    "@bull-board/api": "3.5.0"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+    "@radix-ui/react-alert-dialog": "^0.0.19",
+    "@radix-ui/react-dropdown-menu": "^0.0.22",
     "@types/pretty-bytes": "^5.2.0",
     "@types/react-dom": "^17.0.5",
     "@types/react-highlight": "^0.12.2",


### PR DESCRIPTION
We have a backend app. Which is small. But for some reason we have a couple of hundred React modules installed in production, in a little pure web server (soon to be a little AWS lambda).

Looks like `@bull-board/ui` have the UI inside the NPM gzip bundle: `/dist/static/`. This bundle already contains React dependencies, compiled, minified, bundled.

We identified the problem. The `@radix-ui/` things are not production dependencies. They are build-time dependencies (aka devDependencies in NPM).

This PR decreased the `node_modules` by 
* @radix-ui/react-alert-dialog@0.0.19 (40 deps, 945.31kb, 799 files)
* @radix-ui/react-dropdown-menu@0.0.22 (51 deps, 2.22mb, 721 files)

See for yourself:
```shell
npx howfat -r tree @bull-board/ui
```

Please, publish the `@bull-board/ui` with this little fix. The little servers across the world will be thankful. :)