### PR TITLE
fix(hono): safely parse request body

### DIFF
--- a/packages/hono/src/HonoAdapter.ts
+++ b/packages/hono/src/HonoAdapter.ts
@@ -101,12 +101,20 @@ export class HonoAdapter implements IServerAdapter {
 
     routes.forEach((route) => {
       this.apiRoutes[method](route, async (c: Context) => {
+        let reqBody = {};
+        if (method !== 'get') {
+          // Safely attempt to parse the request body, since the UI does not include a request body with most requests
+          try {
+            reqBody = await c.req.json();
+          } catch {}
+        }
+
         try {
           const response = await handler({
             queues: bullBoardQueues,
             params: c.req.param(),
             query: c.req.query(),
-            body: method !== 'get' ? await c.req.json() : {},
+            body: reqBody,
           });
 
           if (response.status == 204) {


### PR DESCRIPTION
The web UI does not include a request body in most of its requests to the API. Hono's `c.req.json()` method throws if it cannot parse the body (at least on v4, I noticed bull-board is still on v3). This causes all of the mutations in the UI to fail, except for those that include a body such as adding a job.

This PR is a small change to safely attempt to parse the request body.