### PR TITLE
Enhanced Time Formatting for Short-duration Jobs

### DIFF
--- a/packages/ui/src/components/JobCard/Timeline/Timeline.tsx
+++ b/packages/ui/src/components/JobCard/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { format, formatDistance, getYear, isToday } from 'date-fns';
+import { format, formatDistance, getYear, isToday, differenceInMilliseconds } from 'date-fns';
 import React from 'react';
 import s from './Timeline.module.css';
 import { AppJob, Status } from '@bull-board/api/typings/app';
@@ -15,6 +15,19 @@ const formatDate = (ts: TimeStamp) => {
     ? format(ts, 'MM/dd HH:mm:ss')
     : format(ts, 'MM/dd/yyyy HH:mm:ss');
 };
+const formatDuration = (finishedTs: TimeStamp, processedTs: TimeStamp) => {
+  const durationInMs = differenceInMilliseconds(finishedTs, processedTs);
+  const durationInSeconds = durationInMs / 1000;
+  if (durationInSeconds > 5) {
+    return formatDistance(finishedTs, processedTs, {
+      includeSeconds: true,
+    });
+  }
+  if (durationInSeconds >= 1) {
+    return `${durationInSeconds.toFixed(2)} seconds`;
+  }
+    return `${durationInMs} milliseconds`;
+}
 
 export const Timeline = function Timeline({ job, status }: { job: AppJob; status: Status }) {
   return (
@@ -34,9 +47,7 @@ export const Timeline = function Timeline({ job, status }: { job: AppJob; status
           <li>
             <small>
               {job.delay && job.delay > 0 ? 'delayed for ' : ''}
-              {formatDistance(job.processedOn, job.timestamp || 0, {
-                includeSeconds: true,
-              })}
+              {formatDuration(job.processedOn, job.timestamp || 0)}
             </small>
             <small>Process started at</small>
             <time>{formatDate(job.processedOn)}</time>
@@ -45,9 +56,7 @@ export const Timeline = function Timeline({ job, status }: { job: AppJob; status
         {!!job.finishedOn && (
           <li>
             <small>
-              {formatDistance(job.finishedOn, job.processedOn || 0, {
-                includeSeconds: true,
-              })}
+              {formatDuration(job.finishedOn, job.processedOn || 0)}
             </small>
             <small>{job.isFailed && status !== STATUSES.active ? 'Failed' : 'Finished'} at</small>
             <time>{formatDate(job.finishedOn)}</time>


### PR DESCRIPTION
**Current Behavior:**
For jobs that complete in under 5 seconds, the system currently displays the duration as "less than 5 seconds". This approach obscures the details for tasks that finish in mere milliseconds.

**Proposed Change:**
To provide more granular information about job execution times, this pull request introduces an enhanced time formatting mechanism:

Jobs that take less than 1 second will display their duration in milliseconds (e.g., "320 miliseconds").
Jobs that take between 1 to 5 seconds will display their duration with a precision of two decimal places (e.g., "3.25 seconds").

**Rationale:**
This change ensures that users have a clear understanding of the job durations, especially for those that complete rapidly. It will be particularly valuable for performance monitoring and optimization efforts, where millisecond-level precision can be crucial.