### PR TITLE
Add globalPrefix option to BullBoardModuleOptions

### DIFF
--- a/packages/nestjs/src/bull-board.root-module.ts
+++ b/packages/nestjs/src/bull-board.root-module.ts
@@ -16,7 +16,7 @@ export class BullBoardRootModule implements NestModule {
   }
 
   configure(consumer: MiddlewareConsumer): any {
-    this.adapter.setBasePath(this.options.route);
+    this.adapter.setBasePath(this.options.globalPrefix ? `${this.options.globalPrefix}${this.options.route}` : this.options.route);
 
     if (isExpressAdapter(this.adapter)) {
       return consumer

--- a/packages/nestjs/src/bull-board.types.ts
+++ b/packages/nestjs/src/bull-board.types.ts
@@ -5,6 +5,7 @@ import { BaseAdapter } from "@bull-board/api/dist/src/queueAdapters/base";
 export type BullBoardInstance = ReturnType<typeof createBullBoard>;
 
 export type BullBoardModuleOptions = {
+  globalPrefix?: string
   route: string;
   adapter: { new(): BullBoardServerAdapter };
   boardOptions?: BoardOptions;


### PR DESCRIPTION
This PR fixes an issue when using ```app.setGlobalPrefix('/api/v1')``` in NestJS. When only using the `route` option, specifying  `/queues` as the route, the index page would properly load at `/api/v1/queues`, but all assets would be loading from `/queues/...` instead of `/api/v1/queues/...` which would then fail.