### PR TITLE
fix(bun): add missing index.ts entry point

### DIFF
--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -1,0 +1,1 @@
+export { BunAdapter } from './BunAdapter';


### PR DESCRIPTION
- Export BunAdapter from index.ts for proper package usage

- Enables imports like 'import { BunAdapter } from @bull-board/bun'

- Matches the pattern used by other adapter packages

- Fixes missing index.js/index.d.ts in published package