### PR TITLE
Remove unused return value from `createBullBoard()`

### DIFF
--- a/examples/with-express-auth/index.js
+++ b/examples/with-express-auth/index.js
@@ -75,7 +75,7 @@ const run = async () => {
   const serverAdapter = new ExpressAdapter();
   serverAdapter.setBasePath('/ui');
 
-  const { router: bullBoardRouter } = createBullBoard({
+  createBullBoard({
     queues: [new BullMQAdapter(exampleBullMq)],
     serverAdapter,
   });


### PR DESCRIPTION
The express just uses serverAdapter.getRouter(), so I think this is uneeded