### PR TITLE
feat: [NestJS] Fastify global prefix support

### DIFF
--- a/packages/nestjs/src/bull-board.root-module.ts
+++ b/packages/nestjs/src/bull-board.root-module.ts
@@ -17,11 +17,10 @@ export class BullBoardRootModule implements NestModule {
   }
 
   configure(consumer: MiddlewareConsumer): any {
-    const globalPrefix = this.applicationConfig.getGlobalPrefix();
-    const prefix = `${globalPrefix}${this.options.route}`.replace(
-      /^\/?([^\/]+(?:\/[^\/]+)*)\/?$/,
-      '/$1'
-    );
+    const addForwardSlash = (path: string) => {
+      return path.startsWith('/') || path === '' ? path : `/${path}`;
+    };
+    const prefix = addForwardSlash(this.applicationConfig.getGlobalPrefix() + this.options.route);
 
     this.adapter.setBasePath(prefix);
 
@@ -36,7 +35,7 @@ export class BullBoardRootModule implements NestModule {
         .getInstance()
         .register(this.adapter.registerPlugin(), { prefix });
 
-      return consumer
+        return consumer
         .apply(this.options.middleware)
         .forRoutes(this.options.route);
     }

--- a/packages/nestjs/src/bull-board.root-module.ts
+++ b/packages/nestjs/src/bull-board.root-module.ts
@@ -17,8 +17,13 @@ export class BullBoardRootModule implements NestModule {
   }
 
   configure(consumer: MiddlewareConsumer): any {
-    const globalPrefix = this.applicationConfig.getGlobalPrefix() || '';
-    this.adapter.setBasePath(`${ globalPrefix }${ this.options.route }`);
+    const globalPrefix = this.applicationConfig.getGlobalPrefix();
+    const prefix = `${globalPrefix}${this.options.route}`.replace(
+      /^\/?([^\/]+(?:\/[^\/]+)*)\/?$/,
+      '/$1'
+    );
+
+    this.adapter.setBasePath(prefix);
 
     if (isExpressAdapter(this.adapter)) {
       return consumer
@@ -29,7 +34,7 @@ export class BullBoardRootModule implements NestModule {
     if (isFastifyAdapter(this.adapter)) {
       this.adapterHost.httpAdapter
         .getInstance()
-        .register(this.adapter.registerPlugin(), {prefix: this.options.route});
+        .register(this.adapter.registerPlugin(), { prefix });
 
       return consumer
         .apply(this.options.middleware)


### PR DESCRIPTION
Fixes #607.

Apparently https://github.com/felixmosh/bull-board/pull/592 doesn't work with Fastify and https://github.com/felixmosh/bull-board/pull/639 adds Fastify support.
But both PRs fail loading the static folder correctly when global prefix doesn't start with a forward slash.
It was mentioned here https://github.com/felixmosh/bull-board/pull/592#issuecomment-1628526095 with https://github.com/felixmosh/bull-board/issues/607#issuecomment-1833471506 as the solution.

This PR does 2 things:
1. Makes sure that there is a leading forward slash in the `adapter.basePath` to correctly load the static folder for both Express and Fastify.
2. Fastify `prefix` option should be equal to the `adapter.basePath`.

I've setup 2 codesandboxes for you to verify this PR:

NestJS + Express: https://codesandbox.io/p/devbox/vigilant-tdd-nhjg2r
Preview: https://nhjg2r-3000.csb.app/api/queues

NestJS + Fastify: https://codesandbox.io/p/devbox/naughty-kepler-w38fhq
Preview: https://w38fhq-3000.csb.app/api/queues

- `main.ts`: You can change the global prefix here with/without a leading slash. Or comment out the setGlobalPrefix method to see that it still works without it.

- `app.module.ts`: Change the route to something else if you want.

Both use `"@bull-board/nestjs": "github:dimbslmh/bull-board-nestjs",`