### PR TITLE
fix: Explicit rootDir tsconfig for hapi

### DIFF
--- a/packages/hapi/tsconfig.json
+++ b/packages/hapi/tsconfig.json
@@ -13,7 +13,8 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "rootDir": "./src"
   },
   "include": ["./src", "./typings/*.d.ts"]
 }


### PR DESCRIPTION
As of release `6.12.2` `@bull-board/hapi` has not been working. I have an app that does `import { HapiAdapter } from '@bull-board/hapi';`:

```
Error: Cannot find module '/Users/dummy/src/node_modules/@bull-board/hapi/dist/index.js'. Please verify that the package.json has a valid "main" entry
```

Looking at the build, `packages/hapi/dist/` doesn't have the expected output. `tsc` is including `src/` in the build:

```
$ ls -la dist
total 4
drwxr-xr-x  4 jason.williams  staff   128 Aug 25 20:23 .
drwxr-xr-x  6 jason.williams  staff   192 Aug 25 20:23 ..
-rw-r--r--  1 jason.williams  staff  1135 Aug 25 20:23 package.json
drwxr-xr-x  9 jason.williams  staff   288 Aug 25 20:23 src
```

It looks like a combination of the import changes here https://github.com/felixmosh/bull-board/commit/167467f5b546fe9a7b52e93d663a4ae20c2a84a0#diff-784b49ebde702efff09b0042769bb5f7613f1af206a29082d9bd02d0cda8ab84 and the fact that the hapi adapter imports its `package.json` file are causing `tsc` to decide that `hapi/package/` should be the root instead of `hapi/package/src`.

Adding an explicit `rootDir` to `tsconfig.json` with the right directory fixes the build.
