### PR TITLE
Add canRetry options to queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const { setQueues, replaceQueues } = createBullBoard({
 ```
 
 2. `allowRetries` (default: `true`)
-Removes the retry job(s) buttons in the UI for a queue. This option will be ignored if `readOnlyMode` is `true`.
+When set to `false` the UI removes the job retry buttons for a queue. This option will be ignored if `readOnlyMode` is `true`.
 
 ```js
 const QueueMQ = require('bullmq')

--- a/README.md
+++ b/README.md
@@ -118,6 +118,28 @@ const { setQueues, replaceQueues } = createBullBoard({
 })
 ```
 
+2. `allowRetries` (default: `true`)
+Removes the retry job(s) buttons in the UI for a queue. This option will be ignored if `readOnlyMode` is `true`.
+
+```js
+const QueueMQ = require('bullmq')
+const { createBullBoard } = require('@bull-board/api')
+const { BullMQAdapter } = require('@bull-board/api/bullMQAdapter')
+const { BullAdapter } = require('@bull-board/api/bullAdapter')
+
+const someQueue = new Queue()
+const someOtherQueue = new Queue()
+const queueMQ = new QueueMQ()
+
+const { setQueues, replaceQueues } = createBullBoard({
+  queues: [
+    new BullAdapter(someQueue), 
+    new BullAdapter(someOtherQueue, , { allowRetries: false }), // No retry buttons
+    new BullMQAdapter(queueMQ, { allowRetries: true, readOnlyMode: true }), // allowRetries will be ignored in this case in lieu of readOnlyMode
+  ]
+})
+```
+
 ### Hosting router on a sub path
 
 If you host your express service on a different path than root (/) ie. https://<server_name>/<sub_path>/, then you can add the following code to provide the configuration to the bull-board router. In this example the sub path will be `my-base-path`.

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -115,7 +115,7 @@ async function getAppQueues(
         jobs: jobs.filter(Boolean).map((job) => formatJob(job, queue)),
         pagination,
         readOnlyMode: queue.readOnlyMode,
-        canRetry: queue.canRetry,
+        allowRetries: queue.allowRetries,
         isPaused,
       };
     })

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -115,6 +115,7 @@ async function getAppQueues(
         jobs: jobs.filter(Boolean).map((job) => formatJob(job, queue)),
         pagination,
         readOnlyMode: queue.readOnlyMode,
+        canRetry: queue.canRetry,
         isPaused,
       };
     })

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -9,13 +9,13 @@ import {
 
 export abstract class BaseAdapter {
   public readonly readOnlyMode: boolean;
-  public readonly canRetry: boolean;
+  public readonly allowRetries: boolean;
   public readonly prefix: string;
   private formatters = new Map<FormatterField, (data: any) => any>();
 
   protected constructor(options: Partial<QueueAdapterOptions> = {}) {
     this.readOnlyMode = options.readOnlyMode === true;
-    this.canRetry = (this.readOnlyMode) ? false : options.canRetry !== false;
+    this.allowRetries = this.readOnlyMode ? false : options.allowRetries !== false;
     this.prefix = options.prefix || '';
   }
 

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -9,11 +9,13 @@ import {
 
 export abstract class BaseAdapter {
   public readonly readOnlyMode: boolean;
+  public readonly canRetry: boolean;
   public readonly prefix: string;
   private formatters = new Map<FormatterField, (data: any) => any>();
 
   protected constructor(options: Partial<QueueAdapterOptions> = {}) {
     this.readOnlyMode = options.readOnlyMode === true;
+    this.canRetry = (this.readOnlyMode) ? false : options.canRetry !== false;
     this.prefix = options.prefix || '';
   }
 

--- a/packages/api/tests/api/index.spec.ts
+++ b/packages/api/tests/api/index.spec.ts
@@ -42,6 +42,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
+                "canRetry": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -126,6 +127,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
+                "canRetry": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -193,6 +195,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
+                "canRetry": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -326,6 +329,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
+                "canRetry": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -345,6 +349,144 @@ describe('happy', () => {
                   },
                 },
                 "readOnlyMode": false,
+              },
+            ],
+            "stats": Object {
+              "blocked_clients": Any<String>,
+              "connected_clients": Any<String>,
+              "mem_fragmentation_ratio": Any<String>,
+              "redis_version": Any<String>,
+              "total_system_memory": Any<String>,
+              "used_memory": Any<String>,
+            },
+          }
+        `
+        );
+      });
+  });
+
+  it('should disable retries in queue', async () => {
+    const paintQueue = new Queue('Paint', {
+      connection: {
+        host: 'localhost',
+        port: 6379,
+      },
+    });
+
+    createBullBoard({
+      queues: [new BullMQAdapter(paintQueue, { canRetry: false })],
+      serverAdapter,
+    });
+
+    await request(serverAdapter.getRouter())
+      .get('/api/queues')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(JSON.parse(res.text)).toMatchInlineSnapshot(
+          {
+            stats: {
+              blocked_clients: expect.any(String),
+              connected_clients: expect.any(String),
+              mem_fragmentation_ratio: expect.any(String),
+              redis_version: expect.any(String),
+              total_system_memory: expect.any(String),
+              used_memory: expect.any(String),
+            },
+          },
+          `
+          Object {
+            "queues": Array [
+              Object {
+                "canRetry": false,
+                "counts": Object {
+                  "active": 0,
+                  "completed": 0,
+                  "delayed": 0,
+                  "failed": 0,
+                  "paused": 0,
+                  "waiting": 0,
+                },
+                "isPaused": false,
+                "jobs": Array [],
+                "name": "Paint",
+                "pagination": Object {
+                  "pageCount": 1,
+                  "range": Object {
+                    "end": 9,
+                    "start": 0,
+                  },
+                },
+                "readOnlyMode": false,
+              },
+            ],
+            "stats": Object {
+              "blocked_clients": Any<String>,
+              "connected_clients": Any<String>,
+              "mem_fragmentation_ratio": Any<String>,
+              "redis_version": Any<String>,
+              "total_system_memory": Any<String>,
+              "used_memory": Any<String>,
+            },
+          }
+        `
+        );
+      });
+  });
+
+  it('should disable retries in queue if readOnlyMode is true', async () => {
+    const paintQueue = new Queue('Paint', {
+      connection: {
+        host: 'localhost',
+        port: 6379,
+      },
+    });
+
+    createBullBoard({
+      queues: [new BullMQAdapter(paintQueue, { canRetry: true, readOnlyMode: true })],
+      serverAdapter,
+    });
+
+    await request(serverAdapter.getRouter())
+      .get('/api/queues')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        expect(JSON.parse(res.text)).toMatchInlineSnapshot(
+          {
+            stats: {
+              blocked_clients: expect.any(String),
+              connected_clients: expect.any(String),
+              mem_fragmentation_ratio: expect.any(String),
+              redis_version: expect.any(String),
+              total_system_memory: expect.any(String),
+              used_memory: expect.any(String),
+            },
+          },
+          `
+          Object {
+            "queues": Array [
+              Object {
+                "canRetry": false,
+                "counts": Object {
+                  "active": 0,
+                  "completed": 0,
+                  "delayed": 0,
+                  "failed": 0,
+                  "paused": 0,
+                  "waiting": 0,
+                },
+                "isPaused": false,
+                "jobs": Array [],
+                "name": "Paint",
+                "pagination": Object {
+                  "pageCount": 1,
+                  "range": Object {
+                    "end": 9,
+                    "start": 0,
+                  },
+                },
+                "readOnlyMode": true,
               },
             ],
             "stats": Object {

--- a/packages/api/tests/api/index.spec.ts
+++ b/packages/api/tests/api/index.spec.ts
@@ -42,7 +42,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
-                "canRetry": true,
+                "allowRetries": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -127,7 +127,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
-                "canRetry": true,
+                "allowRetries": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -195,7 +195,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
-                "canRetry": true,
+                "allowRetries": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -329,7 +329,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
-                "canRetry": true,
+                "allowRetries": true,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -374,7 +374,7 @@ describe('happy', () => {
     });
 
     createBullBoard({
-      queues: [new BullMQAdapter(paintQueue, { canRetry: false })],
+      queues: [new BullMQAdapter(paintQueue, { allowRetries: false })],
       serverAdapter,
     });
 
@@ -398,7 +398,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
-                "canRetry": false,
+                "allowRetries": false,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,
@@ -443,7 +443,7 @@ describe('happy', () => {
     });
 
     createBullBoard({
-      queues: [new BullMQAdapter(paintQueue, { canRetry: true, readOnlyMode: true })],
+      queues: [new BullMQAdapter(paintQueue, { allowRetries: true, readOnlyMode: true })],
       serverAdapter,
     });
 
@@ -467,7 +467,7 @@ describe('happy', () => {
           Object {
             "queues": Array [
               Object {
-                "canRetry": false,
+                "allowRetries": false,
                 "counts": Object {
                   "active": 0,
                   "completed": 0,

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -11,7 +11,7 @@ export type JobCounts = Record<Status, number>;
 
 export interface QueueAdapterOptions {
   readOnlyMode: boolean;
-  canRetry: boolean;
+  allowRetries: boolean;
   prefix: string;
 }
 
@@ -81,7 +81,7 @@ export interface AppQueue {
   jobs: AppJob[];
   pagination: Pagination;
   readOnlyMode: boolean;
-  canRetry: boolean;
+  allowRetries: boolean;
   isPaused: boolean;
 }
 

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -11,6 +11,7 @@ export type JobCounts = Record<Status, number>;
 
 export interface QueueAdapterOptions {
   readOnlyMode: boolean;
+  canRetry: boolean;
   prefix: string;
 }
 
@@ -80,6 +81,7 @@ export interface AppQueue {
   jobs: AppJob[];
   pagination: Pagination;
   readOnlyMode: boolean;
+  canRetry: boolean;
   isPaused: boolean;
 }
 

--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -10,7 +10,7 @@ import { STATUSES } from '@bull-board/api/src/constants/statuses';
 
 interface JobActionsProps {
   status: Status;
-  canRetry: boolean;
+  allowRetries: boolean;
   actions: {
     promoteJob: () => Promise<void>;
     retryJob: () => Promise<void>;
@@ -37,12 +37,12 @@ const statusToButtonsMap: Record<string, ButtonType[]> = {
   [STATUSES.waiting]: [buttonTypes.clean],
 };
 
-export const JobActions = ({ actions, status, canRetry }: JobActionsProps) => {
+export const JobActions = ({ actions, status, allowRetries }: JobActionsProps) => {
   let buttons = statusToButtonsMap[status];
   if (!buttons) {
     return null;
   }
-  if (!canRetry) {
+  if (!allowRetries) {
     buttons = buttons.filter((btn) => btn.actionKey !== 'retryJob');
   }
   return (

--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -10,6 +10,7 @@ import { STATUSES } from '@bull-board/api/src/constants/statuses';
 
 interface JobActionsProps {
   status: Status;
+  canRetry: boolean;
   actions: {
     promoteJob: () => Promise<void>;
     retryJob: () => Promise<void>;
@@ -36,10 +37,13 @@ const statusToButtonsMap: Record<string, ButtonType[]> = {
   [STATUSES.waiting]: [buttonTypes.clean],
 };
 
-export const JobActions = ({ actions, status }: JobActionsProps) => {
-  const buttons = statusToButtonsMap[status];
+export const JobActions = ({ actions, status, canRetry }: JobActionsProps) => {
+  let buttons = statusToButtonsMap[status];
   if (!buttons) {
     return null;
+  }
+  if (!canRetry) {
+    buttons = buttons.filter((btn) => btn.actionKey !== 'retryJob');
   }
   return (
     <ul className={s.jobActions}>

--- a/packages/ui/src/components/JobCard/JobCard.tsx
+++ b/packages/ui/src/components/JobCard/JobCard.tsx
@@ -11,6 +11,7 @@ interface JobCardProps {
   job: AppJob;
   status: Status;
   readOnlyMode: boolean;
+  canRetry: boolean;
   actions: {
     promoteJob: () => Promise<void>;
     retryJob: () => Promise<void>;
@@ -21,7 +22,7 @@ interface JobCardProps {
 
 const greenStatuses = [STATUSES.active, STATUSES.completed];
 
-export const JobCard = ({ job, status, actions, readOnlyMode }: JobCardProps) => (
+export const JobCard = ({ job, status, actions, readOnlyMode, canRetry }: JobCardProps) => (
   <div className={s.card}>
     <div className={s.sideInfo}>
       <span title={`#${job.id}`}>#{job.id}</span>
@@ -39,7 +40,7 @@ export const JobCard = ({ job, status, actions, readOnlyMode }: JobCardProps) =>
             </span>
           )}
         </h4>
-        {!readOnlyMode && <JobActions status={status} actions={actions} />}
+        {!readOnlyMode && <JobActions status={status} actions={actions} canRetry={canRetry}  />}
       </div>
       <div className={s.content}>
         <Details status={status} job={job} actions={actions} />

--- a/packages/ui/src/components/JobCard/JobCard.tsx
+++ b/packages/ui/src/components/JobCard/JobCard.tsx
@@ -11,7 +11,7 @@ interface JobCardProps {
   job: AppJob;
   status: Status;
   readOnlyMode: boolean;
-  canRetry: boolean;
+  allowRetries: boolean;
   actions: {
     promoteJob: () => Promise<void>;
     retryJob: () => Promise<void>;
@@ -22,7 +22,7 @@ interface JobCardProps {
 
 const greenStatuses = [STATUSES.active, STATUSES.completed];
 
-export const JobCard = ({ job, status, actions, readOnlyMode, canRetry }: JobCardProps) => (
+export const JobCard = ({ job, status, actions, readOnlyMode, allowRetries }: JobCardProps) => (
   <div className={s.card}>
     <div className={s.sideInfo}>
       <span title={`#${job.id}`}>#{job.id}</span>
@@ -40,7 +40,9 @@ export const JobCard = ({ job, status, actions, readOnlyMode, canRetry }: JobCar
             </span>
           )}
         </h4>
-        {!readOnlyMode && <JobActions status={status} actions={actions} canRetry={canRetry}  />}
+        {!readOnlyMode && (
+          <JobActions status={status} actions={actions} allowRetries={allowRetries} />
+        )}
       </div>
       <div className={s.content}>
         <Details status={status} job={job} actions={actions} />

--- a/packages/ui/src/components/QueueActions/QueueActions.tsx
+++ b/packages/ui/src/components/QueueActions/QueueActions.tsx
@@ -11,7 +11,7 @@ interface QueueActionProps {
   queue: AppQueue;
   actions: Store['actions'];
   status: Status;
-  canRetry: boolean;
+  allowRetries: boolean;
 }
 
 const ACTIONABLE_STATUSES = [STATUSES.failed, STATUSES.delayed, STATUSES.completed] as const;
@@ -25,7 +25,7 @@ const CleanAllButton = ({ onClick }: any) => (
   </Button>
 );
 
-export const QueueActions = ({ status, actions, queue, canRetry }: QueueActionProps) => {
+export const QueueActions = ({ status, actions, queue, allowRetries }: QueueActionProps) => {
   if (!isStatusActionable(status)) {
     return null;
   }
@@ -34,7 +34,7 @@ export const QueueActions = ({ status, actions, queue, canRetry }: QueueActionPr
     <ul className={s.queueActions}>
       {status === STATUSES.failed && (
         <>
-          {canRetry && (
+          {allowRetries && (
             <li>
               <Button onClick={actions.retryAll(queue.name)} className={s.button}>
                 <RetryIcon />

--- a/packages/ui/src/components/QueueActions/QueueActions.tsx
+++ b/packages/ui/src/components/QueueActions/QueueActions.tsx
@@ -11,6 +11,7 @@ interface QueueActionProps {
   queue: AppQueue;
   actions: Store['actions'];
   status: Status;
+  canRetry: boolean;
 }
 
 const ACTIONABLE_STATUSES = [STATUSES.failed, STATUSES.delayed, STATUSES.completed] as const;
@@ -24,7 +25,7 @@ const CleanAllButton = ({ onClick }: any) => (
   </Button>
 );
 
-export const QueueActions = ({ status, actions, queue }: QueueActionProps) => {
+export const QueueActions = ({ status, actions, queue, canRetry }: QueueActionProps) => {
   if (!isStatusActionable(status)) {
     return null;
   }
@@ -33,12 +34,14 @@ export const QueueActions = ({ status, actions, queue }: QueueActionProps) => {
     <ul className={s.queueActions}>
       {status === STATUSES.failed && (
         <>
-          <li>
-            <Button onClick={actions.retryAll(queue.name)} className={s.button}>
-              <RetryIcon />
-              Retry all
-            </Button>
-          </li>
+          {canRetry && (
+            <li>
+              <Button onClick={actions.retryAll(queue.name)} className={s.button}>
+                <RetryIcon />
+                Retry all
+              </Button>
+            </li>
+          )}
           <li>
             <CleanAllButton onClick={actions.cleanAllFailed(queue.name)} />
           </li>

--- a/packages/ui/src/components/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/components/QueuePage/QueuePage.tsx
@@ -27,7 +27,7 @@ export const QueuePage = ({
         <div className={s.actionContainer}>
           <div>
             {queue.jobs.length > 0 && !queue.readOnlyMode && (
-              <QueueActions queue={queue} actions={actions} status={selectedStatus[queue.name]} />
+              <QueueActions queue={queue} actions={actions} status={selectedStatus[queue.name]} canRetry={queue.canRetry} />
             )}
           </div>
           <Pagination pageCount={queue.pagination.pageCount} />
@@ -45,6 +45,7 @@ export const QueuePage = ({
             getJobLogs: actions.getJobLogs(queue?.name)(job),
           }}
           readOnlyMode={queue?.readOnlyMode}
+          canRetry={queue?.canRetry}
         />
       ))}
     </section>

--- a/packages/ui/src/components/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/components/QueuePage/QueuePage.tsx
@@ -27,7 +27,12 @@ export const QueuePage = ({
         <div className={s.actionContainer}>
           <div>
             {queue.jobs.length > 0 && !queue.readOnlyMode && (
-              <QueueActions queue={queue} actions={actions} status={selectedStatus[queue.name]} canRetry={queue.canRetry} />
+              <QueueActions
+                queue={queue}
+                actions={actions}
+                status={selectedStatus[queue.name]}
+                allowRetries={queue.allowRetries}
+              />
             )}
           </div>
           <Pagination pageCount={queue.pagination.pageCount} />
@@ -45,7 +50,7 @@ export const QueuePage = ({
             getJobLogs: actions.getJobLogs(queue?.name)(job),
           }}
           readOnlyMode={queue?.readOnlyMode}
-          canRetry={queue?.canRetry}
+          allowRetries={queue?.allowRetries}
         />
       ))}
     </section>


### PR DESCRIPTION
For some queues, I'd like to be able to clear jobs but never retry them. 

This PR adds a `allowRetries` option that defaults to `true` and is superseded by `readOnlyMode`.

**Example**
```ts
const boardQueues = [new BullMQAdapter(commsQueue, { allowRetries: false })];
createBullBoard({
    serverAdapter: new ExpressAdapter(),
    queues: boardQueues,
});
```

**Use Case**
I have a queue responsible for notifications that are only relevant for a short period of time and if they fail, should not be retried. The bull dashboard is available by many people inside my company and I don't want others to accidentally hit the retry button and cause confusion for our users. However, clearing jobs is an important feature to keep.

**readOnlyMode**
Setting the `readOnlyMode` option will supersede this option and set `allowRetries` to `false`.