### PR TITLE
fix(api): Add explicit export for BaseAdapter to support modern moduleResolution options.  Closes #1023

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,7 @@
     "./typings/*": "./typings/*.d.ts",
     "./bullMQAdapter": "./bullMQAdapter.js",
     "./bullAdapter": "./bullAdapter.js",
+    "./baseAdapter": "./baseAdapter.d.ts",
     "./constants/statuses": "./dist/constants/statuses.js"
   },
   "scripts": {

--- a/packages/nestjs/src/bull-board.types.ts
+++ b/packages/nestjs/src/bull-board.types.ts
@@ -4,7 +4,7 @@ import type {
   IServerAdapter,
   QueueAdapterOptions,
 } from '@bull-board/api/typings/app';
-import type { BaseAdapter } from '@bull-board/api/dist/queueAdapters/base';
+import type { BaseAdapter } from '@bull-board/api/baseAdapter';
 import type { InjectionToken, ModuleMetadata, OptionalFactoryDependency } from '@nestjs/common';
 
 export type BullBoardInstance = ReturnType<typeof createBullBoard>;


### PR DESCRIPTION
When using TypeScript with `moduleResolution: "nodenext"` or `"node16"`, importing `BaseAdapter` from its deep path (`.../dist/queueAdapters/base`) fails as it requires an explicit file extension.

This commit adds the path to the `package.json` "exports" field, allowing TypeScript to resolve the module correctly without requiring users to set "skipLibCheck": true in their tsconfig.