### PR TITLE
Feature: Category property

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
   serverAdapter: serverAdapter,
 });
 
+// If you want to group queues by categories
+const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
+  queues: [
+    new BullAdapter(someQueue, { category: 'Foo' } ),
+    new BullAdapter(someOtherQueue, { category: 'Foo' }),
+    new BullMQAdapter(queueMQ, { category: 'Bar' })],
+  serverAdapter: serverAdapter,
+});
+
 const app = express();
 
 app.use('/admin/queues', serverAdapter.getRouter());

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -82,6 +82,7 @@ async function getAppQueues(
         name: queueName,
         description: queue.getDescription() || undefined,
         statuses: queue.getStatuses(),
+        category: queue.getCategory(),
         counts: counts as Record<Status, number>,
         jobs: jobs.filter(Boolean).map((job) => formatJob(job, queue)),
         pagination,

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -14,6 +14,7 @@ export abstract class BaseAdapter {
   public readonly allowCompletedRetries: boolean;
   public readonly prefix: string;
   public readonly description: string;
+  public readonly category: string;
   private formatters = new Map<FormatterField, (data: any) => any>();
 
   protected constructor(
@@ -24,10 +25,15 @@ export abstract class BaseAdapter {
     this.allowCompletedRetries = this.allowRetries && options.allowCompletedRetries !== false;
     this.prefix = options.prefix || '';
     this.description = options.description || '';
+    this.category = options.category || 'default';
   }
 
   public getDescription(): string {
     return this.description;
+  }
+
+  public getCategory(): string {
+    return this.category;
   }
 
   public setFormatter<T extends FormatterField>(

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -31,6 +31,7 @@ export interface QueueAdapterOptions {
   allowRetries: boolean;
   prefix: string;
   description: string;
+  category: string;
 }
 
 export type BullBoardQueues = Map<string, BaseAdapter>;

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -111,6 +111,7 @@ export interface AppJob {
 export interface AppQueue {
   name: string;
   description?: string;
+  category: string;
   counts: Record<Status, number>;
   jobs: AppJob[];
   statuses: Status[];


### PR DESCRIPTION
This adds the base property `category` that will be used to display queues organized by categories.

This is a split from the original PR: https://github.com/felixmosh/bull-board/pull/739