### PR TITLE
feat: Add Async Configuration Support to NestJS Module

### DIFF
--- a/packages/nestjs/src/bull-board.module.ts
+++ b/packages/nestjs/src/bull-board.module.ts
@@ -2,7 +2,7 @@ import { DynamicModule, Module} from "@nestjs/common";
 import { BullBoardFeatureModule } from "./bull-board.feature-module";
 import { BullBoardRootModule } from "./bull-board.root-module";
 import { BULL_BOARD_QUEUES } from "./bull-board.constants";
-import { BullBoardModuleOptions, BullBoardQueueOptions } from "./bull-board.types";
+import { BullBoardModuleAsyncOptions, BullBoardModuleOptions, BullBoardQueueOptions } from "./bull-board.types";
 
 @Module({})
 export class BullBoardModule {
@@ -25,5 +25,13 @@ export class BullBoardModule {
       imports: [ BullBoardRootModule.forRoot(options) ],
       exports: [ BullBoardRootModule ],
     };
+  }
+
+  static forRootAsync(options: BullBoardModuleAsyncOptions): DynamicModule {
+    return {
+      module: BullBoardModule,
+      imports: [ BullBoardRootModule.forRootAsync(options) ],
+      exports: [ BullBoardRootModule ]
+    }
   }
 }

--- a/packages/nestjs/src/bull-board.types.ts
+++ b/packages/nestjs/src/bull-board.types.ts
@@ -1,6 +1,7 @@
 import { createBullBoard } from "@bull-board/api";
 import { BoardOptions, IServerAdapter, QueueAdapterOptions } from "@bull-board/api/dist/typings/app";
 import { BaseAdapter } from "@bull-board/api/dist/src/queueAdapters/base";
+import { InjectionToken, ModuleMetadata, OptionalFactoryDependency } from "@nestjs/common";
 
 export type BullBoardInstance = ReturnType<typeof createBullBoard>;
 
@@ -9,6 +10,12 @@ export type BullBoardModuleOptions = {
   adapter: { new(): BullBoardServerAdapter };
   boardOptions?: BoardOptions;
   middleware?: any
+}
+
+export type BullBoardModuleAsyncOptions = {
+  useFactory: (...args: any[]) => BullBoardModuleOptions| Promise<BullBoardModuleOptions>;
+  imports?: ModuleMetadata['imports'];
+  inject?: Array<InjectionToken | OptionalFactoryDependency>;
 }
 
 export type BullBoardQueueOptions = {


### PR DESCRIPTION
# Description

This PR extends the [NestJS Dynamic Module](https://github.com/felixmosh/bull-board/blob/c208d35ae9f38f86c348a561407cee5050bb539d/packages/nestjs/src/bull-board.module.ts) by adding support for async configuration.

The async configuration allows us to inject/import modules or services we need to construct the module.

Example scenario of our usecase:
```ts
ConfigModule.forRoot({ envFilePath: './.env' }),
BullBoardModule.forRootAsync({
  imports: [ConfigModule], // Import Nest configuration module
  inject: [ConfigService], // Inject Nest configuration service
  useFactory: (configService: ConfigService) => ({
    route: configService.getOrThrow('QUEUE_PATH'), // Get path from Nest configuration service
    adapter: ExpressAdapter,
  })
}),
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

