### PR TITLE
Hide bullboard routes in fastify adapter.

### DIFF
--- a/packages/fastify/src/FastifyAdapter.ts
+++ b/packages/fastify/src/FastifyAdapter.ts
@@ -122,6 +122,10 @@ export class FastifyAdapter implements IServerAdapter {
         fastify.route({
           method,
           url,
+          schema: {
+            // @ts-ignore Added in by the @fastify/swagger plugin, ignored otherwise
+            hide: true
+          },
           handler: (_req, reply) => {
             const { name, params } = handler({ basePath: this.basePath, uiConfig: this.uiConfig });
 
@@ -134,6 +138,10 @@ export class FastifyAdapter implements IServerAdapter {
         fastify.route({
           method: route.method,
           url: route.route,
+          schema: {
+            // @ts-ignore Added in by the @fastify/swagger plugin, ignored otherwise
+            hide: true
+          },
           handler: async (request, reply) => {
             const response = await route.handler({
               queues: this.bullBoardQueues as any,


### PR DESCRIPTION
Reattempting https://github.com/felixmosh/bull-board/pull/762 with the typescript error ignored for this special case.