### PR TITLE
feat: make whole QueueCard clickable

### DIFF
--- a/packages/ui/src/components/QueueCard/QueueCard.tsx
+++ b/packages/ui/src/components/QueueCard/QueueCard.tsx
@@ -10,12 +10,12 @@ interface IQueueCardProps {
 }
 
 export const QueueCard = ({ queue }: IQueueCardProps) => (
-  <Card className={s.queueCard}>
-    <div>
-      <NavLink to={`/queue/${encodeURIComponent(queue.name)}`} className={s.link}>
+  <NavLink to={`/queue/${encodeURIComponent(queue.name)}`} className={s.link}>
+    <Card className={s.queueCard}>
+      <div>
         {queue.name}
-      </NavLink>
-    </div>
-    <QueueStats queue={queue} />
-  </Card>
+      </div>
+      <QueueStats queue={queue} />
+    </Card>
+  </NavLink>
 );

--- a/packages/ui/src/components/QueueCard/QueueCard.tsx
+++ b/packages/ui/src/components/QueueCard/QueueCard.tsx
@@ -13,7 +13,7 @@ export const QueueCard = ({ queue }: IQueueCardProps) => (
   <NavLink to={`/queue/${encodeURIComponent(queue.name)}`} className={s.link}>
     <Card className={s.queueCard}>
       <div>
-        {queue.name}
+        <span>{queue.name}</span>
       </div>
       <QueueStats queue={queue} />
     </Card>


### PR DESCRIPTION
Thanks for a great library. I have extended the new Queue Cards by making the whole card clickable rather than just the queue name.