### PR TITLE
fix(ui): correctly calculate the circumference and offset of the progress citcle

### DIFF
--- a/packages/ui/src/components/JobCard/Progress/Progress.module.css
+++ b/packages/ui/src/components/JobCard/Progress/Progress.module.css
@@ -6,6 +6,12 @@
 .progress circle {
   transform-origin: center;
   transition: stroke-dashoffset 500ms ease-in-out;
+  cx: 70;
+  cy: 70;
+  r: 65;
+  fill: none;
+  stroke-width: 8;
+  stroke-linecap: round;
 }
 
 .progress text {

--- a/packages/ui/src/components/JobCard/Progress/Progress.module.css
+++ b/packages/ui/src/components/JobCard/Progress/Progress.module.css
@@ -11,7 +11,7 @@
   r: 65;
   fill: none;
   stroke-width: 8;
-  stroke-linecap: round;
+  stroke-linecap: butt;
 }
 
 .progress text {

--- a/packages/ui/src/components/JobCard/Progress/Progress.module.css
+++ b/packages/ui/src/components/JobCard/Progress/Progress.module.css
@@ -6,9 +6,6 @@
 .progress circle {
   transform-origin: center;
   transition: stroke-dashoffset 500ms ease-in-out;
-  cx: 70;
-  cy: 70;
-  r: 65;
   fill: none;
   stroke-width: 8;
   stroke-linecap: butt;

--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -13,17 +13,25 @@ interface ProgressProps {
   className?: string;
 }
 
-export const Progress = ({ percentage, status, className }: ProgressProps) => (
-  <svg className={cn(s.progress, className)} viewBox="0 0 140 140">
-    <circle stroke="#E5E7EB" />
-    <circle
-      stroke={status === STATUSES.failed ? '#F56565' : '#48BB78'}
-      strokeDasharray={circumference}
-      strokeDashoffset={circumference - (circumference * percentage) / 100}
-      style={{ transform: 'rotate(-90deg)' }}
-    />
-    <text textAnchor="middle" x="74" y="88">
-      {Math.round(percentage)}%
-    </text>
-  </svg>
-);
+export const Progress = ({ percentage, status, className }: ProgressProps) => {
+  const circleProps = {
+    cx: 70,
+    cy: 70,
+    r: radius,
+  };
+  return (
+    <svg className={cn(s.progress, className)} viewBox="0 0 140 140">
+      <circle stroke="#E5E7EB" {...circleProps} />
+      <circle
+        stroke={status === STATUSES.failed ? '#F56565' : '#48BB78'}
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - (circumference * percentage) / 100}
+        style={{ transform: 'rotate(-90deg)' }}
+        {...circleProps}
+      />
+      <text textAnchor="middle" x="74" y="88">
+        {Math.round(percentage)}%
+      </text>
+    </svg>
+  );
+};

--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -15,13 +15,13 @@ interface ProgressProps {
 
 export const Progress = ({ percentage, status, className }: ProgressProps) => (
   <svg className={cn(s.progress, className)} viewBox="0 0 140 140">
-    <circle stroke="#E5E7EB"></circle>
+    <circle stroke="#E5E7EB" />
     <circle
       stroke={status === STATUSES.failed ? '#F56565' : '#48BB78'}
       strokeDasharray={circumference}
       strokeDashoffset={circumference - (circumference * percentage) / 100}
       style={{ transform: 'rotate(-90deg)' }}
-    ></circle>
+    />
     <text textAnchor="middle" x="74" y="88">
       {Math.round(percentage)}%
     </text>

--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -4,35 +4,22 @@ import cn from 'clsx';
 import { Status } from '@bull-board/api/typings/app';
 import { STATUSES } from '@bull-board/api/src/constants/statuses';
 
-export const Progress = ({
-  percentage,
-  status,
-  className,
-}: {
+const radius = 65;
+const circumference = 2 * Math.PI * radius;
+
+interface ProgressProps {
   percentage: number;
   status: Status;
   className?: string;
-}) => (
+}
+
+export const Progress = ({ percentage, status, className }: ProgressProps) => (
   <svg className={cn(s.progress, className)} viewBox="0 0 140 140">
+    <circle stroke="#E5E7EB"></circle>
     <circle
-      cx="70"
-      cy="70"
-      r="65"
-      fill="none"
-      stroke="#E5E7EB"
-      strokeWidth="8"
-      strokeLinecap="round"
-    ></circle>
-    <circle
-      cx="70"
-      cy="70"
-      r="65"
-      fill="none"
       stroke={status === STATUSES.failed ? '#F56565' : '#48BB78'}
-      strokeWidth="8"
-      strokeLinecap="round"
-      strokeDasharray="600"
-      strokeDashoffset={600 - ((600 - 160) * percentage) / 100}
+      strokeDasharray={circumference}
+      strokeDashoffset={circumference - (circumference * percentage) / 100}
       style={{ transform: 'rotate(-90deg)' }}
     ></circle>
     <text textAnchor="middle" x="74" y="88">


### PR DESCRIPTION
Closes #771 

The `stroke-dasharray` and `stroke-dashoffset` were improperly calculated, resulting in the progress circle "completing" when the percentage was only 90%.

Current version:

![image](https://github.com/felixmosh/bull-board/assets/61335118/b0e38459-4294-401f-8363-da603fa6f324)

I refactored the styling to make it more declarative. I also removed the rounded edge on the border so there is a gap with the percentage > 98%.

Fixed version:

![image](https://github.com/felixmosh/bull-board/assets/61335118/13cf4469-93a4-4693-ab32-0f401228af2a)