### PR TITLE
feat(ui): add collapsible menu state with persistence feature

### DIFF
--- a/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
@@ -1,21 +1,24 @@
 import cn from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { useSelectedStatuses } from '../../../hooks/useSelectedStatuses';
+import { useMenuState } from '../../../hooks/useMenuState';
 import { links } from '../../../utils/links';
 import { AppQueueTreeNode } from '../../../utils/toTree';
 import { NavLink } from 'react-router-dom';
 import React from 'react';
 import s from './MenuTree.module.css';
 
-export const MenuTree = ({ tree, level = 0 }: { tree: AppQueueTreeNode; level?: number }) => {
+export const MenuTree = ({ tree, level = 0, parentPath = '' }: { tree: AppQueueTreeNode; level?: number; parentPath?: string }) => {
   const { t } = useTranslation();
   const selectedStatuses = useSelectedStatuses();
+  const { toggleMenu, isMenuOpen } = useMenuState();
 
   return (
     <ul className={cn(s.menu, level > 0 && s[`level-${level}`])}>
       {tree.children.map((node) => {
         const isLeafNode = !node.children.length;
         const displayName = node.name;
+        const menuPath = parentPath ? `${parentPath}/${node.name}` : node.name;
 
         return (
           <li key={node.name}>
@@ -29,9 +32,16 @@ export const MenuTree = ({ tree, level = 0 }: { tree: AppQueueTreeNode; level?: 
                 {node.queue?.isPaused && <span className={s.isPaused}>[ {t('MENU.PAUSED')} ]</span>}
               </NavLink>
             ) : (
-              <details key={node.name} open>
+              <details 
+                key={node.name} 
+                open={isMenuOpen(menuPath)}
+                onToggle={(e) => {
+                  e.preventDefault();
+                  toggleMenu(menuPath);
+                }}
+              >
                 <summary>{displayName}</summary>
-                <MenuTree tree={node} level={level + 1} />
+                <MenuTree tree={node} level={level + 1} parentPath={menuPath} />
               </details>
             )}
           </li>

--- a/packages/ui/src/hooks/useMenuState.ts
+++ b/packages/ui/src/hooks/useMenuState.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+
+const STORAGE_KEY = 'bull-board-menu-state';
+
+type MenuState = Record<string, boolean>;
+
+export function useMenuState() {
+  const [menuState, setMenuState] = useState<MenuState>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch {
+      return {};
+    }
+  });
+
+  const toggleMenu = useCallback((menuPath: string) => {
+    setMenuState((prev) => {
+      const newState = {
+        ...prev,
+        [menuPath]: !prev[menuPath]
+      };
+      
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+      } catch {
+        // Ignore localStorage errors
+      }
+      
+      return newState;
+    });
+  }, []);
+
+  const isMenuOpen = useCallback((menuPath: string, defaultOpen = true) => {
+    return menuState[menuPath] !== undefined ? menuState[menuPath] : defaultOpen;
+  }, [menuState]);
+
+  return { toggleMenu, isMenuOpen };
+}


### PR DESCRIPTION
- Introduced `useMenuState` hook to manage the open/closed state of menu items with localStorage persistence.
- Updated `MenuTree` component to utilize menu state, allowing users to toggle and persist their menu preferences across sessions.
- Each menu item's state is stored and retrieved using its path as a key, enhancing user experience by maintaining expanded menu sections between visits.