### PR TITLE
Center align logo image in header

### DIFF
--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -27,11 +27,13 @@
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.1);
   z-index: 2;
   display: flex;
+  align-items: center;
   padding: 0 1rem;
   text-decoration: none;
 }
 
 .header > .logo > .img {
+  max-height: 100%;
   margin-right: 0.4em;
 }
 

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -34,6 +34,7 @@
 
 .header > .logo > .img {
   max-height: 100%;
+  width: auto;
   margin-right: 0.4em;
 }
 


### PR DESCRIPTION
Hi! 

This is a minor tweak to the CSS for the header logo and image. It allows the image to be center-aligned vertically, and the image max height is set to the height of the container. This change allows users to set whatever height and width they want for the image, and it will auto-scale in the container.

Thanks!
