### PR TITLE
Enhance link styling for better text overflow handling

### DIFF
--- a/packages/ui/src/components/QueueCard/QueueCard.module.css
+++ b/packages/ui/src/components/QueueCard/QueueCard.module.css
@@ -6,7 +6,10 @@
 
 .link {
   color: inherit;
+  display: block;
+  overflow: hidden;
   text-decoration: none;
+  text-overflow: ellipsis;
 }
 
 .link:after {


### PR DESCRIPTION
Improve link styling to handle text overflow more effectively by adjusting display properties and adding ellipsis for overflowed text.

Fixes #1044.