### PR TITLE
Show percentage when progress is an object

### DIFF
--- a/packages/ui/src/components/JobCard/JobCard.tsx
+++ b/packages/ui/src/components/JobCard/JobCard.tsx
@@ -103,17 +103,15 @@ export const JobCard = ({
               <div className={s.content}>
                 <Details status={status} job={job} actions={actions} />
 
-                {typeof job.progress === 'number' && (
-                  <Progress
-                    percentage={job.progress}
-                    status={
-                      job.isFailed && !greenStatuses.includes(status as any)
-                        ? STATUSES.failed
-                        : status
-                    }
-                    className={s.progress}
-                  />
-                )}
+                <Progress
+                  progress={job.progress}
+                  status={
+                    job.isFailed && !greenStatuses.includes(status as any)
+                      ? STATUSES.failed
+                      : status
+                  }
+                  className={s.progress}
+                />
               </div>
             </div>
           </div>

--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -5,7 +5,7 @@ import { Status } from '@bull-board/api/typings/app';
 import { STATUSES } from '@bull-board/api/src/constants/statuses';
 
 interface ProgressProps {
-  progress: number | object;
+  progress: number | { progress?: number };
   strokeWidth?: number;
   status: Status;
   className?: string;
@@ -19,11 +19,9 @@ export const Progress = ({ progress, status, className, strokeWidth = 6 }: Progr
     strokeWidth,
     ['transform-origin']: 'center',
   };
-  
-  const getPercentage = (): number => {
-    if (typeof progress === 'number') return progress;
-    return (progress as { progress?: number }).progress ?? 0;
-  };  
+
+  const percentage = typeof progress === 'number' ? progress : progress.progress ?? null;
+  if(!percentage) return null
 
   return (
     <svg className={cn(s.progress, className)} width="100%" height="100%">
@@ -32,14 +30,14 @@ export const Progress = ({ progress, status, className, strokeWidth = 6 }: Progr
         stroke={status === STATUSES.failed ? '#F56565' : '#48BB78'}
         pathLength={100}
         strokeDasharray={100}
-        strokeDashoffset={100 - getPercentage()}
+        strokeDashoffset={100 - percentage}
         strokeLinejoin="round"
         strokeLinecap="round"
         transform="rotate(-90)"
         {...commonProps}
       />
       <text textAnchor="middle" dominantBaseline="middle" x="50%" y="50%">
-        {Math.round(getPercentage())}%
+        {Math.round(percentage)}%
       </text>
     </svg>
   );

--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -5,13 +5,13 @@ import { Status } from '@bull-board/api/typings/app';
 import { STATUSES } from '@bull-board/api/src/constants/statuses';
 
 interface ProgressProps {
-  percentage: number;
+  progress: number | object;
   strokeWidth?: number;
   status: Status;
   className?: string;
 }
 
-export const Progress = ({ percentage, status, className, strokeWidth = 6 }: ProgressProps) => {
+export const Progress = ({ progress, status, className, strokeWidth = 6 }: ProgressProps) => {
   const commonProps = {
     cx: '50%',
     cy: '50%',
@@ -19,6 +19,12 @@ export const Progress = ({ percentage, status, className, strokeWidth = 6 }: Pro
     strokeWidth,
     ['transform-origin']: 'center',
   };
+  
+  const getPercentage = (): number => {
+    if (typeof progress === 'number') return progress;
+    return (progress as { progress?: number }).progress ?? 0;
+  };  
+
   return (
     <svg className={cn(s.progress, className)} width="100%" height="100%">
       <circle stroke="#E5E7EB" {...commonProps} />
@@ -26,14 +32,14 @@ export const Progress = ({ percentage, status, className, strokeWidth = 6 }: Pro
         stroke={status === STATUSES.failed ? '#F56565' : '#48BB78'}
         pathLength={100}
         strokeDasharray={100}
-        strokeDashoffset={100 - percentage}
+        strokeDashoffset={100 - getPercentage()}
         strokeLinejoin="round"
         strokeLinecap="round"
         transform="rotate(-90)"
         {...commonProps}
       />
       <text textAnchor="middle" dominantBaseline="middle" x="50%" y="50%">
-        {Math.round(percentage)}%
+        {Math.round(getPercentage())}%
       </text>
     </svg>
   );


### PR DESCRIPTION
I am using bull board with bullMQ, in the job progress I am sending an object e.g.: 
`{ progress: 70, total: 100, completed: 50 }`

when I set the job progress as an object the progress percentage is no longer displayed in bullboard.

![2024-10-08-20_40_35](https://github.com/user-attachments/assets/7aa9ee21-091e-4a13-b9c3-4227a9068c71)

I updated the component to show the progress whether it is a number or an object.

![2024-10-08-20_42_08](https://github.com/user-attachments/assets/3694b750-7992-4048-bdeb-8d26de843c54)

I think this change will be beneficial to many people who pass an object in the job progress.