### PR TITLE
fix(hono): make hono a peer dependency

### DIFF
--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -30,12 +30,15 @@
   "dependencies": {
     "@bull-board/api": "6.9.6",
     "@bull-board/ui": "6.9.6",
-    "ejs": "^3.1.10",
-    "hono": "^4.7.8"
+    "ejs": "^3.1.10"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250503.0",
-    "@hono/node-server": "^1.14.1"
+    "@hono/node-server": "^1.14.1",
+    "hono": "^4.7.8"
+  },
+  "peerDependencies": {
+    "hono": "^4"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,8 @@ __metadata:
     "@hono/node-server": "npm:^1.14.1"
     ejs: "npm:^3.1.10"
     hono: "npm:^4.7.8"
+  peerDependencies:
+    hono: ^4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
If Hono is marked as a dependency, you are restricting users to only use the exact version specified in this repo. Using a peer dependency means type errors like [this](https://github.com/jonahsnider/frc-colors.com/actions/runs/15290145837/job/43007965325?pr=181#step:7:24) won't happen anymore.