### PR TITLE
feat: Option to show queue stats in menu tree

### DIFF
--- a/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
@@ -6,9 +6,12 @@ import { AppQueueTreeNode } from '../../../utils/toTree';
 import { NavLink } from 'react-router-dom';
 import React from 'react';
 import s from './MenuTree.module.css';
+import { useSettingsStore } from '../../../hooks/useSettings';
+import { MenuTreeNodeStats } from './MenuTreeNodeStats/MenuTreeNodeStats';
 
 export const MenuTree = ({ tree, level = 0 }: { tree: AppQueueTreeNode; level?: number }) => {
   const { t } = useTranslation();
+  const { showQueueStatsInMenuTree } = useSettingsStore();
   const selectedStatuses = useSelectedStatuses();
 
   return (
@@ -26,6 +29,7 @@ export const MenuTree = ({ tree, level = 0 }: { tree: AppQueueTreeNode; level?: 
               >
                 {node.name}
                 {node.queue?.isPaused && <span className={s.isPaused}>[ {t('MENU.PAUSED')} ]</span>}
+                {showQueueStatsInMenuTree && <MenuTreeNodeStats treeNode={node} />}
               </NavLink>
             ) : (
               <details key={node.name} open>

--- a/packages/ui/src/components/Menu/MenuTree/MenuTreeNodeStats/MenuTreeNodeStats.module.css
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTreeNodeStats/MenuTreeNodeStats.module.css
@@ -1,0 +1,53 @@
+.legend {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-transform: uppercase;
+  gap: 0.5em;
+  margin-top: 0.5em;
+  overflow-x: auto;
+
+  li {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.35em;
+    padding: 0 0.3em;
+    background-color: var(--item-bg);
+    margin: 0;
+    font-size: 0.8rem;
+  }
+}
+
+.waiting {
+  --item-bg: var(--waiting);
+}
+
+.waitingChildren {
+  --item-bg: var(--waiting-children);
+}
+
+.prioritized {
+  --item-bg: var(--prioritized);
+}
+
+.active {
+  --item-bg: var(--active);
+}
+
+.failed {
+  --item-bg: var(--failed);
+}
+
+.completed {
+  --item-bg: var(--completed);
+}
+
+.delayed {
+  --item-bg: var(--delayed);
+}
+
+.paused {
+  --item-bg: var(--paused);
+}

--- a/packages/ui/src/components/Menu/MenuTree/MenuTreeNodeStats/MenuTreeNodeStats.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTreeNodeStats/MenuTreeNodeStats.tsx
@@ -11,7 +11,7 @@ export const MenuTreeNodeStats = ({ treeNode }: { treeNode: AppQueueTreeNode }) 
 
   const { statuses, counts } = treeNode.queue;
   const statusesWithCounts = statuses
-    .filter((status) => status !== STATUSES.latest && counts[status] >= 0)
+    .filter((status) => status !== STATUSES.latest && counts[status] > 0)
     .map((status) => ({
       status,
       count: counts[status],

--- a/packages/ui/src/components/Menu/MenuTree/MenuTreeNodeStats/MenuTreeNodeStats.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTreeNodeStats/MenuTreeNodeStats.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { AppQueueTreeNode } from '../../../../utils/toTree';
+import { toCamelCase } from '../../../../utils/toCamelCase';
+import s from './MenuTreeNodeStats.module.css';
+import { STATUSES } from '@bull-board/api/src/constants/statuses';
+import { formatShortNumber } from '../../../../utils/formatNumber';
+export const MenuTreeNodeStats = ({ treeNode }: { treeNode: AppQueueTreeNode }) => {
+  if (!treeNode.queue || !treeNode.queue.statuses || !treeNode.queue.counts) {
+    return null;
+  }
+
+  const { statuses, counts } = treeNode.queue;
+  const statusesWithCounts = statuses
+    .filter((status) => status !== STATUSES.latest && counts[status] >= 0)
+    .map((status) => ({
+      status,
+      count: counts[status],
+    }));
+
+  if (!statusesWithCounts.length) {
+    return null;
+  }
+
+  return (
+    <ul className={s.legend}>
+      {statusesWithCounts.map(({ status, count }) => (
+        <li className={s[toCamelCase(status)]}>{formatShortNumber(count)}</li>
+      ))}
+    </ul>
+  );
+};

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -31,6 +31,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
     collapseJobError,
     defaultJobTab,
     darkMode,
+    showQueueStatsInMenuTree,
     setSettings,
   } = useSettingsStore((state) => state);
   const { pollingInterval: uiConfigPollingInterval } = useUIConfig();
@@ -129,6 +130,12 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
         id="dark-mode"
         checked={darkMode}
         onCheckedChange={(checked) => setSettings({ darkMode: checked })}
+      />
+      <SwitchField
+        label={t('SETTINGS.SHOW_QUEUE_STATS_IN_MENU_TREE')}
+        id="show-queue-stats-in-menu-tree"
+        checked={showQueueStatsInMenuTree}
+        onCheckedChange={(checked) => setSettings({ showQueueStatsInMenuTree: checked })}
       />
     </Modal>
   );

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -14,6 +14,7 @@ interface SettingsState {
   collapseJobError: boolean;
   darkMode: boolean;
   defaultJobTab: TabsType;
+  showQueueStatsInMenuTree: boolean;
   setSettings: (settings: Partial<Omit<SettingsState, 'setSettings'>>) => void;
 }
 
@@ -31,6 +32,7 @@ export const useSettingsStore = create<SettingsState>()(
       collapseJobError: false,
       darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
       defaultJobTab: 'Data',
+      showQueueStatsInMenuTree: false,
       setSettings: (settings) => set(() => settings),
     }),
     {

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -132,6 +132,7 @@
     "COLLAPSE_JOB_DATA": "Collapse job data",
     "COLLAPSE_JOB_OPTIONS": "Collapse job options",
     "COLLAPSE_JOB_ERROR": "Collapse job error",
+    "SHOW_QUEUE_STATS_IN_MENU_TREE": "Show queue stats in menu tree",
     "DARK_MODE": "Dark mode"
   },
   "ADD_JOB": {

--- a/packages/ui/src/utils/formatNumber.ts
+++ b/packages/ui/src/utils/formatNumber.ts
@@ -1,0 +1,21 @@
+export const formatShortNumber = (number: number) => {
+  if (number < 1000) {
+    return number;
+  }
+
+  if (number >= 90000) {
+    return '90K+';
+  }
+
+  const thousands = number / 1000;
+
+  if (number < 10000) {
+    // For 1000-9999, show single digit + K (e.g., "3K")
+    return `${Math.floor(thousands)}K`;
+  }
+
+  // For 10000-89999, show two digits + decimal + K (e.g., "10.3K")
+  // Remove decimal if it's .0
+  const formatted = thousands.toFixed(1);
+  return formatted.endsWith('.0') ? `${Math.floor(thousands)}K` : `${formatted}K`;
+};


### PR DESCRIPTION
This implements an option to show queue stats in the sidebar so one can see at a glance the activity across all their queues.

Notes:

* I attempted to implement tooltips so when hovering over the number it would show but it seems the Tooltip implementation doesn't work with overflow containers
* Statuses with 0-counts are filtered out of rendered array

In the screenshots below, I used just a single example number to show a worst-ish case scenario, where the user has to scroll over if every queue has jobs in it. The "NewRegistration" queue shows what it looks like when scrolled all the way to the right:

<img width="273" alt="Screenshot 2025-04-02 at 9 45 49 AM" src="https://github.com/user-attachments/assets/c90dd2ff-2859-47be-83a7-5a60bdf6403b" />

<img width="624" alt="Screenshot 2025-04-02 at 9 45 55 AM" src="https://github.com/user-attachments/assets/fc281bda-425a-4978-b0cc-75845b540304" />


Love bull-board, thank you for it!