### PR TITLE
feat: toggle failed queues only

### DIFF
--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -26,6 +26,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
     collapseJobOptions,
     collapseJobError,
     defaultJobTab,
+    showOnlyFailedQueues,
     setSettings,
   } = useSettingsStore((state) => state);
   const { t } = useTranslation();
@@ -105,6 +106,12 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
         id="collapse-job-error"
         checked={collapseJobError}
         onCheckedChange={(checked) => setSettings({ collapseJobError: checked })}
+      />
+      <SwitchField
+        label={t('SETTINGS.SHOW_ONLY_FAILED_QUEUES')}
+        id="collapse-job-error"
+        checked={showOnlyFailedQueues}
+        onCheckedChange={(checked) => setSettings({ showOnlyFailedQueues: checked })}
       />
     </Modal>
   );

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -11,6 +11,7 @@ interface SettingsState {
   collapseJobData: boolean;
   collapseJobOptions: boolean;
   collapseJobError: boolean;
+  showOnlyFailedQueues: boolean;
   defaultJobTab: TabsType;
   setSettings: (settings: Partial<Omit<SettingsState, 'setSettings'>>) => void;
 }
@@ -27,6 +28,7 @@ export const useSettingsStore = create<SettingsState>()(
       collapseJobOptions: false,
       collapseJobError: false,
       defaultJobTab: 'Data',
+      showOnlyFailedQueues: false,
       setSettings: (settings) => set(() => settings),
     }),
     {

--- a/packages/ui/src/pages/OverviewPage/OverviewPage.tsx
+++ b/packages/ui/src/pages/OverviewPage/OverviewPage.tsx
@@ -3,21 +3,35 @@ import { QueueCard } from '../../components/QueueCard/QueueCard';
 import { StatusLegend } from '../../components/StatusLegend/StatusLegend';
 import { useQueues } from '../../hooks/useQueues';
 import s from './OverviewPage.module.css';
+import { useSettingsStore } from '../../hooks/useSettings';
+import { useTranslation } from 'react-i18next';
 
 export const OverviewPage = () => {
   const { actions, queues } = useQueues();
+  const { showOnlyFailedQueues } = useSettingsStore();
+  const { t } = useTranslation();
   actions.pollQueues();
+
+  const getFilteredQueues = () => {
+    if (showOnlyFailedQueues) {
+      return queues?.filter((queue) => queue.counts.failed > 0);
+    }
+    return queues;
+  };
 
   return (
     <section>
       <StatusLegend />
       <ul className={s.overview}>
-        {queues?.map((queue) => (
+        {getFilteredQueues()?.map((queue) => (
           <li key={queue.name}>
             <QueueCard queue={queue} />
           </li>
         ))}
       </ul>
+      {showOnlyFailedQueues && getFilteredQueues()?.length === 0 && (
+        <>{t('QUEUE.FAILED_QUEUES_NOT_FOUND')}</>
+      )}
     </section>
   );
 };

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -73,7 +73,8 @@
       "FAILED": "Failed",
       "DELAYED": "Delayed",
       "PAUSED": "Paused"
-    }
+    },
+    "FAILED_QUEUES_NOT_FOUND": "Failed queues not found"
   },
   "CONFIRM": {
     "DEFAULT_TITLE": "Are you sure?",
@@ -114,6 +115,7 @@
     "COLLAPSE_JOB": "Collapse job",
     "COLLAPSE_JOB_DATA": "Collapse job data",
     "COLLAPSE_JOB_OPTIONS": "Collapse job options",
-    "COLLAPSE_JOB_ERROR": "Collapse job error"
+    "COLLAPSE_JOB_ERROR": "Collapse job error",
+    "SHOW_ONLY_FAILED_QUEUES": "Show only failed queues"
   }
 }


### PR DESCRIPTION
Added a toggle to filter out non-failing queues.

Why?

When using Bull Board for production monitoring purposes, it's very useful when you want to know about failing jobs (not as a substitute for alerts).

In my case, I'm displaying it on a TV in my company's office and we have 20 different queues currently, which makes it hard to follow if any of them have failures, especially if one of the queues has a lot of successful jobs, so it's easy to miss that there's one failed job out of a thousand successful ones.

Filtering successful ones out should help us focus on the board only when we notice that there are any failing queues.

![image](https://github.com/felixmosh/bull-board/assets/6060751/5990a8ef-6386-4888-82c4-2470c102fe03)
