### PR TITLE
Round Progress percent (JobCard)

### DIFF
--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -36,7 +36,7 @@ export const Progress = ({
       style={{ transform: 'rotate(-90deg)' }}
     ></circle>
     <text textAnchor="middle" x="74" y="88">
-      {percentage}%
+      {Math.round(percentage)}%
     </text>
   </svg>
 );


### PR DESCRIPTION
Here is an example showing 18.18181818%:

<img width="176" alt="Screenshot 2024-05-22 à 15 51 26" src="https://github.com/felixmosh/bull-board/assets/160279/14f9b797-1311-4d07-9490-2a3928cccadd">

We don't need the decimals. Or we could keep one or two if you prefer.