### PR TITLE
Add job action buttons to "prioritized" status

### DIFF
--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -53,6 +53,7 @@ const statusToButtonsMap: Record<string, ButtonType[]> = {
   [STATUSES.completed]: [buttonTypes.duplicate, buttonTypes.retry, buttonTypes.clean],
   [STATUSES.waiting]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
   [STATUSES.waitingChildren]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
+  [STATUSES.prioritized]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
   [STATUSES.paused]: [buttonTypes.duplicate, buttonTypes.updateData, buttonTypes.clean],
 } as const;
 


### PR DESCRIPTION
This status is similar to `waiting`, only that the job also has a priority set.

Fixes #930 