### PR TITLE
feat: add status filters on overview page

### DIFF
--- a/packages/ui/src/components/StatusLegend/StatusLegend.module.css
+++ b/packages/ui/src/components/StatusLegend/StatusLegend.module.css
@@ -6,18 +6,55 @@
   text-transform: uppercase;
 }
 
-.legend > li:before {
+.legend > li {
+  display: flex;
+  align-items: center;
+  border-bottom: 2px solid transparent;
+}
+
+.legend > li.isSelected {
+  border-color: var(--status-menu-active-border);
+  color: var(--status-menu-active-text);
+  font-weight: 500;
+}
+
+.legend > li > a {
+  text-decoration: none;
+  margin: 0 0 -2px;
+  padding: 0.5em 1em;
+  color: var(--status-menu-text);
+  transition: border-bottom-color 200ms ease-in-out, color 0.1s ease;
+  display: flex;
+  align-items: center;
+}
+
+.legend > li > a:before {
   content: '';
   background-color: var(--item-bg);
   border-radius: 50%;
   width: 0.5rem;
   height: 0.5rem;
-  display: inline-block;
+  display: flex;
   margin-right: 0.5rem;
 }
 
-.legend > li + li {
-  margin-left: 2rem;
+.legend > li > a span {
+  flex: 1;
+  white-space: nowrap;
+}
+
+.legend > li > a span:before {
+  display: block;
+  content: attr(title);
+  font-weight: 600;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.legend > li > a:hover,
+.legend > li > a:active {
+  border-color: #7a8085;
 }
 
 .waiting {

--- a/packages/ui/src/components/StatusLegend/StatusLegend.module.css
+++ b/packages/ui/src/components/StatusLegend/StatusLegend.module.css
@@ -34,7 +34,7 @@
   border-radius: 50%;
   width: 0.5rem;
   height: 0.5rem;
-  display: flex;
+  display: inline-block;
   margin-right: 0.5rem;
 }
 

--- a/packages/ui/src/components/StatusLegend/StatusLegend.tsx
+++ b/packages/ui/src/components/StatusLegend/StatusLegend.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
 import { queueStatsStatusList } from '../../constants/queue-stats-status';
 import s from './StatusLegend.module.css';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toCamelCase } from '../../utils/toCamelCase';
+import cn from 'clsx';
 
 export const StatusLegend = () => {
   const { t } = useTranslation();
+  const { search } = useLocation();
 
   return (
     <ul className={s.legend}>
       {queueStatsStatusList.map((status) => {
         const displayStatus = t(`QUEUE.STATUS.${status.toUpperCase()}`).toLocaleUpperCase();
 
-        return (<li key={status} className={s[toCamelCase(status)]}>
+        const query = new URLSearchParams(search);
+
+        return (<li key={status} className={cn(s[toCamelCase(status)], {
+          [s.isSelected]: query.get('status') === status,
+        })}>
           <NavLink
             to={`/?status=${status}`}
-            activeClassName={s.active}
-            isActive={(_path, { search }) => {
-              const query = new URLSearchParams(search);
-              return query.get('status') === status;
-            }}
             className={s[toCamelCase(status)]}
             key={`overview-${status}`}
           >

--- a/packages/ui/src/components/StatusLegend/StatusLegend.tsx
+++ b/packages/ui/src/components/StatusLegend/StatusLegend.tsx
@@ -22,7 +22,6 @@ export const StatusLegend = () => {
         })}>
           <NavLink
             to={`/?status=${status}`}
-            className={s[toCamelCase(status)]}
             key={`overview-${status}`}
           >
             <span title={displayStatus}>{displayStatus}</span>

--- a/packages/ui/src/components/StatusLegend/StatusLegend.tsx
+++ b/packages/ui/src/components/StatusLegend/StatusLegend.tsx
@@ -1,21 +1,20 @@
 import React from 'react';
 import { queueStatsStatusList } from '../../constants/queue-stats-status';
 import s from './StatusLegend.module.css';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toCamelCase } from '../../utils/toCamelCase';
 import cn from 'clsx';
+import { useQuery } from '../../hooks/useQuery';
 
 export const StatusLegend = () => {
   const { t } = useTranslation();
-  const { search } = useLocation();
+  const query = useQuery();
 
   return (
     <ul className={s.legend}>
       {queueStatsStatusList.map((status) => {
         const displayStatus = t(`QUEUE.STATUS.${status.toUpperCase()}`).toLocaleUpperCase();
-
-        const query = new URLSearchParams(search);
 
         return (<li key={status} className={cn(s[toCamelCase(status)], {
           [s.isSelected]: query.get('status') === status,

--- a/packages/ui/src/components/StatusLegend/StatusLegend.tsx
+++ b/packages/ui/src/components/StatusLegend/StatusLegend.tsx
@@ -1,18 +1,33 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { queueStatsStatusList } from '../../constants/queue-stats-status';
-import { toCamelCase } from '../../utils/toCamelCase';
 import s from './StatusLegend.module.css';
+import { NavLink } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toCamelCase } from '../../utils/toCamelCase';
 
 export const StatusLegend = () => {
   const { t } = useTranslation();
+
   return (
     <ul className={s.legend}>
-      {queueStatsStatusList.map((status) => (
-        <li key={status} className={s[toCamelCase(status)]}>
-          {t(`QUEUE.STATUS.${status.toUpperCase()}`)}
-        </li>
-      ))}
+      {queueStatsStatusList.map((status) => {
+        const displayStatus = t(`QUEUE.STATUS.${status.toUpperCase()}`).toLocaleUpperCase();
+
+        return (<li key={status} className={s[toCamelCase(status)]}>
+          <NavLink
+            to={`/?status=${status}`}
+            activeClassName={s.active}
+            isActive={(_path, { search }) => {
+              const query = new URLSearchParams(search);
+              return query.get('status') === status;
+            }}
+            className={s[toCamelCase(status)]}
+            key={`overview-${status}`}
+          >
+            <span title={displayStatus}>{displayStatus}</span>
+          </NavLink>
+        </li>);
+      })}
     </ul>
   );
 };

--- a/packages/ui/src/hooks/useSelectedStatuses.ts
+++ b/packages/ui/src/hooks/useSelectedStatuses.ts
@@ -18,9 +18,8 @@ export function useSelectedStatuses(): SelectedStatuses {
 
   useEffect(() => {
     const status = getActiveStatus(search);
-    if (activeQueueName) {
-      setSelectedStatuses({ ...selectedStatuses, [activeQueueName]: status });
-    }
+
+    setSelectedStatuses({ ...selectedStatuses, [activeQueueName]: status });
   }, [search, activeQueueName]);
 
   return selectedStatuses;

--- a/packages/ui/src/pages/OverviewPage/OverviewPage.tsx
+++ b/packages/ui/src/pages/OverviewPage/OverviewPage.tsx
@@ -3,16 +3,21 @@ import { QueueCard } from '../../components/QueueCard/QueueCard';
 import { StatusLegend } from '../../components/StatusLegend/StatusLegend';
 import { useQueues } from '../../hooks/useQueues';
 import s from './OverviewPage.module.css';
+import { useSelectedStatuses } from '../../hooks/useSelectedStatuses';
 
 export const OverviewPage = () => {
   const { actions, queues } = useQueues();
   actions.pollQueues();
 
+  const selectedStatus = useSelectedStatuses();
+  const overviewPageStatus = selectedStatus[''];
+
   return (
     <section>
       <StatusLegend />
+
       <ul className={s.overview}>
-        {queues?.map((queue) => (
+        {queues?.filter((queue) => overviewPageStatus === 'latest' || queue.counts[overviewPageStatus] > 0).map((queue) => (
           <li key={queue.name}>
             <QueueCard queue={queue} />
           </li>


### PR DESCRIPTION
Following the discussion on https://github.com/felixmosh/bull-board/pull/742, I added some simple links to the `StatusLegend` so it's now possible to filter queues based on a given status. This can be useful to direct link to a list of failed queues from some alerting system for example:

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/26d17a2d-b3e6-4f03-8dd2-ff63a756eae5">

I've tried to reuse as much as I could from existing components but I'm unsure whether you tend to duplicate similar things or not to future-proof them (for example I've reused css vars from `status-menu` in the StatusLegend module css but maybe that's an anti-pattern for you?).

Also, a current known limitation to this is that there is no `ALL` link (but we can click on the logo for example to go back to the initial state) as I wasn't sure on how best to handle this (I'm a first-time contributor to this project so I'm not comfortable with the architecture of it all just yet). Would adding a new status and associated translation for this make sense?