### PR TITLE
feat: Allow retrying completed jobs when using BullMQ

### DIFF
--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -11,7 +11,6 @@ import {
 } from '../../typings/app';
 import { STATUSES } from '../constants/statuses';
 import { BaseAdapter } from '../queueAdapters/base';
-import { BullMQAdapter } from '../queueAdapters/bullMQ';
 
 const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
   const jobProps = job.toJSON();
@@ -96,7 +95,7 @@ async function getAppQueues(
         pagination,
         readOnlyMode: queue.readOnlyMode,
         allowRetries: queue.allowRetries,
-        allowCompletedRetries: queue instanceof BullMQAdapter,
+        allowCompletedRetries: queue.allowCompletedRetries,
         isPaused,
       };
     })

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -11,6 +11,7 @@ import {
 } from '../../typings/app';
 import { STATUSES } from '../constants/statuses';
 import { BaseAdapter } from '../queueAdapters/base';
+import { BullMQAdapter } from '../queueAdapters/bullMQ';
 
 const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
   const jobProps = job.toJSON();
@@ -95,6 +96,7 @@ async function getAppQueues(
         pagination,
         readOnlyMode: queue.readOnlyMode,
         allowRetries: queue.allowRetries,
+        allowCompletedRetries: queue instanceof BullMQAdapter,
         isPaused,
       };
     })

--- a/packages/api/src/handlers/retryAll.ts
+++ b/packages/api/src/handlers/retryAll.ts
@@ -1,14 +1,15 @@
 import { BullBoardRequest, ControllerHandlerReturnType } from '../../typings/app';
 import { BaseAdapter } from '../queueAdapters/base';
 import { queueProvider } from '../providers/queue';
-import { STATUSES } from '../constants/statuses';
 
 async function retryAll(
-  _req: BullBoardRequest,
-  queue: BaseAdapter
+  req: BullBoardRequest,
+  queue: BaseAdapter,
 ): Promise<ControllerHandlerReturnType> {
-  const jobs = await queue.getJobs([STATUSES.failed]);
-  await Promise.all(jobs.map((job) => job.retry()));
+  const { queueStatus } = req.params;
+
+  const jobs = await queue.getJobs([queueStatus]);
+  await Promise.all(jobs.map((job) => job.retry(queueStatus)));
 
   return { status: 200, body: {} };
 }

--- a/packages/api/src/handlers/retryJob.ts
+++ b/packages/api/src/handlers/retryJob.ts
@@ -7,10 +7,12 @@ import { jobProvider } from '../providers/job';
 import { queueProvider } from '../providers/queue';
 
 async function retryJob(
-  _req: BullBoardRequest,
+  req: BullBoardRequest,
   job: QueueJob
 ): Promise<ControllerHandlerReturnType> {
-  await job.retry();
+  const { queueStatus } = req.params;
+
+  await job.retry(queueStatus);
 
   return {
     status: 204,

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -10,6 +10,7 @@ import {
 export abstract class BaseAdapter {
   public readonly readOnlyMode: boolean;
   public readonly allowRetries: boolean;
+  public readonly allowCompletedRetries: boolean;
   public readonly prefix: string;
   public readonly description: string;
   private formatters = new Map<FormatterField, (data: any) => any>();
@@ -17,6 +18,7 @@ export abstract class BaseAdapter {
   protected constructor(options: Partial<QueueAdapterOptions> = {}) {
     this.readOnlyMode = options.readOnlyMode === true;
     this.allowRetries = this.readOnlyMode ? false : options.allowRetries !== false;
+    this.allowCompletedRetries = this.allowRetries && options.allowCompletedRetries !== false;
     this.prefix = options.prefix || '';
     this.description = options.description || '';
   }

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -4,6 +4,7 @@ import { BaseAdapter } from './base';
 
 export class BullAdapter extends BaseAdapter {
   constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
+    options.allowCompletedRetries = false; // bull doesn't support this
     super(options);
   }
 

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -28,7 +28,7 @@ export const appRoutes: AppRouteDefs = {
     },
     {
       method: 'put',
-      route: '/api/queues/:queueName/retry',
+      route: '/api/queues/:queueName/retry/:queueStatus',
       handler: retryAllHandler,
     },
     {
@@ -53,7 +53,7 @@ export const appRoutes: AppRouteDefs = {
     },
     {
       method: 'put',
-      route: '/api/queues/:queueName/:jobId/retry',
+      route: '/api/queues/:queueName/:jobId/retry/:queueStatus',
       handler: retryJobHandler,
     },
     {

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -4,6 +4,8 @@ import { BaseAdapter } from '../src/queueAdapters/base';
 
 export type JobCleanStatus = 'completed' | 'wait' | 'active' | 'delayed' | 'failed';
 
+export type JobFinishedStatus = 'completed' | 'failed';
+
 export type Status = keyof typeof STATUSES;
 
 export type JobStatus = keyof Omit<typeof STATUSES, 'latest'>;
@@ -28,7 +30,7 @@ export interface QueueJob {
 
   remove(): Promise<void>;
 
-  retry(): Promise<void>;
+  retry(state?: JobFinishedStatus): Promise<void>;
 
   toJSON(): QueueJobJson;
 }
@@ -94,6 +96,7 @@ export interface AppQueue {
   pagination: Pagination;
   readOnlyMode: boolean;
   allowRetries: boolean;
+  allowCompletedRetries: boolean;
   isPaused: boolean;
 }
 

--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -13,7 +13,8 @@ interface JobActionsProps {
   allowRetries: boolean;
   actions: {
     promoteJob: () => Promise<void>;
-    retryJob: () => Promise<void>;
+    retryFailedJob: () => Promise<void>;
+    retryCompletedJob: () => Promise<void>;
     cleanJob: () => Promise<void>;
   };
 }
@@ -21,19 +22,20 @@ interface JobActionsProps {
 interface ButtonType {
   title: string;
   Icon: React.ElementType;
-  actionKey: 'promoteJob' | 'cleanJob' | 'retryJob';
+  actionKey: 'promoteJob' | 'cleanJob' | 'retryFailedJob' | 'retryCompletedJob';
 }
 
 const buttonTypes: Record<string, ButtonType> = {
   promote: { title: 'Promote', Icon: PromoteIcon, actionKey: 'promoteJob' },
   clean: { title: 'Clean', Icon: TrashIcon, actionKey: 'cleanJob' },
-  retry: { title: 'Retry', Icon: RetryIcon, actionKey: 'retryJob' },
+  retryFailed: { title: 'Retry', Icon: RetryIcon, actionKey: 'retryFailedJob' },
+  retryCompleted: { title: 'Retry', Icon: RetryIcon, actionKey: 'retryCompletedJob' },
 };
 
 const statusToButtonsMap: Record<string, ButtonType[]> = {
-  [STATUSES.failed]: [buttonTypes.retry, buttonTypes.clean],
+  [STATUSES.failed]: [buttonTypes.retryFailed, buttonTypes.clean],
   [STATUSES.delayed]: [buttonTypes.promote, buttonTypes.clean],
-  [STATUSES.completed]: [buttonTypes.clean],
+  [STATUSES.completed]: [buttonTypes.retryCompleted, buttonTypes.clean],
   [STATUSES.waiting]: [buttonTypes.clean],
 };
 
@@ -43,7 +45,7 @@ export const JobActions = ({ actions, status, allowRetries }: JobActionsProps) =
     return null;
   }
   if (!allowRetries) {
-    buttons = buttons.filter((btn) => btn.actionKey !== 'retryJob');
+    buttons = buttons.filter((btn) => btn.actionKey !== 'retryFailedJob' && btn.actionKey !== 'retryCompletedJob');
   }
   return (
     <ul className={s.jobActions}>

--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -39,13 +39,17 @@ const statusToButtonsMap: Record<string, ButtonType[]> = {
   [STATUSES.waiting]: [buttonTypes.clean],
 };
 
+function isRetry(actionKey: ButtonType['actionKey']) {
+  return ['retryFailedJob', 'retryCompletedJob'].includes(actionKey);
+}
+
 export const JobActions = ({ actions, status, allowRetries }: JobActionsProps) => {
   let buttons = statusToButtonsMap[status];
   if (!buttons) {
     return null;
   }
   if (!allowRetries) {
-    buttons = buttons.filter((btn) => btn.actionKey !== 'retryFailedJob' && btn.actionKey !== 'retryCompletedJob');
+    buttons = buttons.filter((btn) => !isRetry(btn.actionKey));
   }
   return (
     <ul className={s.jobActions}>

--- a/packages/ui/src/components/JobCard/JobCard.tsx
+++ b/packages/ui/src/components/JobCard/JobCard.tsx
@@ -14,7 +14,8 @@ interface JobCardProps {
   allowRetries: boolean;
   actions: {
     promoteJob: () => Promise<void>;
-    retryJob: () => Promise<void>;
+    retryFailedJob: () => Promise<void>;
+    retryCompletedJob: () => Promise<void>;
     cleanJob: () => Promise<void>;
     getJobLogs: () => Promise<string[]>;
   };

--- a/packages/ui/src/components/QueueActions/QueueActions.tsx
+++ b/packages/ui/src/components/QueueActions/QueueActions.tsx
@@ -25,6 +25,13 @@ const CleanAllButton = ({ onClick }: any) => (
   </Button>
 );
 
+const RetryAllButton = ({ onClick }: any) => (
+  <Button onClick={onClick} className={s.button}>
+    <RetryIcon />
+    Retry all
+  </Button>
+);
+
 export const QueueActions = ({ status, actions, queue, allowRetries }: QueueActionProps) => {
   if (!isStatusActionable(status)) {
     return null;
@@ -36,10 +43,7 @@ export const QueueActions = ({ status, actions, queue, allowRetries }: QueueActi
         <>
           {allowRetries && (
             <li>
-              <Button onClick={actions.retryAll(queue.name)} className={s.button}>
-                <RetryIcon />
-                Retry all
-              </Button>
+              <RetryAllButton onClick={actions.retryAllFailed(queue.name)} />
             </li>
           )}
           <li>
@@ -53,9 +57,16 @@ export const QueueActions = ({ status, actions, queue, allowRetries }: QueueActi
         </li>
       )}
       {status === STATUSES.completed && (
-        <li>
-          <CleanAllButton onClick={actions.cleanAllCompleted(queue.name)} />
-        </li>
+        <>
+          {allowRetries && (
+            <li>
+              <RetryAllButton onClick={actions.retryAllCompleted(queue.name)} />
+            </li>
+          )}
+          <li>
+            <CleanAllButton onClick={actions.cleanAllCompleted(queue.name)} />
+          </li>
+        </>
       )}
     </ul>
   );

--- a/packages/ui/src/components/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/components/QueuePage/QueuePage.tsx
@@ -46,8 +46,8 @@ export const QueuePage = ({
           actions={{
             cleanJob: actions.cleanJob(queue?.name)(job),
             promoteJob: actions.promoteJob(queue?.name)(job),
-            retryFailedJob: actions.retryFailedJob(queue?.name)(job),
-            retryCompletedJob: actions.retryCompletedJob(queue?.name)(job),
+            retryFailedJob: actions.retryJob(queue?.name)(job, 'failed'),
+            retryCompletedJob: actions.retryJob(queue?.name)(job, 'completed'),
             getJobLogs: actions.getJobLogs(queue?.name)(job),
           }}
           readOnlyMode={queue?.readOnlyMode}

--- a/packages/ui/src/components/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/components/QueuePage/QueuePage.tsx
@@ -31,7 +31,7 @@ export const QueuePage = ({
                 queue={queue}
                 actions={actions}
                 status={selectedStatus[queue.name]}
-                allowRetries={queue.allowRetries}
+                allowRetries={(selectedStatus[queue.name] == 'failed' || queue.allowCompletedRetries) && queue.allowRetries}
               />
             )}
           </div>
@@ -46,11 +46,12 @@ export const QueuePage = ({
           actions={{
             cleanJob: actions.cleanJob(queue?.name)(job),
             promoteJob: actions.promoteJob(queue?.name)(job),
-            retryJob: actions.retryJob(queue?.name)(job),
+            retryFailedJob: actions.retryFailedJob(queue?.name)(job),
+            retryCompletedJob: actions.retryCompletedJob(queue?.name)(job),
             getJobLogs: actions.getJobLogs(queue?.name)(job),
           }}
           readOnlyMode={queue?.readOnlyMode}
-          allowRetries={queue?.allowRetries}
+          allowRetries={(job.isFailed || queue.allowCompletedRetries) && queue?.allowRetries}
         />
       ))}
     </section>

--- a/packages/ui/src/hooks/useStore.ts
+++ b/packages/ui/src/hooks/useStore.ts
@@ -1,4 +1,4 @@
-import { AppJob } from '@bull-board/api/typings/app';
+import { AppJob, JobFinishedStatus } from '@bull-board/api/typings/app';
 import { GetQueuesResponse } from '@bull-board/api/typings/responses';
 import { useState } from 'react';
 import { QueueActions, SelectedStatuses } from '../../typings/app';
@@ -88,16 +88,9 @@ export const useStore = (): Store => {
       confirmJobActions
     );
 
-  const retryFailedJob = (queueName: string) => (job: AppJob) =>
+  const retryJob = (queueName: string) => (job: AppJob, status: JobFinishedStatus) =>
     withConfirmAndUpdate(
-      () => api.retryFailedJob(queueName, job.id),
-      'Are you sure that you want to retry this job?',
-      confirmJobActions
-    );
-
-  const retryCompletedJob = (queueName: string) => (job: AppJob) =>
-    withConfirmAndUpdate(
-      () => api.retryCompletedJob(queueName, job.id),
+      () => api.retryJob(queueName, job.id, status),
       'Are you sure that you want to retry this job?',
       confirmJobActions
     );
@@ -109,17 +102,10 @@ export const useStore = (): Store => {
       confirmJobActions
     );
 
-  const retryAllFailed = (queueName: string) =>
+  const retryAll = (queueName: string, status: JobFinishedStatus) =>
     withConfirmAndUpdate(
-      () => api.retryAllFailed(queueName),
+      () => api.retryAll(queueName, status),
       'Are you sure that you want to retry all failed jobs?',
-      confirmQueueActions
-    );
-
-  const retryAllCompleted = (queueName: string) =>
-    withConfirmAndUpdate(
-      () => api.retryAllCompleted(queueName),
-      'Are you sure that you want to retry all completed jobs?',
       confirmQueueActions
     );
 
@@ -172,10 +158,8 @@ export const useStore = (): Store => {
     state,
     actions: {
       promoteJob,
-      retryFailedJob,
-      retryCompletedJob,
-      retryAllFailed,
-      retryAllCompleted,
+      retryJob,
+      retryAll,
       cleanJob,
       cleanAllDelayed,
       cleanAllFailed,

--- a/packages/ui/src/hooks/useStore.ts
+++ b/packages/ui/src/hooks/useStore.ts
@@ -88,9 +88,16 @@ export const useStore = (): Store => {
       confirmJobActions
     );
 
-  const retryJob = (queueName: string) => (job: AppJob) =>
+  const retryFailedJob = (queueName: string) => (job: AppJob) =>
     withConfirmAndUpdate(
-      () => api.retryJob(queueName, job.id),
+      () => api.retryFailedJob(queueName, job.id),
+      'Are you sure that you want to retry this job?',
+      confirmJobActions
+    );
+
+  const retryCompletedJob = (queueName: string) => (job: AppJob) =>
+    withConfirmAndUpdate(
+      () => api.retryCompletedJob(queueName, job.id),
       'Are you sure that you want to retry this job?',
       confirmJobActions
     );
@@ -102,10 +109,17 @@ export const useStore = (): Store => {
       confirmJobActions
     );
 
-  const retryAll = (queueName: string) =>
+  const retryAllFailed = (queueName: string) =>
     withConfirmAndUpdate(
-      () => api.retryAll(queueName),
-      'Are you sure that you want to retry all jobs?',
+      () => api.retryAllFailed(queueName),
+      'Are you sure that you want to retry all failed jobs?',
+      confirmQueueActions
+    );
+
+  const retryAllCompleted = (queueName: string) =>
+    withConfirmAndUpdate(
+      () => api.retryAllCompleted(queueName),
+      'Are you sure that you want to retry all completed jobs?',
       confirmQueueActions
     );
 
@@ -158,8 +172,10 @@ export const useStore = (): Store => {
     state,
     actions: {
       promoteJob,
-      retryJob,
-      retryAll,
+      retryFailedJob,
+      retryCompletedJob,
+      retryAllFailed,
+      retryAllCompleted,
       cleanJob,
       cleanAllDelayed,
       cleanAllFailed,

--- a/packages/ui/src/hooks/useStore.ts
+++ b/packages/ui/src/hooks/useStore.ts
@@ -105,7 +105,7 @@ export const useStore = (): Store => {
   const retryAll = (queueName: string, status: JobFinishedStatus) =>
     withConfirmAndUpdate(
       () => api.retryAll(queueName, status),
-      'Are you sure that you want to retry all failed jobs?',
+      `Are you sure that you want to retry all ${status} jobs?`,
       confirmQueueActions
     );
 

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -25,8 +25,12 @@ export class Api {
     return this.axios.get(`/queues`, { params: { activeQueue, status, page, jobsPerPage } });
   }
 
-  public retryAll(queueName: string): Promise<void> {
-    return this.axios.put(`/queues/${encodeURIComponent(queueName)}/retry`);
+  public retryAllFailed(queueName: string): Promise<void> {
+    return this.axios.put(`/queues/${encodeURIComponent(queueName)}/retry/failed`);
+  }
+
+  public retryAllCompleted(queueName: string): Promise<void> {
+    return this.axios.put(`/queues/${encodeURIComponent(queueName)}/retry/completed`);
   }
 
   public cleanAllDelayed(queueName: string): Promise<void> {
@@ -47,9 +51,15 @@ export class Api {
     );
   }
 
-  public retryJob(queueName: string, jobId: AppJob['id']): Promise<void> {
+  public retryFailedJob(queueName: string, jobId: AppJob['id']): Promise<void> {
     return this.axios.put(
-      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry`
+      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry/failed`
+    );
+  }
+
+  public retryCompletedJob(queueName: string, jobId: AppJob['id']): Promise<void> {
+    return this.axios.put(
+      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry/completed`
     );
   }
 

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -1,4 +1,4 @@
-import { AppJob, RedisStats, Status } from '@bull-board/api/typings/app';
+import { AppJob, JobFinishedStatus, RedisStats, Status } from '@bull-board/api/typings/app';
 import { GetQueuesResponse } from '@bull-board/api/typings/responses';
 import Axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { toast } from 'react-toastify';
@@ -25,12 +25,8 @@ export class Api {
     return this.axios.get(`/queues`, { params: { activeQueue, status, page, jobsPerPage } });
   }
 
-  public retryAllFailed(queueName: string): Promise<void> {
-    return this.axios.put(`/queues/${encodeURIComponent(queueName)}/retry/failed`);
-  }
-
-  public retryAllCompleted(queueName: string): Promise<void> {
-    return this.axios.put(`/queues/${encodeURIComponent(queueName)}/retry/completed`);
+  public retryAll(queueName: string, status: JobFinishedStatus): Promise<void> {
+    return this.axios.put(`/queues/${encodeURIComponent(queueName)}/retry/${encodeURIComponent(status)}`);
   }
 
   public cleanAllDelayed(queueName: string): Promise<void> {
@@ -51,15 +47,9 @@ export class Api {
     );
   }
 
-  public retryFailedJob(queueName: string, jobId: AppJob['id']): Promise<void> {
+  public retryJob(queueName: string, jobId: AppJob['id'], status: JobFinishedStatus): Promise<void> {
     return this.axios.put(
-      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry/failed`
-    );
-  }
-
-  public retryCompletedJob(queueName: string, jobId: AppJob['id']): Promise<void> {
-    return this.axios.put(
-      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry/completed`
+      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry/${encodeURIComponent(status)}`,
     );
   }
 

--- a/packages/ui/typings/app.d.ts
+++ b/packages/ui/typings/app.d.ts
@@ -1,4 +1,4 @@
-import { AppJob, AppQueue, Status } from '@bull-board/api/typings/app';
+import { AppJob, AppQueue, JobFinishedStatus, Status } from '@bull-board/api/typings/app';
 
 export { Status } from '@bull-board/api/typings/app';
 
@@ -6,12 +6,10 @@ export type SelectedStatuses = Record<AppQueue['name'], Status>;
 
 export interface QueueActions {
   promoteJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
-  retryFailedJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
-  retryCompletedJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
+  retryJob: (queueName: string) => (job: AppJob, status: JobFinishedStatus) => () => Promise<void>;
   cleanJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
   getJobLogs: (queueName: string) => (job: AppJob) => () => Promise<string[]>;
-  retryAllFailed: (queueName: string) => () => Promise<void>;
-  retryAllCompleted: (queueName: string) => () => Promise<void>;
+  retryAll: (queueName: string, status: JobFinishedStatus) => () => Promise<void>;
   cleanAllDelayed: (queueName: string) => () => Promise<void>;
   cleanAllFailed: (queueName: string) => () => Promise<void>;
   cleanAllCompleted: (queueName: string) => () => Promise<void>;

--- a/packages/ui/typings/app.d.ts
+++ b/packages/ui/typings/app.d.ts
@@ -6,10 +6,12 @@ export type SelectedStatuses = Record<AppQueue['name'], Status>;
 
 export interface QueueActions {
   promoteJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
-  retryJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
+  retryFailedJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
+  retryCompletedJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
   cleanJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
   getJobLogs: (queueName: string) => (job: AppJob) => () => Promise<string[]>;
-  retryAll: (queueName: string) => () => Promise<void>;
+  retryAllFailed: (queueName: string) => () => Promise<void>;
+  retryAllCompleted: (queueName: string) => () => Promise<void>;
   cleanAllDelayed: (queueName: string) => () => Promise<void>;
   cleanAllFailed: (queueName: string) => () => Promise<void>;
   cleanAllCompleted: (queueName: string) => () => Promise<void>;


### PR DESCRIPTION
This PR adds support for retrying completed jobs when using the BullMQ adapter. Retrying completed jobs is not possible in bull, only in BullMq.

closes #506