### PR TITLE
fix(JobActions): show actions for "waiting children" jobs just as for "waiting" ones

### DIFF
--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -52,6 +52,7 @@ const statusToButtonsMap: Record<string, ButtonType[]> = {
   ],
   [STATUSES.completed]: [buttonTypes.duplicate, buttonTypes.retry, buttonTypes.clean],
   [STATUSES.waiting]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
+  [STATUSES.waitingChildren]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
   [STATUSES.paused]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
 } as const;
 


### PR DESCRIPTION
Currently there's no possibility to delete a job which is in "waiting children" status. Yet, such a job can be awaiting another job which is simply in "waiting" status, which can be removed... and if you do that, you'll end up with a "zombie" job in "waiting children", that will never succeed, nor can be removed through the Bull Board.

Screenshot of the current behaviour:
![image](https://github.com/user-attachments/assets/9fed32df-aa13-4c99-9665-d35ab16a892b)

This PR fixes it, making actions appear in a "waiting children" job just as in a "waiting" one.

Fixed behaviour:

![image](https://github.com/user-attachments/assets/4cad3f37-38ab-42e3-a644-68e5af3e7fac)

