### PR TITLE
feat: add processedOn to job card if set

### DIFF
--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -60,6 +60,7 @@ export interface QueueJobJson {
   attemptsMade: number;
   finishedOn?: number | null;
   processedOn?: number | null;
+  processedBy?: string | null;
   delay?: number;
   timestamp: number;
   failedReason: string;
@@ -93,6 +94,7 @@ export interface AppJob {
   name: QueueJobJson['name'];
   timestamp: QueueJobJson['timestamp'];
   processedOn?: QueueJobJson['processedOn'];
+  processedBy?: QueueJobJson['processedBy'];
   finishedOn?: QueueJobJson['finishedOn'];
   progress: QueueJobJson['progress'];
   attempts: QueueJobJson['attemptsMade'];

--- a/packages/ui/src/components/JobCard/Timeline/Timeline.tsx
+++ b/packages/ui/src/components/JobCard/Timeline/Timeline.tsx
@@ -79,6 +79,11 @@ export const Timeline = function Timeline({ job, status }: { job: AppJob; status
             </small>
             <small>{t('JOB.PROCESS_STARTED_AT')}</small>
             <time>{formatDate(job.processedOn, i18n.language)}</time>
+            {!!job.processedBy && (
+              <small>
+                {t('JOB.PROCESSED_BY', { processedBy: job.processedBy })}
+              </small>
+            )}
           </li>
         )}
         {!!job.finishedOn && (

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -17,6 +17,7 @@
     "WILL_RUN_AT": "Will run at",
     "DELAYED_FOR": "delayed for",
     "PROCESS_STARTED_AT": "Process started at",
+    "PROCESSED_BY": "by {{processedBy}}",
     "FAILED_AT": "Failed at",
     "FINISHED_AT": "Finished at",
     "ATTEMPTS": "attempt #{{attempts}}",

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -19,6 +19,7 @@
     "WILL_RUN_AT": "Iniciará em",
     "DELAYED_FOR": "aguardando por",
     "PROCESS_STARTED_AT": "Processo iniciado em",
+    "PROCESSED_BY": "por {{processedBy}}",
     "FAILED_AT": "Falha em",
     "FINISHED_AT": "Concluído em",
     "ATTEMPTS": "tentativas #{{attempts}}",


### PR DESCRIPTION
As of BullMQ [v5.3.0](https://github.com/taskforcesh/bullmq/releases/tag/v5.3.0), workers can now be named. Jobs processed by named workers will have the [`processedBy`](https://api.docs.bullmq.io/classes/v5.Job.html#processedBy) property set on them.

This PR adds the value of this property (if set) to the JobCard beneath the "Processed on" timeline label.

<img width="168" alt="image" src="https://github.com/felixmosh/bull-board/assets/87633852/fe685567-c34f-44a6-aa43-3d2e66befd6e">

closes felixmosh/bull-board#718