### PR TITLE
Add default job tab setting

### DIFF
--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -5,6 +5,7 @@ import { InputField } from '../Form/InputField/InputField';
 import { SelectField } from '../Form/SelectField/InputField';
 import { SwitchField } from '../Form/SwitchField/SwitchField';
 import { Modal } from '../Modal/Modal';
+import { availableJobTabs } from '../../hooks/useDetailsTabs';
 
 export interface SettingsModalProps {
   open: boolean;
@@ -23,6 +24,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
     collapseJobData,
     collapseJobOptions,
     collapseJobError,
+    defaultJobTab,
     setSettings,
   } = useSettingsStore((state) => state);
   const { t } = useTranslation();
@@ -43,6 +45,16 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
         }))}
         value={`${pollingInterval}`}
         onChange={(event) => setSettings({ pollingInterval: +event.target.value })}
+      />
+      <SelectField
+        label={t('SETTINGS.DEFAULT_JOB_TAB')}
+        id="default-job-tab"
+        options={availableJobTabs.map((tab) => ({
+          text: t(`JOB.TABS.${tab.toUpperCase()}`),
+          value: tab,
+        }))}
+        value={defaultJobTab}
+        onChange={(event) => setSettings({ defaultJobTab: event.target.value })}
       />
       <InputField
         label={t('SETTINGS.JOBS_PER_PAGE')}

--- a/packages/ui/src/hooks/useDetailsTabs.tsx
+++ b/packages/ui/src/hooks/useDetailsTabs.tsx
@@ -34,10 +34,6 @@ export function useDetailsTabs(currentStatus: Status, isJobFailed: boolean) {
     }
   }, [defaultJobTab, tabs]);
 
-  console.log({
-    selectedTab,
-    defaultJobTab,
-  });
   return {
     tabs: tabs?.map((title) => ({
       title,

--- a/packages/ui/src/hooks/useDetailsTabs.tsx
+++ b/packages/ui/src/hooks/useDetailsTabs.tsx
@@ -7,13 +7,13 @@ export const availableJobTabs = ['Data', 'Options', 'Logs', 'Error'] as const;
 
 export type TabsType = (typeof availableJobTabs)[number];
 
-const FALLBACK_TAB: TabsType = 'Data';
-
 export function useDetailsTabs(currentStatus: Status, isJobFailed: boolean) {
   const [tabs, updateTabs] = useState<TabsType[]>([]);
   const { defaultJobTab } = useSettingsStore();
 
-  const [selectedTab, setSelectedTab] = useState<TabsType>(defaultJobTab);
+  const [selectedTab, setSelectedTab] = useState<TabsType>(
+    tabs.find((tab) => tab === defaultJobTab) || tabs[0]
+  );
 
   useEffect(() => {
     let nextState = availableJobTabs.filter((tab) => tab !== 'Error');
@@ -28,7 +28,7 @@ export function useDetailsTabs(currentStatus: Status, isJobFailed: boolean) {
 
   useEffect(() => {
     if (!tabs.includes(defaultJobTab)) {
-      setSelectedTab(FALLBACK_TAB);
+      setSelectedTab(tabs[0]);
     } else {
       setSelectedTab(defaultJobTab);
     }

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { TabsType } from './useDetailsTabs';
 
 interface SettingsState {
   pollingInterval: number;
@@ -9,6 +10,7 @@ interface SettingsState {
   collapseJobData: boolean;
   collapseJobOptions: boolean;
   collapseJobError: boolean;
+  defaultJobTab: TabsType;
   setSettings: (settings: Partial<Omit<SettingsState, 'setSettings'>>) => void;
 }
 
@@ -22,6 +24,7 @@ export const useSettingsStore = create<SettingsState>()(
       collapseJobData: false,
       collapseJobOptions: false,
       collapseJobError: false,
+      defaultJobTab: 'Data',
       setSettings: (settings) => set(() => settings),
     }),
     {

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -105,6 +105,7 @@
       "MINS": "{{count}} minutes",
       "MINS_one": "{{count}} minute"
     },
+    "DEFAULT_JOB_TAB": "Default job tab",
     "JOBS_PER_PAGE": "Jobs per page (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Confirm queue actions",
     "CONFIRM_JOB_ACTIONS": "Confirm job actions",


### PR DESCRIPTION
Hi @felixmosh! First of all, thank you for this amazing tool! We use it everyday and really enjoy it. This is my first PR on this project, would love to get any feedback from you and hope it will be useful for other users as well 🙏

In our project, we were required to implement this feature https://github.com/felixmosh/bull-board/issues/264. So basically, we want to have "logs" tab to be opened by default. 

To make the solution more flexible I decided to create setting **default-job-tab** which is used for selecting initial job tab.

### Screens:
![IMAGE 2024-01-21 10:42:21](https://github.com/felixmosh/bull-board/assets/38187639/cc46d5bf-49a2-47c1-8ff8-7e9ea90c38b6)

![IMAGE 2024-01-21 10:42:24](https://github.com/felixmosh/bull-board/assets/38187639/c4c22e0b-8581-431a-9aa4-dcf0e343dca4)

![CleanShot 2024-01-21 at 10 43 38@2x](https://github.com/felixmosh/bull-board/assets/38187639/998db425-b58e-4777-8ac3-44636bb99b91)

### Todos:
* Add pt-BR locales
### Description: 
This commit adds a new setting for the default job tab in the SettingsModal component. The selected default job tab is stored in the useSettingsStore and can be changed by the user.