### PR TITLE
feat(adapters): support hono v4

### DIFF
--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -31,7 +31,7 @@
     "@bull-board/api": "5.20.2",
     "@bull-board/ui": "5.20.2",
     "ejs": "^3.1.10",
-    "hono": "^3.12.0"
+    "hono": "^4.4.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231218.0",

--- a/packages/hono/src/HonoAdapter.ts
+++ b/packages/hono/src/HonoAdapter.ts
@@ -42,7 +42,15 @@ export class HonoAdapter implements IServerAdapter {
       | typeof nodeServeStatic
       | typeof cloudflarePagesServeStatic
       | typeof cloudflareWorkersServeStatic
-      | typeof denoServeStatic
+      | typeof denoServeStatic,
+    /**
+     * only required for Cloudflare Workers. you should import it like this:
+     *
+     *   import manifest from '__STATIC_CONTENT_MANIFEST'
+     *
+     * ... and pass it as-is to the HonoAdapter constructor.
+     */
+    protected manifest: Record<string, unknown> = {}
   ) {
     this.apiRoutes = new Hono();
   }
@@ -174,6 +182,7 @@ export class HonoAdapter implements IServerAdapter {
       this.serveStatic({
         root: path.relative(process.cwd(), staticPath),
         rewriteRequestPath: (p: string) => p.replace(path.join(this.basePath, staticRoute), ''),
+        manifest: this.manifest,
       })
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8355,10 +8355,10 @@ hoist-non-react-statics@^3.1.0:
   dependencies:
     react-is "^16.7.0"
 
-hono@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-3.12.0.tgz#889214938af36ac265a99864f4a0104c4942f3fa"
-  integrity sha512-UPEtZuLY7Wo7g0mqKWSOjLFdT8t7wJ60IYEcxKl3AQNU4u+R2QqU2fJMPmSu24C+/ag20Z8mOTQOErZzK4DMvA==
+hono@^4.4.7:
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.4.7.tgz#c7b195bdeff0b46e829189c08049decc0c6510c0"
+  integrity sha512-WoQWFQyVFEVRtIzP5sHPv7nvIw+RYL/HRnvnOCDxj6A+BtrwuC9S0vryZbV4IyFcNgOJ87r/phDiC1x2eEo4Gg==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"


### PR DESCRIPTION
Support Hono V4. Since the adapters are not versioned separately, I tried to make a minimally-breaking change - it requires no changes unless you use Cloudflare Workers, which has a breaking change in Hono v4[^1]. 

This makes the types in the `HonoAdapter` slightly unsound. A proper long-term fix would be to change the API to accept `handler: ({ root, rewriteRequestPath }) => MiddlewareHandler` (where `MiddlewareHandler` is the return type of `serveStatic`).

Consumers could then construct `serveStatic` themselves, including requirements such as the manifest. That would, of course, require _every_ consumer to update their `HonoAdapter` constructor, so maybe something to reserve for a major release.

Closes #721 (supersedes)

[^1]: https://github.com/honojs/hono/blob/main/docs/MIGRATION.md#servestatic-in-cloudflare-workers-adapter-requires-manifest