### PR TITLE
NestJS package

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ With this library you get a beautiful UI for visualizing what's happening with e
 | [@bull-board/fastify](https://www.npmjs.com/package/@bull-board/fastify) | ![npm (scoped)](https://img.shields.io/npm/v/@bull-board/fastify) |
 | [@bull-board/koa](https://www.npmjs.com/package/@bull-board/koa)         | ![npm (scoped)](https://img.shields.io/npm/v/@bull-board/koa)     |
 | [@bull-board/hapi](https://www.npmjs.com/package/@bull-board/hapi)       | ![npm (scoped)](https://img.shields.io/npm/v/@bull-board/hapi)    |
+| [@bull-board/nestjs](https://www.npmjs.com/package/@bull-board/nestjs)   | ![npm (scoped)](https://img.shields.io/npm/v/@bull-board/nestjs)  |
 
 ## Notes
 
@@ -50,16 +51,9 @@ yarn add @bull-board/hapi
 # or
 yarn add @bull-board/koa
 ```
-Or
-```sh
-npm i @bull-board/express
-# or
-npm i @bull-board/fastify
-# or
-npm i @bull-board/hapi
-# or
-npm i @bull-board/koa
-```
+
+### NestJS specific setup
+@bull-board provides a module for easy integration with NestJS, for reference on how to use the module refer to the [NestJS Module](https://github.com/felixmosh/bull-board/tree/master/packages/nestjs) package
 
 ## Hello World
 
@@ -105,10 +99,11 @@ That's it! Now you can access the `/admin/queues` route, and you will be able to
 For more advanced usages check the `examples` folder, currently it contains:
 1. [Basic authentication example](https://github.com/felixmosh/bull-board/tree/master/examples/with-express-auth)
 2. [Multiple instance of the board](https://github.com/felixmosh/bull-board/tree/master/examples/with-multiple-instances)
-2. [With Fastify server](https://github.com/felixmosh/bull-board/tree/master/examples/with-fastify)
-2. [With Hapi.js server](https://github.com/felixmosh/bull-board/tree/master/examples/with-hapi)
-2. [With Koa.js server](https://github.com/felixmosh/bull-board/tree/master/examples/with-koa)
-2. [With Nest.js server](https://github.com/felixmosh/bull-board/tree/master/examples/with-nestjs) (Thanx to @lodi-g)
+3. [With Fastify server](https://github.com/felixmosh/bull-board/tree/master/examples/with-fastify)
+4. [With Hapi.js server](https://github.com/felixmosh/bull-board/tree/master/examples/with-hapi)
+5. [With Koa.js server](https://github.com/felixmosh/bull-board/tree/master/examples/with-koa)
+6. [With Nest.js server using the built-in module](https://github.com/felixmosh/bull-board/tree/master/examples/with-nestjs) (Thanx to @dennissnijder)
+7. [With Nest.js server using the express adapter](https://github.com/felixmosh/bull-board/tree/master/examples/with-nestjs) (Thanx to @lodi-g)
 
 ### Board options
 1. `uiConfig.boardTitle` (default: `empty`)

--- a/examples/with-nestjs-module/.gitignore
+++ b/examples/with-nestjs-module/.gitignore
@@ -1,0 +1,35 @@
+# compiled output
+/dist
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/examples/with-nestjs-module/README.md
+++ b/examples/with-nestjs-module/README.md
@@ -1,0 +1,62 @@
+<p align="center">
+  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo_text.svg" width="320" alt="Nest Logo" /></a>
+</p>
+
+[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
+[circleci-url]: https://circleci.com/gh/nestjs/nest
+
+  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
+    <p align="center">
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
+<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
+<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
+<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
+<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
+<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
+  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
+    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
+  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
+</p>
+  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
+  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+
+## Description
+
+[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+
+## Installation
+
+```bash
+$ yarn install
+```
+
+## Running the app
+
+```bash
+# Run the redis dependency using docker.
+$ docker compose up -d
+```
+
+```bash
+# watch mode
+$ yarn start:dev
+
+# production mode
+$ npm run start:prod
+```
+
+## Support
+
+Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+
+## Stay in touch
+
+- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
+- Website - [https://nestjs.com](https://nestjs.com/)
+- Twitter - [@nestframework](https://twitter.com/nestframework)
+
+## License
+
+Nest is [MIT licensed](LICENSE).

--- a/examples/with-nestjs-module/docker-compose.yml
+++ b/examples/with-nestjs-module/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  redis:
+    image: redis:6.2-alpine
+    ports:
+      - '6379:6379'
+    command: redis-server --save 20 1 --loglevel warning --requirepass eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81

--- a/examples/with-nestjs-module/nest-cli.json
+++ b/examples/with-nestjs-module/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/examples/with-nestjs-module/package.json
+++ b/examples/with-nestjs-module/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "bullboard-with-nestjs-module",
+  "version": "0.0.1",
+  "description": "",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main"
+  },
+  "dependencies": {
+    "@bull-board/api": "^5.2.1",
+    "@bull-board/express": "^5.2.1",
+    "@nestjs/bullmq": "^1.1.0",
+    "@nestjs/common": "^9.0.0",
+    "@nestjs/core": "^9.0.0",
+    "@nestjs/platform-express": "^8.0.0",
+    "bullmq": "^3.15.4",
+    "@bull-board/nestjs": "^5.2.1",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^8.0.0",
+    "@nestjs/schematics": "^8.0.0",
+    "@nestjs/testing": "^8.0.0",
+    "@types/express": "^4.17.13",
+    "@types/node": "^16.0.0",
+    "jest": "^27.2.5",
+    "source-map-support": "^0.5.20",
+    "ts-loader": "^9.2.3",
+    "ts-node": "^10.0.0",
+    "tsconfig-paths": "^3.10.1",
+    "typescript": "^4.3.5"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/examples/with-nestjs-module/src/app.module.ts
+++ b/examples/with-nestjs-module/src/app.module.ts
@@ -1,0 +1,32 @@
+import { Module } from "@nestjs/common";
+import { BullModule } from "@nestjs/bullmq";
+import { BullBoardModule } from "@bull-board/nestjs";
+import { FeatureModule } from "./feature/feature.module";
+import { ExpressAdapter } from "@bull-board/express";
+
+@Module({
+  imports: [
+    // infrastructure from here
+    BullModule.forRoot({
+      connection: {
+        host: "localhost",
+        port: 6379,
+        username: "default",
+        password: "eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81" //defined in the docker compose yml
+      }
+    }),
+
+    //register the bull-board module forRoot in your app.module
+    BullBoardModule.forRoot({
+      route: "/queues",
+      adapter: ExpressAdapter
+    }),
+
+    //feature modules from here.
+    FeatureModule
+  ],
+  controllers: [],
+  providers: []
+})
+export class AppModule {
+}

--- a/examples/with-nestjs-module/src/feature/feature.controller.ts
+++ b/examples/with-nestjs-module/src/feature/feature.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from "@nestjs/common";
+import { BullBoardInstance, InjectBullBoard } from "@bull-board/nestjs";
+
+@Controller('my-feature')
+export class FeatureController {
+
+  constructor(
+    //inject the bull-board instance using the provided decorator
+    @InjectBullBoard() private readonly boardInstance: BullBoardInstance
+  ) {
+  }
+
+  @Get()
+  getFeature() {
+    // You can do anything from here with the boardInstance for example:
+
+    //this.boardInstance.replaceQueues();
+    //this.boardInstance.addQueue();
+    //this.boardInstance.setQueues();
+
+    return 'ok';
+  }
+
+}

--- a/examples/with-nestjs-module/src/feature/feature.module.ts
+++ b/examples/with-nestjs-module/src/feature/feature.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { BullBoardModule } from "@bull-board/nestjs";
+import { BullModule } from "@nestjs/bullmq";
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
+
+// example feature module, feature can be anything. eg. user module
+@Module({
+  imports: [
+    BullModule.registerQueue({
+      name: 'feature_queue'
+    }),
+
+    //Register each queue using the `forFeature` method.
+    BullBoardModule.forFeature({
+      name: 'feature_queue',
+      adapter: BullMQAdapter
+    })
+  ]
+})
+export class FeatureModule {}

--- a/examples/with-nestjs-module/src/main.ts
+++ b/examples/with-nestjs-module/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/examples/with-nestjs-module/tsconfig.build.json
+++ b/examples/with-nestjs-module/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/examples/with-nestjs-module/tsconfig.json
+++ b/examples/with-nestjs-module/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -20,7 +20,7 @@
 
 Install both @bull-board/api and this module.
 ```bash
-$ npm install --save nestjs-bull-board @bull-board/api
+$ npm install --save @bull-board/nestjs @bull-board/api
 ```
 
 Install the Express or Fastify adapter depending on what you use in NestJS (default is Express)

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -1,0 +1,118 @@
+# <img alt="@bull-board" src="https://raw.githubusercontent.com/felixmosh/bull-board/master/packages/ui/src/static/images/logo.svg" width="35px" /> @bull-board/nestjs
+
+[NestJS](https://nestjs.com/)  for `bull-board`.
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@bull-board/nestjs">
+    <img alt="npm version" src="https://img.shields.io/npm/v/@bull-board/nestjs">
+  </a>
+  <a href="https://www.npmjs.com/package/bull-board">
+    <img alt="npm downloads" src="https://img.shields.io/npm/dw/bull-board">
+  </a>
+  <a href="https://github.com/vcapretz/bull-board/blob/master/LICENSE">
+    <img alt="licence" src="https://img.shields.io/github/license/vcapretz/bull-board">
+  </a>
+<p>
+
+![UI](https://raw.githubusercontent.com/felixmosh/bull-board/master/screenshots/dashboard.png)
+
+## Installation
+
+Install both @bull-board/api and this module.
+```bash
+$ npm install --save nestjs-bull-board @bull-board/api
+```
+
+Install the Express or Fastify adapter depending on what you use in NestJS (default is Express)
+```bash
+$ npm install --save @bull-board/express
+//or 
+$ npm install --save @bull-board/fastify
+```
+
+## Register the root module
+Once the installation is completed, we can import the `BullBoardModule` into your rootmodule e.g. `AppModule`.
+
+```typescript
+import { Module } from '@nestjs/common';
+import { BullBoardModule } from "@bull-board/nestjs";
+import { ExpressAdapter } from "@bull-board/express";
+
+@Module({
+  imports: [
+    BullModule.forRoot({
+      // your bull module config here.
+    }),
+
+    BullBoardModule.forRoot({
+      route: '/queues',
+      adapter: ExpressAdapter // Or FastifyAdapter from `@bull-board/fastify`
+    }),
+  ],
+})
+export class AppModule {
+}
+```
+
+The `forRoot()` method registers the bull-board instance and allows you to pass several options to both the instance and module.
+The following options are available.
+- `route` the base route for the bull-board instance adapter.
+- `adapter` The routing adapter to be used, either the Express Adapter or Fastify Adapter provided by bull-board.
+- `boardOptions` options as provided by the bull-board package, such as `uiBasePath` and `uiConfig`
+- `middleware` optional middleware for the express adapter (e.g. basic authentication)
+
+## Register your queues
+To register a new queue, you need to register `BullBoardModule.forFeature` in the same module as where your queues are registered.
+
+```typescript
+import { Module } from '@nestjs/common';
+import { BullBoardModule } from "@bull-board/nestjs";
+import { BullModule } from "@nestjs/bullmq";
+
+@Module({
+  imports: [
+    BullModule.registerQueue(
+      {
+        name: 'my_awesome_queue'
+      }
+    ),
+    
+    BullBoardModule.forFeature({
+      name: 'my_awesome_queue',
+      adapter: BullMQAdapter, //or use BullAdapter if you're using bull instead of bullMQ
+    }),
+  ],
+})
+export class FeatureModule {}
+```
+
+The `forFeature` method registers the given queues to the bull-board instance.
+The following options are available.
+- `name` the queue name to register
+- `adapter` either `BullAdapter` or `BullMQAdapter` depending on which package you use.
+- `options` queue adapter options as found in the bull-board package, such as `readOnlyMode`, `description` etc.
+
+##  Using the bull-board instance in your controllers and/or services.
+The created bull-board instance is available via the `@InjectBullBoard()` decorator.
+For example in a controller:
+
+```typescript
+import { Controller, Get } from "@nestjs/common";
+import { BullBoardInstance, InjectBullBoard } from "@bull-board/nestjs";
+
+@Controller('my-feature')
+export class FeatureController {
+
+  constructor(
+    @InjectBullBoard() private readonly boardInstance: BullBoardInstance
+  ) {
+  }
+  
+  //controller methods
+}
+```
+
+# Usage examples
+1. [Simple NestJS setup](https://github.com/felixmosh/bull-board/tree/master/examples/with-nestjs)
+
+For more info visit the main [README](https://github.com/felixmosh/bull-board#readme)

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@bull-board/nestjs",
+  "version": "5.2.1",
+  "description": "A NestJS module for Bull-Board dashboard.",
+  "keywords": [
+    "bull",
+    "bullmq",
+    "redis",
+    "queue",
+    "monitoring",
+    "nestjs",
+    "nestjs-module"
+  ],
+  "main": "dist/index.js",
+  "author": "Dennis Snijder <dennis@snijder.io>",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@bull-board/api": "^5.2.1",
+    "@bull-board/express": "^5.2.1",
+    "@bull-board/fastify": "^5.2.1",
+    "@nestjs/bullmq": "^1.1.0",
+    "@nestjs/common": "9.4.2",
+    "@nestjs/core": "9.4.2",
+    "@types/node": "18.16.16",
+    "bull": "^4.10.4",
+    "bullmq": "^3.15.2",
+    "reflect-metadata": "0.1.13",
+    "rxjs": "7.8.1",
+    "typescript": "^5.1.3"
+  },
+  "dependencies": {
+    "@nestjs/bull-shared": "^0.1.3"
+  },
+  "peerDependencies": {
+    "@bull-board/api": "^5.0.0",
+    "@bull-board/express": "^5.0.0",
+    "@nestjs/common": "^8.0.0 || ^9.0.0",
+    "@nestjs/core": "^8.0.0 || ^9.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felixmosh/bull-board.git",
+    "directory": "packages/nestjs"
+  }
+}

--- a/packages/nestjs/src/bull-board.constants.ts
+++ b/packages/nestjs/src/bull-board.constants.ts
@@ -1,0 +1,5 @@
+
+export const BULL_BOARD_OPTIONS = 'bull_board_options';
+export const BULL_BOARD_QUEUES = 'bull_board_queues';
+export const BULL_BOARD_ADAPTER = 'bull_board_adapter';
+export const BULL_BOARD_INSTANCE = 'bull_board_instance';

--- a/packages/nestjs/src/bull-board.decorator.ts
+++ b/packages/nestjs/src/bull-board.decorator.ts
@@ -1,0 +1,4 @@
+import { Inject } from '@nestjs/common';
+import { BULL_BOARD_INSTANCE } from "./bull-board.constants";
+
+export const InjectBullBoard = (): ParameterDecorator => Inject(BULL_BOARD_INSTANCE);

--- a/packages/nestjs/src/bull-board.feature-module.ts
+++ b/packages/nestjs/src/bull-board.feature-module.ts
@@ -1,0 +1,25 @@
+import { Inject, Module, OnModuleInit } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import { getQueueToken } from "@nestjs/bull-shared";
+import { BullBoardInstance, BullBoardQueueOptions } from "./bull-board.types";
+import { Queue } from "bullmq";
+import { BULL_BOARD_INSTANCE, BULL_BOARD_QUEUES } from "./bull-board.constants";
+
+@Module({})
+export class BullBoardFeatureModule implements OnModuleInit {
+
+  constructor(
+    private readonly moduleRef: ModuleRef,
+    @Inject(BULL_BOARD_QUEUES) private readonly queues: BullBoardQueueOptions[],
+    @Inject(BULL_BOARD_INSTANCE) private readonly board: BullBoardInstance
+  ) {
+  }
+
+  onModuleInit(): any {
+    for (const queueOption of this.queues) {
+      const queue = this.moduleRef.get<Queue>(getQueueToken(queueOption.name), {strict: false});
+      const queueAdapter = new queueOption.adapter(queue, queueOption.options);
+      this.board.addQueue(queueAdapter);
+    }
+  }
+}

--- a/packages/nestjs/src/bull-board.module.ts
+++ b/packages/nestjs/src/bull-board.module.ts
@@ -1,0 +1,29 @@
+import { DynamicModule, Module} from "@nestjs/common";
+import { BullBoardFeatureModule } from "./bull-board.feature-module";
+import { BullBoardRootModule } from "./bull-board.root-module";
+import { BULL_BOARD_QUEUES } from "./bull-board.constants";
+import { BullBoardModuleOptions, BullBoardQueueOptions } from "./bull-board.types";
+
+@Module({})
+export class BullBoardModule {
+
+  static forFeature(...queues: BullBoardQueueOptions[]): DynamicModule {
+    return {
+      module: BullBoardFeatureModule,
+      providers: [
+        {
+          provide: BULL_BOARD_QUEUES,
+          useValue: queues
+        }
+      ]
+    };
+  }
+
+  static forRoot(options: BullBoardModuleOptions): DynamicModule {
+    return {
+      module: BullBoardModule,
+      imports: [ BullBoardRootModule.forRoot(options) ],
+      exports: [ BullBoardRootModule ],
+    };
+  }
+}

--- a/packages/nestjs/src/bull-board.root-module.ts
+++ b/packages/nestjs/src/bull-board.root-module.ts
@@ -1,0 +1,76 @@
+import { DynamicModule, Inject, MiddlewareConsumer, Module, NestModule, Provider } from "@nestjs/common";
+import { createBullBoard } from "@bull-board/api";
+import { BULL_BOARD_ADAPTER, BULL_BOARD_INSTANCE, BULL_BOARD_OPTIONS } from "./bull-board.constants";
+import { BullBoardModuleOptions, BullBoardServerAdapter } from "./bull-board.types";
+import { HttpAdapterHost } from "@nestjs/core";
+import { isExpressAdapter, isFastifyAdapter } from "./bull-board.util";
+
+@Module({})
+export class BullBoardRootModule implements NestModule {
+
+  constructor(
+    private readonly adapterHost: HttpAdapterHost,
+    @Inject(BULL_BOARD_ADAPTER) private readonly adapter: BullBoardServerAdapter,
+    @Inject(BULL_BOARD_OPTIONS) private readonly options: BullBoardModuleOptions
+  ) {
+  }
+
+  configure(consumer: MiddlewareConsumer): any {
+    this.adapter.setBasePath(this.options.route);
+
+    if (isExpressAdapter(this.adapter)) {
+      return consumer
+        .apply(this.options.middleware, this.adapter.getRouter())
+        .forRoutes(this.options.route);
+    }
+
+    if (isFastifyAdapter(this.adapter)) {
+      this.adapterHost.httpAdapter
+        .getInstance()
+        .register(this.adapter.registerPlugin(), {prefix: this.options.route});
+
+      return consumer
+        .apply(this.options.middleware)
+        .forRoutes(this.options.route);
+    }
+  }
+
+  static forRoot(options: BullBoardModuleOptions): DynamicModule {
+    const serverAdapter = new options.adapter();
+
+    const bullBoardProvider: Provider = {
+      provide: BULL_BOARD_INSTANCE,
+      useFactory: () => createBullBoard({
+        queues: [],
+        serverAdapter: serverAdapter,
+        options: options.boardOptions,
+      })
+    };
+
+    const serverAdapterProvider: Provider = {
+      provide: BULL_BOARD_ADAPTER,
+      useFactory: () => serverAdapter
+    };
+
+    const optionsProvider: Provider = {
+      provide: BULL_BOARD_OPTIONS,
+      useValue: options
+    };
+
+    return {
+      module: BullBoardRootModule,
+      global: true,
+      imports: [],
+      providers: [
+        serverAdapterProvider,
+        optionsProvider,
+        bullBoardProvider
+      ],
+      exports: [
+        serverAdapterProvider,
+        bullBoardProvider,
+        optionsProvider
+      ],
+    };
+  }
+}

--- a/packages/nestjs/src/bull-board.types.ts
+++ b/packages/nestjs/src/bull-board.types.ts
@@ -1,0 +1,23 @@
+import { createBullBoard } from "@bull-board/api";
+import { BoardOptions, IServerAdapter, QueueAdapterOptions } from "@bull-board/api/dist/typings/app";
+import { BaseAdapter } from "@bull-board/api/dist/src/queueAdapters/base";
+
+export type BullBoardInstance = ReturnType<typeof createBullBoard>;
+
+export type BullBoardModuleOptions = {
+  route: string;
+  adapter: { new(): BullBoardServerAdapter };
+  boardOptions?: BoardOptions;
+  middleware?: any
+}
+
+export type BullBoardQueueOptions = {
+  name: string;
+  adapter: { new(queue: any, options?: QueueAdapterOptions): BaseAdapter },
+  options?: QueueAdapterOptions,
+};
+
+//create our own types with the needed functions, so we don't need to include express/fastify libraries here.
+export type BullBoardServerAdapter = IServerAdapter & { setBasePath(path: string): any };
+export type BullBoardFastifyAdapter = BullBoardServerAdapter & { registerPlugin(): any };
+export type BullBoardExpressAdapter = BullBoardServerAdapter & { getRouter(): any };

--- a/packages/nestjs/src/bull-board.util.ts
+++ b/packages/nestjs/src/bull-board.util.ts
@@ -1,0 +1,12 @@
+import {
+  BullBoardExpressAdapter,
+  BullBoardFastifyAdapter, BullBoardServerAdapter,
+} from "./bull-board.types";
+
+export const isFastifyAdapter = (adapter: BullBoardServerAdapter): adapter is BullBoardFastifyAdapter => {
+  return 'registerPlugin' in adapter;
+}
+
+export const isExpressAdapter = (adapter: BullBoardServerAdapter): adapter is BullBoardExpressAdapter => {
+  return 'getRouter' in adapter;
+}

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -1,0 +1,4 @@
+export * from './bull-board.module';
+export * from './bull-board.types';
+export * from './bull-board.constants';
+export * from './bull-board.decorator';

--- a/packages/nestjs/tsconfig.json
+++ b/packages/nestjs/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true,
+    "removeComments": false,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "useUnknownInCatchVariables": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+    "tests",
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,6 +2502,11 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
+"@lukeed/csprng@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
 "@msgpackr-extract/msgpackr-extract-darwin-arm64@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz#901c5937e1441572ea23e631fe6deca68482fe76"
@@ -2531,6 +2536,42 @@
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz#016d855b6bc459fd908095811f6826e45dd4ba64"
   integrity sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==
+
+"@nestjs/bull-shared@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@nestjs/bull-shared/-/bull-shared-0.1.3.tgz#df08180d3990c1234599069fa37c399d4913c6c1"
+  integrity sha512-K0a1ERpnl/ZnTmm0UtYSSClDlDkQwNNwJYM6PogzpeflD64oqwVIn8Pj8rdS+BOYUxqdDy55q3p67ytO5oaVDA==
+  dependencies:
+    tslib "2.5.0"
+
+"@nestjs/bullmq@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/bullmq/-/bullmq-1.1.0.tgz#8f8aa077c325e8a5d4ce52d75f3ffe9f2a7fafab"
+  integrity sha512-XloO39ACm9TuB8XOX53iMUaCW5BTQAnZADtX4a9kczJZU/5/cQVBfSCyfzq9L6dfi5EX6w/1Ayyv+5qBQ5yrzw==
+  dependencies:
+    "@nestjs/bull-shared" "^0.1.3"
+    tslib "2.5.0"
+
+"@nestjs/common@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-9.4.2.tgz#d1f8a685217e2d94f8950d00b618c542ffa2a5f1"
+  integrity sha512-sea+qZnbD5x3YWZDVQT/wbVJ2NiABaM1tyZTLuW9hpkcM2KFA96xKtK3VaCxyz49zoXIgSOefsyK7HuUMCe27Q==
+  dependencies:
+    uid "2.0.2"
+    iterare "1.2.1"
+    tslib "2.5.2"
+
+"@nestjs/core@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-9.4.2.tgz#51b02e07da42a0f68a0b91d188ea49c402805c35"
+  integrity sha512-S5K9GTpjBqEJtu5VxRsVaaGEBZ1bkY+Ht4+2hqZSKsI+rzcEB5hcvR+5KiMsMY1VGYvlZ99lxYz72p4h8B0mKw==
+  dependencies:
+    uid "2.0.2"
+    "@nuxtjs/opencollective" "0.3.2"
+    fast-safe-stringify "2.1.1"
+    iterare "1.2.1"
+    path-to-regexp "3.2.0"
+    tslib "2.5.2"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2617,6 +2658,15 @@
     "@npmcli/promise-spawn" "^1.3.2"
     node-gyp "^7.1.0"
     read-package-json-fast "^2.0.1"
+
+"@nuxtjs/opencollective@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/opencollective/-/opencollective-0.3.2.tgz#620ce1044f7ac77185e825e1936115bb38e2681c"
+  integrity sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==
+  dependencies:
+    chalk "^4.1.0"
+    consola "^2.15.0"
+    node-fetch "^2.6.1"
 
 "@octokit/auth-token@^2.4.4":
   version "2.5.0"
@@ -3596,6 +3646,11 @@
   version "18.11.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.10.tgz#4c64759f3c2343b7e6c4b9caf761c7a3a05cee34"
   integrity sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==
+
+"@types/node@18.16.16":
+  version "18.16.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.16.tgz#3b64862856c7874ccf7439e6bab872d245c86d8e"
+  integrity sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==
 
 "@types/node@^17.0.25":
   version "17.0.45"
@@ -4729,6 +4784,20 @@ bull@^4.10.2, bull@^4.9.0:
     semver "^7.3.2"
     uuid "^8.3.0"
 
+bull@^4.10.4:
+  version "4.10.4"
+  resolved "https://registry.yarnpkg.com/bull/-/bull-4.10.4.tgz#db39ee0c3bfbe3b76f1f35db800501de5bba4f84"
+  integrity sha512-o9m/7HjS/Or3vqRd59evBlWCXd9Lp+ALppKseoSKHaykK46SmRjAilX98PgmOz1yeVaurt8D5UtvEt4bUjM3eA==
+  dependencies:
+    cron-parser "^4.2.1"
+    debuglog "^1.0.0"
+    get-port "^5.1.1"
+    ioredis "^5.0.0"
+    lodash "^4.17.21"
+    msgpackr "^1.5.2"
+    semver "^7.3.2"
+    uuid "^8.3.0"
+
 bullmq@^1.80.6, bullmq@^1.90.1:
   version "1.91.1"
   resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-1.91.1.tgz#ed17cfd4e314afa398fd099a32d365046b1ed4bc"
@@ -4738,6 +4807,20 @@ bullmq@^1.80.6, bullmq@^1.90.1:
     get-port "6.1.2"
     glob "^8.0.3"
     ioredis "^5.2.2"
+    lodash "^4.17.21"
+    msgpackr "^1.6.2"
+    semver "^7.3.7"
+    tslib "^2.0.0"
+    uuid "^9.0.0"
+
+bullmq@^3.15.2:
+  version "3.15.5"
+  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-3.15.5.tgz#b8e80f47cd167a0ce77e34e47404adcb98447813"
+  integrity sha512-NotMUfU5wBAjZQgcl/F5UMUIs1DiXDRmZBN5BPuSQ841w7mYlaghTMGSy0H+kAwFa7388e7/5COTiX8EUxFo5w==
+  dependencies:
+    cron-parser "^4.6.0"
+    glob "^8.0.3"
+    ioredis "^5.3.2"
     lodash "^4.17.21"
     msgpackr "^1.6.2"
     semver "^7.3.7"
@@ -5247,6 +5330,11 @@ connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
+
+consola@^2.15.0:
+  version "2.15.3"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
+  integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -5798,7 +5886,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-denque@^2.0.1:
+denque@^2.0.1, denque@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
@@ -6618,7 +6706,7 @@ fast-redact@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.1.2.tgz#d58e69e9084ce9fa4c1a6fa98a3e1ecf5d7839aa"
   integrity sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==
 
-fast-safe-stringify@^2.1.1:
+fast-safe-stringify@2.1.1, fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
@@ -7851,6 +7939,21 @@ ioredis@^5.0.0, ioredis@^5.2.2:
     redis-parser "^3.0.0"
     standard-as-callback "^2.1.0"
 
+ioredis@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.3.2.tgz#9139f596f62fc9c72d873353ac5395bcf05709f7"
+  integrity sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ip@^1.1.5:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
@@ -8261,6 +8364,11 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterare@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/iterare/-/iterare-1.2.1.tgz#139c400ff7363690e33abffa33cbba8920f00042"
+  integrity sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==
 
 iterate-iterator@^1.0.1:
   version "1.0.2"
@@ -10474,6 +10582,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
+path-to-regexp@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.2.0.tgz#fa7877ecbc495c601907562222453c43cc204a5f"
+  integrity sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==
+
 path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
@@ -11696,6 +11809,11 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
+reflect-metadata@0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz#7c3192cab6dd24e21cb4461e5ddd7dd24fa8374c"
@@ -12022,6 +12140,13 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
 
 rxjs@^6.6.0:
   version "6.6.7"
@@ -13098,6 +13223,16 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
+tslib@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
+  integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
+
 tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -13226,6 +13361,11 @@ typescript@^4.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
+
 uglify-js@^3.1.4:
   version "3.15.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.4.tgz#fa95c257e88f85614915b906204b9623d4fa340d"
@@ -13235,6 +13375,13 @@ uid-number@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
   integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
+
+uid@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/uid/-/uid-2.0.2.tgz#4b5782abf0f2feeefc00fa88006b2b3b7af3e3b9"
+  integrity sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==
+  dependencies:
+    "@lukeed/csprng" "^1.0.0"
 
 umask@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Context
As discussed in [#303,](https://github.com/felixmosh/bull-board/issues/303#issuecomment-1586974364)  I created a new package called `nestjs-bull-board` to easily integrate bull-board with NestJS. After some back and forth between @felixmosh and me, the library reached a state where it can be integrated into the `bull-board` mono-repo 😄 

## What has been done
- Added a new package to the mono-repo `@bull-board/nestjs`
- Added the existing package code from https://github.com/DennisSnijder/nestjs-bull-board to the new package.
- Updated documentation on the package README.md to match the new package name.

## Todo
- [X] Update the index README.md to mention the NestJS package.
- [X] Add a `with-nestjs-module` example to use the new module.
