### PR TITLE
Close express security vulnerability (4.19.2) 

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -31,7 +31,7 @@
     "@bull-board/api": "5.18.1",
     "@bull-board/ui": "5.18.1",
     "ejs": "^3.1.10",
-    "express": "^4.17.3"
+    "express": "^4.19.2"
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",


### PR DESCRIPTION
Per SYNK we should upgrade express to 4.19.2

![image](https://github.com/felixmosh/bull-board/assets/82471930/06d9a559-c06a-4b9d-a8ab-5b357781d96f)
