### PR TITLE
Fix Elysia example

### DIFF
--- a/examples/with-elysia/index.ts
+++ b/examples/with-elysia/index.ts
@@ -1,6 +1,6 @@
 import { createBullBoard } from '@bull-board/api';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
-import { ElysiaAdapter } from '../../node_modules/@bull-board/elysia';
+import { ElysiaAdapter } from '@bull-board/elysia';
 import { Queue as QueueMQ, Worker } from 'bullmq';
 import Elysia from 'elysia';
 


### PR DESCRIPTION
Although this is a minor change, I believe it's worth making. 

Changes:
Updated the import path for `ElysiaAdapter` to use a direct package reference instead of a relative path to **node_modules**. This ensures proper module resolution and improves code clarity.