### PR TITLE
fix: prioritize Redis maxmemory over total_system_memory in stats

### DIFF
--- a/packages/api/src/handlers/redisStats.ts
+++ b/packages/api/src/handlers/redisStats.ts
@@ -13,7 +13,7 @@ async function getStats(queue: BaseAdapter): Promise<RedisStats> {
     os: redisInfo.os,
     uptime: +redisInfo.uptime_in_seconds,
     memory: {
-      total: +redisInfo.total_system_memory || +redisInfo.maxmemory,
+      total: +redisInfo.maxmemory || +redisInfo.total_system_memory,
       used: +redisInfo.used_memory,
       fragmentationRatio: +redisInfo.mem_fragmentation_ratio,
       peak: +redisInfo.used_memory_peak,


### PR DESCRIPTION
## Summary

This PR fixes the Redis stats display to show the Redis instance's configured `maxmemory` instead of the system's `total_system_memory`.

## Problem

Previously, the Redis stats handler was prioritizing `total_system_memory` over `maxmemory` when displaying memory statistics. This resulted in showing the entire system's memory rather than the actual Redis instance's configured memory limit, which is misleading for monitoring purposes.

## Solution

Changed the priority order in `packages/api/src/handlers/redisStats.ts` to use:
- **Primary**: `maxmemory` (Redis instance's configured max memory)
- **Fallback**: `total_system_memory` (only if maxmemory is not set)

This provides a more accurate representation of the Redis instance's actual memory constraints.

## Changes

- Modified line 16 in `packages/api/src/handlers/redisStats.ts` to prioritize `redisInfo.maxmemory` over `redisInfo.total_system_memory`

## Testing

- [x] Code change is minimal and focused
- [x] Maintains backward compatibility (falls back to `total_system_memory` if `maxmemory` is not configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)