### PR TITLE
fix(nestjs): edit bullboard path have global prefix when using fastify

### DIFF
--- a/packages/nestjs/src/bull-board.root-module.ts
+++ b/packages/nestjs/src/bull-board.root-module.ts
@@ -29,7 +29,7 @@ export class BullBoardRootModule implements NestModule {
     if (isFastifyAdapter(this.adapter)) {
       this.adapterHost.httpAdapter
         .getInstance()
-        .register(this.adapter.registerPlugin(), {prefix: this.options.route});
+        .register(this.adapter.registerPlugin(), {prefix: `${ globalPrefix }${ this.options.route }`});
 
       return consumer
         .apply(this.options.middleware)


### PR DESCRIPTION
Hi @felixmosh, first of all thank you and everyone build this repo. It nice

- I using NestJS + Fastify, and now try implement the BullMQ, so I add your library, it nice!
- But when I test it not recognize if I have a global prefix in Fastify
![Issue](https://github.com/felixmosh/bull-board/assets/50540212/5715019e-98a6-4f97-8261-6649a09ecd5c)

- I've read all the issues of this repo but not find the best way to fix this
- So I try on your code and figure out the issue in here
![Bug](https://github.com/felixmosh/bull-board/assets/50540212/69cb55be-5bce-4fe8-91fe-d7fd139bc417)

The result after change my code is working correctly my expectation
![Fixway](https://github.com/felixmosh/bull-board/assets/50540212/e58833fb-2d4f-4a88-9c29-1addd0f51a02)

I create this PR maybe it make it right. If you think not more problem you can merge it

Thank and have a good day