### PR TITLE
Add headers UIConfig option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ An object that allows you to specify a different logo
 An array of misc link that you can add to the dashboard, such as logout link.
 4. uiConfig.favIcon (default: `{ default: 'static/images/logo.svg', alternative: 'static/favicon-32x32.png', }`) `{ default: string; alternative: 'string' }`
 An object that allows you to specify the default and alternative favicons.
+5. uiConfig.requestHeaders (default: `empty`) `{ [string]: string }`
+An object of headers to send with requests made by the UI. Useful if, for example, you have CSRF protection enabled.
 
 ```js
 const QueueMQ = require('bullmq');

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -184,6 +184,7 @@ export type UIConfig = Partial<{
   boardLogo: { path: string; width?: number | string; height?: number | string };
   miscLinks: Array<IMiscLink>;
   favIcon: FavIcon;
+  requestHeaders: { [string]: string }
 }>;
 
 export type FavIcon = {

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -11,8 +11,8 @@ import './toastify.css';
 
 const basePath = ((window as any).__basePath__ =
   document.head.querySelector('base')?.getAttribute('href') || '');
-const api = new Api({ basePath });
 const uiConfig = JSON.parse(document.getElementById('__UI_CONFIG__')?.textContent || '{}');
+const api = new Api({ basePath, headers: uiConfig.requestHeaders });
 
 render(
   <BrowserRouter basename={basePath}>

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -12,8 +12,8 @@ import { toast } from 'react-toastify';
 export class Api {
   private axios: AxiosInstance;
 
-  constructor({ basePath }: { basePath: string } = { basePath: '' }) {
-    this.axios = Axios.create({ baseURL: `${basePath}api` });
+  constructor({ basePath = '', headers = {} }: { basePath: string; headers: { [string]: string } }) {
+    this.axios = Axios.create({ baseURL: `${basePath}api`, headers });
     this.axios.interceptors.response.use(this.handleResponse, this.handleError);
   }
 


### PR DESCRIPTION
Adds the option to set request headers through UI config. This is useful if you have CSRF protection enabled on your app, and need to tell bull to pass a certain header with every request.