### PR TITLE
Improve Elysia example by resolving Bun build issue caused by eval.

### DIFF
--- a/examples/with-elysia/index.ts
+++ b/examples/with-elysia/index.ts
@@ -41,6 +41,10 @@ const serverAdapter = new ElysiaAdapter('/ui');
 createBullBoard({
   queues: [new BullMQAdapter(exampleBullMq)],
   serverAdapter,
+  options: {
+    // This configuration fixes a build error on Bun caused by eval (https://github.com/oven-sh/bun/issues/5809#issuecomment-2065310008)
+    uiBasePath: 'node_modules/@bull-board/ui',
+  }
 });
 
 const app = new Elysia()

--- a/examples/with-elysia/package.json
+++ b/examples/with-elysia/package.json
@@ -6,12 +6,14 @@
   "module": "index.ts",
   "scripts": {
     "dev": "bun --watch index.ts",
+    "build": "bun build ./index.ts --target bun --outdir ./dist --sourcemap=linked",
+    "start": "bun ./dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "kravetsone",
   "license": "ISC",
   "dependencies": {
-    "@bull-board/elysia": "^5.20.1",
+    "@bull-board/elysia": "^6.7.10",
     "bullmq": "^5.13.2",
     "elysia": "^1.1.24"
   }

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -201,7 +201,7 @@ export type FormatterField = 'data' | 'returnValue' | 'name';
 
 export type BoardOptions = {
   uiBasePath?: string;
-  uiConfig: UIConfig;
+  uiConfig?: UIConfig;
 };
 
 export type IMiscLink = {


### PR DESCRIPTION
issue: https://github.com/felixmosh/bull-board/issues/913

Improve Elysia example by resolving Bun build issue caused by eval.

Changelog:
1. Fixed the @bull-board/elysia package version because the specified one didn't exist, causing Bun to fail when loading it.
2. Added the options.uiBasePath parameter to fix the build issue.
3. Added build and start commands to package.json—build compiles the project, and start runs the compiled version.
4. Updated the BoardOptions type to make uiConfig optional since it wasn’t actually required.
<img width="826" alt="Screenshot 2025-03-23 at 15 48 33" src="https://github.com/user-attachments/assets/4f2e61db-ab82-4d59-8ac1-eca616c9f380" />
