### PR TITLE
fix: allow nestjs v11

### DIFF
--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -38,8 +38,8 @@
   "peerDependencies": {
     "@bull-board/api": "^6.7.0",
     "@bull-board/express": "^6.7.0",
-    "@nestjs/common": "^9.0.0 || ^10.0.0",
-    "@nestjs/core": "^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rxjs": "^7.8.1"
   },


### PR DESCRIPTION
Fixes the following issue in `BullBoardModule.forFeature`:

```
Type 'DynamicModule' is not assignable to type 'Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference<any>'.
  Type 'import("/Users/snigdhasingh/Development/btp/node_modules/@mikro-orm/nestjs/node_modules/@nestjs/common/interfaces/modules/dynamic-module.interface").DynamicModule' is not assignable to type 'import("/Users/snigdhasingh/Development/btp/node_modules/@nestjs/common/interfaces/modules/dynamic-module.interface").DynamicModule'.
    Types of property 'imports' are incompatible.
      Type '(DynamicModule | Type<any> | Promise<DynamicModule> | ForwardReference<any>)[] | undefined' is not assignable to type '(Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference<any>)[] | undefined'.
        Type '(DynamicModule | Type<any> | Promise<DynamicModule> | ForwardReference<any>)[]' is not assignable to type '(Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference<any>)[]'.
          Type 'DynamicModule | Type<any> | Promise<DynamicModule> | ForwardReference<any>' is not assignable to type 'Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference<any>'.
            Type 'Promise<DynamicModule>' is not assignable to type 'Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference<any>'.
```