### PR TITLE
support clean each jobScheduler job

### DIFF
--- a/packages/api/src/handlers/cleanJob.ts
+++ b/packages/api/src/handlers/cleanJob.ts
@@ -10,7 +10,7 @@ async function cleanJob(
   _req: BullBoardRequest,
   job: QueueJob
 ): Promise<ControllerHandlerReturnType> {
-  if (job.repeatJobKey) {
+  if (job.repeatJobKey && queue?.removeJobScheduler) {
     const { queueName } = _req.params;
     const queue = _req.queues.get(queueName);
     await queue.removeJobScheduler(job.repeatJobKey);

--- a/packages/api/src/handlers/cleanJob.ts
+++ b/packages/api/src/handlers/cleanJob.ts
@@ -10,7 +10,13 @@ async function cleanJob(
   _req: BullBoardRequest,
   job: QueueJob
 ): Promise<ControllerHandlerReturnType> {
-  await job.remove();
+  if (job.repeatJobKey) {
+    const { queueName } = _req.params;
+    const queue = _req.queues.get(queueName);
+    await queue.removeJobScheduler(job.repeatJobKey);
+  } else {
+    await job.remove();
+  }
 
   return {
     status: 204,


### PR DESCRIPTION
It's related with #908.
It doesn't help to clean with `Clean all` Button.
But it will allow to delete specific jobScheduler job