### PR TITLE
Fix: Polling Interval not being updated to "off" when selecting a queue.

### DIFF
--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -41,7 +41,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
     if (queue?.readOnlyMode && pollingInterval !== -1) {
       setSettings({ pollingInterval: -1 });
     }
-  }, [queue?.readOnlyMode]);
+  }, [queue?.readOnlyMode, pollingInterval]);
 
   return (
     <Modal width="small" open={open} onClose={onClose} title={t('SETTINGS.TITLE')}>

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -6,6 +6,7 @@ import { SelectField } from '../Form/SelectField/SelectField';
 import { SwitchField } from '../Form/SwitchField/SwitchField';
 import { Modal } from '../Modal/Modal';
 import { availableJobTabs } from '../../hooks/useDetailsTabs';
+import { useActiveQueue } from '../../hooks/useActiveQueue';
 
 export interface SettingsModalProps {
   open: boolean;
@@ -13,7 +14,7 @@ export interface SettingsModalProps {
   onClose(): void;
 }
 
-const pollingIntervals = [-1, 3, 5, 10, 20, 60, 60 * 5, 60 * 15];
+const allPollingIntervals = [-1, 3, 5, 10, 20, 60, 60 * 5, 60 * 15];
 
 export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
   const {
@@ -31,6 +32,8 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
   } = useSettingsStore((state) => state);
   const { t, i18n } = useTranslation();
   const languages = ['en-US', 'fr-FR', 'pt-BR', 'zh-CN'];
+  const queue = useActiveQueue();
+  const pollingIntervals = queue?.readOnlyMode ? [-1] : allPollingIntervals;
 
   return (
     <Modal width="small" open={open} onClose={onClose} title={t('SETTINGS.TITLE')}>

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -33,7 +33,9 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
   const { t, i18n } = useTranslation();
   const languages = ['en-US', 'fr-FR', 'pt-BR', 'zh-CN'];
   const queue = useActiveQueue();
-  const pollingIntervals = queue?.readOnlyMode ? [-1] : allPollingIntervals;
+  const pollingIntervals = queue?.readOnlyMode
+  ? allPollingIntervals.slice(0, 1)
+  : allPollingIntervals;
 
   useEffect(() => {
     if (queue?.readOnlyMode && pollingInterval !== -1) {

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettingsStore } from '../../hooks/useSettings';
 import { InputField } from '../Form/InputField/InputField';
@@ -34,6 +34,12 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
   const languages = ['en-US', 'fr-FR', 'pt-BR', 'zh-CN'];
   const queue = useActiveQueue();
   const pollingIntervals = queue?.readOnlyMode ? [-1] : allPollingIntervals;
+
+  useEffect(() => {
+    if (queue?.readOnlyMode && pollingInterval !== -1) {
+      setSettings({ pollingInterval: -1 });
+    }
+  }, [queue?.readOnlyMode]);
 
   return (
     <Modal width="small" open={open} onClose={onClose} title={t('SETTINGS.TITLE')}>


### PR DESCRIPTION
Scenario: From the dashboard, select the polling interval as 3 sec, then select a read-only queue, then you can see that the polling will continue in 3 sec interval, although in the settings modal the polling intervals are hidden and set to off. 

Fix: Added a use effect, which will trigger when queue is set to read-only and update the polling interval to off, instead of only hiding the options