### PR TITLE
F/277 api getting job tree

### DIFF
--- a/packages/api/src/handlers/job.ts
+++ b/packages/api/src/handlers/job.ts
@@ -5,17 +5,20 @@ import { BaseAdapter } from '../queueAdapters/base';
 import { formatJob } from './queues';
 
 async function getJobState(
-  _req: BullBoardRequest,
+  req: BullBoardRequest,
   job: QueueJob,
   queue: BaseAdapter
 ): Promise<ControllerHandlerReturnType> {
+  const { jobId } = req.params;
   const status = await job.getState();
+  const jobTree = await queue.getJobTree(jobId);
 
   return {
     status: 200,
     body: {
       job: formatJob(job, queue),
       status,
+      jobTree: jobTree ?? [],
     },
   };
 }

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -3,6 +3,7 @@ import {
   JobCleanStatus,
   JobCounts,
   JobStatus,
+  JobTreeNode,
   QueueAdapterOptions,
   QueueJob,
   QueueJobOptions,
@@ -53,6 +54,8 @@ export abstract class BaseAdapter {
   public abstract addJob(name: string, data: any, options: QueueJobOptions): Promise<QueueJob>;
 
   public abstract getJob(id: string): Promise<QueueJob | undefined | null>;
+
+  public abstract getJobTree(id: string): Promise<JobTreeNode[]>;
 
   public abstract getJobCounts(): Promise<JobCounts>;
 

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -4,6 +4,7 @@ import {
   JobCleanStatus,
   JobCounts,
   JobStatus,
+  JobTreeNode,
   QueueAdapterOptions,
   QueueJobOptions,
   Status,
@@ -38,6 +39,11 @@ export class BullAdapter extends BaseAdapter {
 
   public getJob(id: string): Promise<Job | undefined | null> {
     return this.queue.getJob(id).then((job) => job && this.alignJobData(job));
+  }
+
+  public getJobTree(): Promise<JobTreeNode[]> {
+    // Bull doesn't support Flow, so an empty array is returned
+    return Promise.resolve([]);
   }
 
   public getJobs(jobStatuses: JobStatus<'bull'>[], start?: number, end?: number): Promise<Job[]> {

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -76,7 +76,7 @@ export interface QueueJobJson {
 export interface JobTreeNode {
   id: string;
   name: string;
-  children?: JobTreeNode[];
+  jobTree?: JobTreeNode[];
 }
 
 export interface QueueJobOptions {

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -73,6 +73,12 @@ export interface QueueJobJson {
   parentKey?: string;
 }
 
+export interface JobTreeNode {
+  id: string;
+  name: string;
+  children?: JobTreeNode[];
+}
+
 export interface QueueJobOptions {
   delay?: number;
   attempts?: number;

--- a/packages/api/typings/responses.ts
+++ b/packages/api/typings/responses.ts
@@ -1,4 +1,4 @@
-import { AppJob, AppQueue, Status } from './app';
+import { AppJob, AppQueue, JobTreeNode, Status } from './app';
 
 export interface GetQueuesResponse {
   queues: AppQueue[];
@@ -7,4 +7,5 @@ export interface GetQueuesResponse {
 export interface GetJobResponse {
   job: AppJob;
   status: Status;
+  jobTree: JobTreeNode[];
 }


### PR DESCRIPTION
Issue: #277 
This PR is a small PR that supports BullMQ `Flow` and it focuses on the backened `api`.

The endpoint `/api/queues/:queuename/:jobId` now includes a new property called `jobTree`, and this property contains all children jobs to the related job.  Here is what the response looks like when the endpoint is called:

```js
 {
    "job": {
        "id": "46a7c114-3390-4d23-9ca6-aa70a8dddba8",
        "timestamp": 1735957798661,
        "processedOn": 1735957832167,
        "finishedOn": 1735957832168,
        "progress": 0,
        // ...
     },
    "status": "completed",
    "jobTree": [
        {
            "name": "B",
            "id": "6f6f5fe7-8f65-48e7-9bb5-7386bd9b8fa2",
            "jobTree": [
                {
                    "name": "C",
                    "id": "c09cf2b7-f9c9-47ab-9777-699a9c9d8d38",
                    "jobTree": [
                        {
                            "name": "D",
                            "id": "69d4d27c-321d-462c-a484-c59db54183fa",
                            "jobTree": [
                                {
                                    "name": "E",
                                    "id": "62d1e7d8-6b42-485f-ae85-db27b0da9353"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```

The FE should be able to consume `jobTree` (NOT in this PR) and display something like this:
![image](https://github.com/user-attachments/assets/7efe0e95-547c-47d8-9d36-0614fe5189f3)

A future PR will handle the FE once this is merged.

Please let me know if I missed something. Any feedback is welcomed.