### PR TITLE
Optional chain queue find to fix blank dashboard

### DIFF
--- a/packages/ui/src/components/App.tsx
+++ b/packages/ui/src/components/App.tsx
@@ -28,11 +28,11 @@ export const App = ({ api }: { api: Api }) => {
                   path="/queue/:name"
                   render={({ match: { params } }) => {
                     const currentQueueName = decodeURIComponent(params.name);
-                    const queue = state.data?.queues.find((q) => q.name === currentQueueName);
+                    const queue = state.data?.queues?.find((q) => q.name === currentQueueName);
 
                     return (
                       <QueuePage
-                        queue={queue}
+                        queue={queue || undefined}
                         actions={actions}
                         selectedStatus={selectedStatuses}
                       />


### PR DESCRIPTION
I sometimes encounter this error when going to the path for a valid queue. The screen is blank, and this is what the Console shows:
<img width="945" alt="Screen Shot 2022-07-13 at 8 35 21 PM" src="https://user-images.githubusercontent.com/4657956/178892520-ce75900a-079f-417c-b126-c7d3179b8b0b.png">

Note that this is different from when I enter an invalid path -- in that scenario I see the expected "Queue Not found" message.

When looking into the stack trace, it was from the line I changed in this PR. Since the error was on `queues.find`, optional chaining fixes this until the state updates and the queue can be found.