### PR TITLE
[express] Make ExpressAdapter fields protected instead of private

### DIFF
--- a/packages/express/src/ExpressAdapter.ts
+++ b/packages/express/src/ExpressAdapter.ts
@@ -12,11 +12,11 @@ import express, { Express, NextFunction, Request, Response, Router } from 'expre
 import { wrapAsync } from './helpers/wrapAsync';
 
 export class ExpressAdapter implements IServerAdapter {
-  private readonly app: Express;
-  private basePath = '';
-  private bullBoardQueues: BullBoardQueues | undefined;
-  private errorHandler: ((error: Error) => ControllerHandlerReturnType) | undefined;
-  private uiConfig: UIConfig = {};
+  protected readonly app: Express;
+  protected basePath = '';
+  protected bullBoardQueues: BullBoardQueues | undefined;
+  protected errorHandler: ((error: Error) => ControllerHandlerReturnType) | undefined;
+  protected uiConfig: UIConfig = {};
 
   constructor() {
     this.app = express();


### PR DESCRIPTION
Private fields make it difficult to extends ExpressAdapter. Using protected instead make ExpressAdapter open to extension.

Close #626 