### PR TITLE
Respect the `basePath` argument

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -391,7 +391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bull-board/api@npm:6.9.6, @bull-board/api@npm:^6.9.6, @bull-board/api@workspace:packages/api":
+"@bull-board/api@npm:6.10.0, @bull-board/api@npm:^6.10.0, @bull-board/api@workspace:packages/api":
   version: 0.0.0-use.local
   resolution: "@bull-board/api@workspace:packages/api"
   dependencies:
@@ -403,7 +403,7 @@ __metadata:
     redis-info: "npm:^3.1.0"
     supertest: "npm:^7.1.1"
   peerDependencies:
-    "@bull-board/ui": 6.9.6
+    "@bull-board/ui": 6.10.0
   languageName: unknown
   linkType: soft
 
@@ -411,8 +411,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bull-board/elysia@workspace:packages/elysia"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@types/ejs": "npm:^3.1.5"
     "@types/node": "npm:^22.15.30"
     ejs: "npm:^3.1.10"
@@ -423,12 +423,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bull-board/express@npm:^6.9.6, @bull-board/express@workspace:packages/express":
+"@bull-board/express@npm:^6.10.0, @bull-board/express@workspace:packages/express":
   version: 0.0.0-use.local
   resolution: "@bull-board/express@workspace:packages/express"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@types/ejs": "npm:^3.1.5"
     "@types/express": "npm:^4.17.21 || ^5.0.0"
     ejs: "npm:^3.1.10"
@@ -436,12 +436,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bull-board/fastify@npm:^6.9.6, @bull-board/fastify@workspace:packages/fastify":
+"@bull-board/fastify@npm:^6.10.0, @bull-board/fastify@workspace:packages/fastify":
   version: 0.0.0-use.local
   resolution: "@bull-board/fastify@workspace:packages/fastify"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@fastify/static": "npm:^8.2.0"
     "@fastify/view": "npm:^11.1.0"
     ejs: "npm:^3.1.10"
@@ -453,8 +453,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bull-board/h3@workspace:packages/h3"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@types/ejs": "npm:^3.1.5"
     ejs: "npm:^3.1.10"
     h3: "npm:^1.15.3"
@@ -465,8 +465,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bull-board/hapi@workspace:packages/hapi"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@hapi/hapi": "npm:^21.4.0"
     "@hapi/inert": "npm:^7.1.0"
     "@hapi/vision": "npm:^7.0.3"
@@ -481,8 +481,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bull-board/hono@workspace:packages/hono"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@cloudflare/workers-types": "npm:^4.20250607.0"
     "@hono/node-server": "npm:^1.14.4"
     ejs: "npm:^3.1.10"
@@ -496,8 +496,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bull-board/koa@workspace:packages/koa"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
-    "@bull-board/ui": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
+    "@bull-board/ui": "npm:6.10.0"
     "@koa/bodyparser": "npm:^5.1.2"
     "@ladjs/koa-views": "npm:^9.0.0"
     "@types/co-body": "npm:^6.1.3"
@@ -518,9 +518,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bull-board/nestjs@workspace:packages/nestjs"
   dependencies:
-    "@bull-board/api": "npm:^6.9.6"
-    "@bull-board/express": "npm:^6.9.6"
-    "@bull-board/fastify": "npm:^6.9.6"
+    "@bull-board/api": "npm:^6.10.0"
+    "@bull-board/express": "npm:^6.10.0"
+    "@bull-board/fastify": "npm:^6.10.0"
     "@nestjs/bull-shared": "npm:^11.0.2"
     "@nestjs/bullmq": "npm:^11.0.2"
     "@nestjs/common": "npm:^11.1.3"
@@ -532,8 +532,7 @@ __metadata:
     rxjs: "npm:^7.8.2"
     typescript: "npm:^5.8.3"
   peerDependencies:
-    "@bull-board/api": ^6.9.6
-    "@bull-board/express": ^6.9.6
+    "@bull-board/api": ^6.10.0
     "@nestjs/bull-shared": ^10.0.0 || ^11.0.0
     "@nestjs/common": ^9.0.0 || ^10.0.0 || ^11.0.0
     "@nestjs/core": ^9.0.0 || ^10.0.0 || ^11.0.0
@@ -566,11 +565,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bull-board/ui@npm:6.9.6, @bull-board/ui@workspace:packages/ui":
+"@bull-board/ui@npm:6.10.0, @bull-board/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@bull-board/ui@workspace:packages/ui"
   dependencies:
-    "@bull-board/api": "npm:6.9.6"
+    "@bull-board/api": "npm:6.10.0"
     "@codemirror/commands": "npm:^6.8.1"
     "@codemirror/lang-json": "npm:^6.0.1"
     "@codemirror/language": "npm:^6.11.1"


### PR DESCRIPTION
This makes four changes to the `@bullboard/fastify` package:
1. Run `yarn` to update the lockfile to the latest versions
2. Refactor the `as any` casts to be more precise casts (so that future fastify changes that might cause bugs will be detected as a mismatch by the compiler)
3. Default the `opts.basePath` value to the `this.basePath` value for the adapter
4. Most importantly: use the `basePath` as a prefix on the templates, static content, handlers, and apiRoutes

This means that now if you set `setBasePath` before calling `registerPlugin`, the bullboard UI and other routes will actually register beneath that base path.