### PR TITLE
Add autodiscover queues option for BullBoard

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,7 +14,7 @@ export function createBullBoard({
   serverAdapter: IServerAdapter;
   options?: BoardOptions;
 }) {
-  const { bullBoardQueues, setQueues, replaceQueues, addQueue, removeQueue } = getQueuesApi(queues);
+  const { bullBoardQueues, setQueues, replaceQueues, addQueue, removeQueue, discoverQueues } = getQueuesApi(queues, options.queuesConfig);
   const uiBasePath =
     options.uiBasePath || path.dirname(eval(`require.resolve('@bull-board/ui/package.json')`));
 
@@ -34,5 +34,5 @@ export function createBullBoard({
     .setErrorHandler(errorHandler)
     .setApiRoutes(appRoutes.api);
 
-  return { setQueues, replaceQueues, addQueue, removeQueue };
+  return { setQueues, replaceQueues, addQueue, removeQueue, discoverQueues };
 }

--- a/packages/api/src/queuesApi.ts
+++ b/packages/api/src/queuesApi.ts
@@ -50,10 +50,10 @@ export function getQueuesApi(queues: ReadonlyArray<BaseAdapter>, queuesConfig: Q
           }
           return null;
         })
-        .filter((key) => key !== null)
-        .forEach((key) => {
+        .filter((queueName) => queueName !== null)
+        .forEach((queueName) => {
           addQueue(new BullMQAdapter(
-              new Queue<unknown, unknown, string>(key, {
+              new Queue<unknown, unknown, string>(queueName, {
                 connection: autoDiscover.connection,
                 prefix,
               }),

--- a/packages/api/typings/app.ts
+++ b/packages/api/typings/app.ts
@@ -1,6 +1,7 @@
 import { RedisInfo } from 'redis-info';
 import { STATUSES } from '../src/constants/statuses';
 import { BaseAdapter } from '../src/queueAdapters/base';
+import Redis, {Cluster} from "ioredis";
 
 export type JobCleanStatus = 'completed' | 'wait' | 'active' | 'delayed' | 'failed';
 
@@ -204,6 +205,7 @@ export type FormatterField = 'data' | 'returnValue' | 'name';
 export type BoardOptions = {
   uiBasePath?: string;
   uiConfig?: UIConfig;
+  queuesConfig?: QueuesConfig
 };
 
 export type IMiscLink = {
@@ -224,6 +226,13 @@ export type UIConfig = Partial<{
     forceInterval: number;
   }>;
 }>;
+
+export type QueuesConfig = {
+  autoDiscover?: {
+    connection: Cluster | Redis;
+    prefix?: string;
+  };
+};
 
 export type FavIcon = {
   default: string;


### PR DESCRIPTION
Adding an autodiscover option in bull board to let bull bord discover all the queues with workers that are defined by bull.

When creating the dashboard, fill the autodiscover option with the connection and the prefix to use to discover all the queues

The example.ts has been updated to help testing it

Make sure that a Bull Engine is running to have workers active on the queues. Otherwise it won't show up in the dashboard