### PR TITLE
Fix h3 adapter route param decode

### DIFF
--- a/packages/h3/src/H3Adapter.ts
+++ b/packages/h3/src/H3Adapter.ts
@@ -182,7 +182,7 @@ export class H3Adapter implements IServerAdapter {
           try {
             const { body } = await handler({
               queues: this.bullBoardQueues as BullBoardQueues,
-              params: getRouterParams(event),
+              params: getRouterParams(event, { decode: true }),
               query: getQuery(event),
               body: method !== 'get' ? await readBody(event) : {},
             });


### PR DESCRIPTION
If the queue or job was encoded (e.g. because it had a `/`) it could not be found because h3 does not decode the route param by default.