### PR TITLE
feat: paused jobs: support edit/duplicate/clean

### DIFF
--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -52,6 +52,7 @@ const statusToButtonsMap: Record<string, ButtonType[]> = {
   ],
   [STATUSES.completed]: [buttonTypes.duplicate, buttonTypes.retry, buttonTypes.clean],
   [STATUSES.waiting]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
+  [STATUSES.paused]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
 } as const;
 
 export const JobActions = ({ actions, status, allowRetries }: JobActionsProps) => {


### PR DESCRIPTION
As a happy user of bull-board when browsing the paused queue I noticed there was no action for deleting a job in a paused queue.

This PR adds the possibility to edit/duplicate and clean paused jobs.

I could not think of any reason why it's a bad idea not to expose these actions for paused jobs - did I miss something?