### PR TITLE
feat: add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "bull-board",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "christian-kohler.npm-intellisense",
+                "christian-kohler.path-intellisense",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "Orta.vscode-jest",
+                "SonarSource.sonarlint-vscode",
+                "streetsidesoftware.code-spell-checker"
+            ],
+            "settings": {
+                "extensions.ignoreRecommendations": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
this allows setup inside modern IDEs without having to install any nodejs / third party code to your system and throw away the entire development environment when not needed anymore without leaving leftover on the host system

this is entirely optional for anyone that clones the repo
also, the extensions from the devcontainer.json are only installed, when a user installs the devcontainer