### PR TITLE
Allow importing "@bull-board/api/*Adapter" in ESM

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,11 @@
     "dist",
     "*Adapter.*"
   ],
+  "exports": {
+    ".": "./dist/src/index.js",
+    "./bullMQAdapter": "./bullMQAdapter.js",
+    "./bullAdapter": "./bullAdapter.js"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",


### PR DESCRIPTION
import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";