### PR TITLE
fix: incorrect value of job name when job name is undefined

### DIFF
--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -29,7 +29,7 @@ const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
     stacktrace,
     opts: jobProps.opts,
     data: queue.format('data', jobProps.data),
-    name: queue.format('name', jobProps, jobProps.name),
+    name: queue.format('name', jobProps, jobProps.name || ''),
     returnValue: queue.format('returnValue', jobProps.returnvalue),
     isFailed: !!jobProps.failedReason || (Array.isArray(stacktrace) && stacktrace.length > 0),
   };


### PR DESCRIPTION
## Description

https://github.com/felixmosh/bull-board/blob/9c17cec31e296787fe0d8b53f0ae27806d6b2c0d/packages/api/src/handlers/queues.ts#L32

When the `jobProps.name` is undefined, the default value of `BaseAdapter.format(field, data, defaultValue = data)` will be `jobProps`. And then React will throw `Error: Minified React error #31;`.