### PR TITLE
feat: Queue name alias

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -141,7 +141,7 @@ const run = async () => {
       new BullMQAdapter(exampleBullMq, { delimiter: '.' }),
       new BullAdapter(exampleBull, { delimiter: '.' }),
       new BullMQAdapter(newRegistration, { delimiter: '.' }),
-      new BullMQAdapter(resetPassword, { delimiter: ':' }),
+      new BullMQAdapter(resetPassword, { delimiter: ':', nameAlias: 'Reset Password' }),
     ],
     serverAdapter,
   });

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -81,6 +81,7 @@ async function getAppQueues(
 
       return {
         name: queueName,
+        nameAlias: queue.getNameAlias() || undefined,
         description: queue.getDescription() || undefined,
         statuses: queue.getStatuses(),
         counts: counts as Record<Status, number>,

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -17,6 +17,7 @@ export abstract class BaseAdapter {
   public readonly prefix: string;
   public readonly delimiter: string;
   public readonly description: string;
+  public readonly nameAlias: string;
   public readonly type: QueueType;
   private formatters = new Map<FormatterField, (data: any) => any>();
 
@@ -30,11 +31,16 @@ export abstract class BaseAdapter {
     this.prefix = options.prefix || '';
     this.delimiter = options.delimiter || '';
     this.description = options.description || '';
+    this.nameAlias = options.nameAlias || '';
     this.type = type;
   }
 
   public getDescription(): string {
     return this.description;
+  }
+
+  public getNameAlias(): string {
+    return this.nameAlias;
   }
 
   public setFormatter<T extends FormatterField>(

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -31,6 +31,7 @@ export interface QueueAdapterOptions {
   allowRetries: boolean;
   prefix: string;
   description: string;
+  nameAlias: string;
   delimiter: string;
 }
 
@@ -120,6 +121,7 @@ export type QueueType = 'bull' | 'bullmq';
 export interface AppQueue {
   delimiter: string;
   name: string;
+  nameAlias?: string;
   description?: string;
   counts: Record<Status, number>;
   jobs: AppJob[];

--- a/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
@@ -15,6 +15,7 @@ export const MenuTree = ({ tree, level = 0 }: { tree: AppQueueTreeNode; level?: 
     <ul className={cn(s.menu, level > 0 && s[`level-${level}`])}>
       {tree.children.map((node) => {
         const isLeafNode = !node.children.length;
+        const displayName = isLeafNode && node.queue?.nameAlias ? node.queue.nameAlias : node.name;
 
         return (
           <li key={node.name}>
@@ -22,14 +23,14 @@ export const MenuTree = ({ tree, level = 0 }: { tree: AppQueueTreeNode; level?: 
               <NavLink
                 to={links.queuePage(node.queue!.name, selectedStatuses)}
                 activeClassName={s.active}
-                title={node.name}
+                title={displayName}
               >
-                {node.name}
+                {displayName}
                 {node.queue?.isPaused && <span className={s.isPaused}>[ {t('MENU.PAUSED')} ]</span>}
               </NavLink>
             ) : (
               <details key={node.name} open>
-                <summary>{node.name}</summary>
+                <summary>{displayName}</summary>
                 <MenuTree tree={node} level={level + 1} />
               </details>
             )}

--- a/packages/ui/src/components/QueueCard/QueueCard.tsx
+++ b/packages/ui/src/components/QueueCard/QueueCard.tsx
@@ -14,7 +14,7 @@ export const QueueCard = ({ queue }: IQueueCardProps) => (
   <Card className={s.queueCard}>
     <div>
       <NavLink to={links.queuePage(queue.name)} className={s.link}>
-        {queue.name}
+        {queue.nameAlias || queue.name}
       </NavLink>
     </div>
     <QueueStats queue={queue} />

--- a/packages/ui/src/components/Title/Title.tsx
+++ b/packages/ui/src/components/Title/Title.tsx
@@ -5,17 +5,16 @@ import { useActiveQueue } from '../../hooks/useActiveQueue';
 export const Title = () => {
   const queue = useActiveQueue();
 
-  if (!queue)
-    return <div/>
+  if (!queue) return <div />;
 
   return (
     <div className={s.queueTitle}>
       {queue.name && (
         <>
-          <h1 className={s.name}>{queue.name}</h1>
+          <h1 className={s.name}>{queue.nameAlias || queue.name}</h1>
           {queue.description && <p className={s.description}>{queue.description}</p>}
         </>
       )}
     </div>
-  )
+  );
 };


### PR DESCRIPTION
Implements #921 

The nameAlias is optional. If provided, everywhere the queue name is currently rendered it will preference the `nameAlias` else fall back to the `name`

<img width="1687" alt="Screenshot 2025-04-03 at 1 06 27 PM" src="https://github.com/user-attachments/assets/b27e4f2c-d69e-4576-b967-1a35e3b31130" />
<img width="1687" alt="Screenshot 2025-04-03 at 1 07 03 PM" src="https://github.com/user-attachments/assets/754266b4-2997-4536-a522-7cba4532d51f" />
