### PR TITLE
fix: reverse array to display recent errors

### DIFF
--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -14,7 +14,7 @@ import { BaseAdapter } from '../queueAdapters/base';
 export const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
   const jobProps = job.toJSON();
 
-  const stacktrace = jobProps.stacktrace ? jobProps.stacktrace.filter(Boolean) : [];
+  const stacktrace = jobProps.stacktrace ? jobProps.stacktrace.filter(Boolean).toReversed() : [];
 
   return {
     id: jobProps.id,


### PR DESCRIPTION
Closes #862 

A user reported that when they retry failed jobs they want to be able to see the latest error at the top and this PR fixes this problem so that users don't need to scroll down to find the last error for a failed job.
 
The only change made is in the `api` and that is reversing the order of the `stacktrace` array.