### PR TITLE
fix: use job's delay attribute to reflect changes in delay 

### DIFF
--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -24,7 +24,7 @@ const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
     finishedOn: jobProps.finishedOn,
     progress: jobProps.progress,
     attempts: jobProps.attemptsMade,
-    delay: job.opts.delay,
+    delay: jobProps.delay,
     failedReason: jobProps.failedReason,
     stacktrace,
     opts: jobProps.opts,

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -44,6 +44,7 @@ export interface QueueJobJson {
   attemptsMade: number;
   finishedOn?: number | null;
   processedOn?: number | null;
+  delay?: number;
   timestamp: number;
   failedReason: string;
   stacktrace: string[] | null;


### PR DESCRIPTION
(via `changeDelay`), closes #544