### PR TITLE
fix(README): use proper path to bullMQAdapter file

### DIFF
--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -68,7 +68,7 @@ To register a new queue, you need to register `BullBoardModule.forFeature` in th
 ```typescript
 import { Module } from '@nestjs/common';
 import { BullBoardModule } from "@bull-board/nestjs";
-import { BullMQAdapter } from "@bull-board/api/bullMQadapter";
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
 import { BullModule } from "@nestjs/bullmq";
 
 @Module({


### PR DESCRIPTION
I've just installed bull board by following the README example, and somehow building the project was failing to me with following message:

```

src/main/worker.module.ts:19:31 - error TS2307: Cannot find module '@bull-board/api/bullMQadapter' or its corresponding type declarations.

19 import { BullMQAdapter } from '@bull-board/api/bullMQadapter';
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After a bit of inspecting I've found out that import path (that I've took from the README example) is incorrect.