### PR TITLE
feat(ui): add Progress tab to job details

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -23,8 +23,9 @@ function setupBullProcessor(bullQueue: Bull.Queue) {
   bullQueue.process(async (job) => {
     for (let i = 0; i <= 100; i++) {
       await sleep(Math.random());
-      await job.progress(i);
-      await job.log(`Processing job at interval ${i}`);
+      const message = `Processing job at interval ${i}`;
+      await job.progress({ progress: i, message });
+      await job.log(message);
       if (Math.random() * 200 < 1) throw new Error(`Random error ${i}`);
     }
 
@@ -38,8 +39,9 @@ function setupBullMQProcessor(queueName: string) {
     async (job) => {
       for (let i = 0; i <= 100; i++) {
         await sleep(Math.random());
-        await job.updateProgress(i);
-        await job.log(`Processing job at interval ${i}`);
+        const message = `Processing job at interval ${i}`;
+        await job.updateProgress({ progress: i, message });
+        await job.log(message);
 
         if (Math.random() * 200 < 1) throw new Error(`Random error ${i}`);
       }

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -23,7 +23,7 @@ export const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
     processedOn: jobProps.processedOn,
     processedBy: jobProps.processedBy,
     finishedOn: jobProps.finishedOn,
-    progress: jobProps.progress,
+    progress: queue.format('progress', jobProps.progress),
     attempts: jobProps.attemptsMade,
     delay: jobProps.delay,
     failedReason: jobProps.failedReason,

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -214,7 +214,7 @@ export interface Pagination {
   };
 }
 
-export type FormatterField = 'data' | 'returnValue' | 'name';
+export type FormatterField = 'data' | 'returnValue' | 'name' | 'progress';
 
 export type BoardOptions = {
   uiBasePath?: string;

--- a/packages/ui/src/components/JobCard/Details/DetailsContent/DetailsContent.tsx
+++ b/packages/ui/src/components/JobCard/Details/DetailsContent/DetailsContent.tsx
@@ -24,12 +24,18 @@ export const DetailsContent = ({ selectedTab, job, actions, status }: DetailsCon
   const { t } = useTranslation();
   const {
     collapseJobData,
+    collapseJobProgress,
     collapseJobOptions,
     collapseJobError,
     defaultCollapseDepth,
     useCollapsibleJson,
   } = useSettingsStore();
-  const [collapseState, setCollapse] = useState({ data: false, options: false, error: false });
+  const [collapseState, setCollapse] = useState({
+    data: false,
+    progress: false,
+    options: false,
+    error: false,
+  });
   const { stacktrace, data: jobData, returnValue, opts, failedReason } = job;
 
   switch (selectedTab) {
@@ -48,6 +54,27 @@ export const DetailsContent = ({ selectedTab, job, actions, status }: DetailsCon
         />
       ) : (
         <Highlight language="json" text={JSON.stringify({ jobData, returnValue }, null, 2)} />
+      );
+    case 'Progress':
+      // Show N/A if progress is a simple number (circle already shows it),
+      // null, undefined, or boolean
+      if (
+        typeof job.progress === 'number' ||
+        typeof job.progress === 'boolean' ||
+        job.progress === null ||
+        job.progress === undefined
+      ) {
+        return <div className="error">{t('JOB.NA')}</div>;
+      }
+      // For objects or strings, display as JSON
+      return collapseJobProgress && !collapseState.progress ? (
+        <Button onClick={() => setCollapse({ ...collapseState, progress: true })}>
+          {t('JOB.SHOW_PROGRESS_BTN')} <ChevronDown />
+        </Button>
+      ) : useCollapsibleJson ? (
+        <CollapsibleJSON data={job.progress} defaultCollapseDepth={defaultCollapseDepth} />
+      ) : (
+        <Highlight language="json" text={JSON.stringify(job.progress, null, 2)} />
       );
     case 'Options':
       if (collapseJobOptions && !collapseState.options) {

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -27,6 +27,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
     confirmJobActions,
     collapseJob,
     collapseJobData,
+    collapseJobProgress,
     collapseJobOptions,
     collapseJobError,
     defaultCollapseDepth,
@@ -113,6 +114,12 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
         id="collapse-job-data"
         checked={collapseJobData}
         onCheckedChange={(checked) => setSettings({ collapseJobData: checked })}
+      />
+      <SwitchField
+        label={t('SETTINGS.COLLAPSE_JOB_PROGRESS')}
+        id="collapse-job-progress"
+        checked={collapseJobProgress}
+        onCheckedChange={(checked) => setSettings({ collapseJobProgress: checked })}
       />
       <SwitchField
         label={t('SETTINGS.COLLAPSE_JOB_OPTIONS')}

--- a/packages/ui/src/hooks/useDetailsTabs.tsx
+++ b/packages/ui/src/hooks/useDetailsTabs.tsx
@@ -3,7 +3,7 @@ import type { Status } from '@bull-board/api/typings/app';
 import { useEffect, useState } from 'react';
 import { useSettingsStore } from './useSettings';
 
-export const availableJobTabs = ['Data', 'Options', 'Logs', 'Error', 'Timeline'] as const;
+export const availableJobTabs = ['Data', 'Progress', 'Options', 'Logs', 'Error', 'Timeline'] as const;
 
 export type TabsType = (typeof availableJobTabs)[number];
 

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -11,6 +11,7 @@ interface SettingsState {
   confirmJobActions: boolean;
   collapseJob: boolean;
   collapseJobData: boolean;
+  collapseJobProgress: boolean;
   collapseJobOptions: boolean;
   collapseJobError: boolean;
   defaultCollapseDepth: number;
@@ -31,6 +32,7 @@ export const useSettingsStore = create<SettingsState>()(
       confirmQueueActions: true,
       collapseJob: false,
       collapseJobData: false,
+      collapseJobProgress: false,
       collapseJobOptions: false,
       collapseJobError: false,
       defaultCollapseDepth: 3,

--- a/packages/ui/src/static/locales/da-DK/messages.json
+++ b/packages/ui/src/static/locales/da-DK/messages.json
@@ -37,6 +37,7 @@
       "MILLI_SECS": "{{duration}} millisekunder"
     },
     "SHOW_DATA_BTN": "Vis data",
+    "SHOW_PROGRESS_BTN": "Vis fremskridt",
     "SHOW_OPTIONS_BTN": "Vis indstillinger",
     "SHOW_ERRORS_BTN": "Vis fejl",
     "NA": "N/A",
@@ -58,6 +59,7 @@
     "TABS": {
       "DEFAULT": "Standard",
       "DATA": "Data",
+      "PROGRESS": "Fremskridt",
       "OPTIONS": "Indstillinger",
       "LOGS": "Logs",
       "ERROR": "Fejl",
@@ -142,6 +144,7 @@
     "CONFIRM_JOB_ACTIONS": "Bekræft jobhandlinger",
     "COLLAPSE_JOB": "Sammenfold job",
     "COLLAPSE_JOB_DATA": "Sammenfold jobdata",
+    "COLLAPSE_JOB_PROGRESS": "Sammenfold jobfremskridt",
     "COLLAPSE_JOB_OPTIONS": "Sammenfold jobindstillinger",
     "COLLAPSE_JOB_ERROR": "Sammenfold jobfejl",
     "DARK_MODE": "Mørk tilstand"

--- a/packages/ui/src/static/locales/en-GB/messages.json
+++ b/packages/ui/src/static/locales/en-GB/messages.json
@@ -37,6 +37,7 @@
       "MILLI_SECS": "{{duration}} milliseconds"
     },
     "SHOW_DATA_BTN": "Show data",
+    "SHOW_PROGRESS_BTN": "Show progress",
     "SHOW_OPTIONS_BTN": "Show options",
     "SHOW_ERRORS_BTN": "Show errors",
     "NA": "NA",
@@ -58,6 +59,7 @@
     "TABS": {
       "DEFAULT": "Default",
       "DATA": "Data",
+      "PROGRESS": "Progress",
       "OPTIONS": "Options",
       "LOGS": "Logs",
       "ERROR": "Error",
@@ -142,6 +144,7 @@
     "CONFIRM_JOB_ACTIONS": "Confirm job actions",
     "COLLAPSE_JOB": "Collapse job",
     "COLLAPSE_JOB_DATA": "Collapse job data",
+    "COLLAPSE_JOB_PROGRESS": "Collapse job progress",
     "COLLAPSE_JOB_OPTIONS": "Collapse job options",
     "COLLAPSE_JOB_ERROR": "Collapse job error",
     "DARK_MODE": "Dark mode"

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -38,6 +38,7 @@
       "MILLI_SECS": "{{duration}} milliseconds"
     },
     "SHOW_DATA_BTN": "Show data",
+    "SHOW_PROGRESS_BTN": "Show progress",
     "SHOW_OPTIONS_BTN": "Show options",
     "SHOW_ERRORS_BTN": "Show errors",
     "NA": "NA",
@@ -59,6 +60,7 @@
     "TABS": {
       "DEFAULT": "Default",
       "DATA": "Data",
+      "PROGRESS": "Progress",
       "OPTIONS": "Options",
       "LOGS": "Logs",
       "ERROR": "Error",
@@ -144,6 +146,7 @@
     "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "Collapse job",
     "COLLAPSE_JOB_DATA": "Collapse job data",
+    "COLLAPSE_JOB_PROGRESS": "Collapse job progress",
     "COLLAPSE_JOB_OPTIONS": "Collapse job options",
     "COLLAPSE_JOB_ERROR": "Collapse job error",
     "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",

--- a/packages/ui/src/static/locales/es-ES/messages.json
+++ b/packages/ui/src/static/locales/es-ES/messages.json
@@ -39,6 +39,7 @@
       "MILLI_SECS": "{{duration}} milisegundos"
     },
     "SHOW_DATA_BTN": "Mostrar datos",
+    "SHOW_PROGRESS_BTN": "Mostrar progreso",
     "SHOW_OPTIONS_BTN": "Mostrar opciones",
     "SHOW_ERRORS_BTN": "Mostrar errores",
     "NA": "N/A",
@@ -60,6 +61,7 @@
     "TABS": {
       "DEFAULT": "Predeterminado",
       "DATA": "Datos",
+      "PROGRESS": "Progreso",
       "OPTIONS": "Opciones",
       "LOGS": "Registros",
       "ERROR": "Error",
@@ -146,6 +148,7 @@
     "CONFIRM_JOB_ACTIONS": "Confirmar acciones de tarea",
     "COLLAPSE_JOB": "Contraer tarea",
     "COLLAPSE_JOB_DATA": "Contraer datos de tarea",
+    "COLLAPSE_JOB_PROGRESS": "Contraer progreso de tarea",
     "COLLAPSE_JOB_OPTIONS": "Contraer opciones de tarea",
     "COLLAPSE_JOB_ERROR": "Contraer error de tarea",
     "DARK_MODE": "Modo oscuro"

--- a/packages/ui/src/static/locales/fr-FR/messages.json
+++ b/packages/ui/src/static/locales/fr-FR/messages.json
@@ -39,6 +39,7 @@
       "MILLI_SECS": "{{duration}} millisecondes"
     },
     "SHOW_DATA_BTN": "Afficher les données",
+    "SHOW_PROGRESS_BTN": "Afficher la progression",
     "SHOW_OPTIONS_BTN": "Afficher les options",
     "SHOW_ERRORS_BTN": "Afficher les erreurs",
     "NA": "N/A",
@@ -60,6 +61,7 @@
     "TABS": {
       "DEFAULT": "Par défaut",
       "DATA": "Données",
+      "PROGRESS": "Progression",
       "OPTIONS": "Options",
       "LOGS": "Journaux",
       "ERROR": "Erreur",
@@ -146,6 +148,7 @@
     "CONFIRM_JOB_ACTIONS": "Confirmer les actions de tâche",
     "COLLAPSE_JOB": "Réduire la tâche",
     "COLLAPSE_JOB_DATA": "Réduire les données de la tâche",
+    "COLLAPSE_JOB_PROGRESS": "Réduire la progression de la tâche",
     "COLLAPSE_JOB_OPTIONS": "Réduire les options de la tâche",
     "COLLAPSE_JOB_ERROR": "Réduire l'erreur de la tâche",
     "DARK_MODE": "Mode sombre"

--- a/packages/ui/src/static/locales/ja-JP/messages.json
+++ b/packages/ui/src/static/locales/ja-JP/messages.json
@@ -39,6 +39,7 @@
       "MILLI_SECS": "{{duration}} ミリ秒"
     },
     "SHOW_DATA_BTN": "データを表示",
+    "SHOW_PROGRESS_BTN": "進捗を表示",
     "SHOW_OPTIONS_BTN": "オプションを表示",
     "SHOW_ERRORS_BTN": "エラーを表示",
     "NA": "N/A",
@@ -60,6 +61,7 @@
     "TABS": {
       "DEFAULT": "デフォルト",
       "DATA": "データ",
+      "PROGRESS": "進捗",
       "OPTIONS": "オプション",
       "LOGS": "ログ",
       "ERROR": "エラー",
@@ -146,6 +148,7 @@
     "CONFIRM_JOB_ACTIONS": "ジョブアクションの確認",
     "COLLAPSE_JOB": "ジョブを折りたたむ",
     "COLLAPSE_JOB_DATA": "ジョブデータを折りたたむ",
+    "COLLAPSE_JOB_PROGRESS": "ジョブ進捗を折りたたむ",
     "COLLAPSE_JOB_OPTIONS": "ジョブオプションを折りたたむ",
     "COLLAPSE_JOB_ERROR": "ジョブエラーを折りたたむ",
     "DARK_MODE": "ダークモード"

--- a/packages/ui/src/static/locales/ko-KR/messages.json
+++ b/packages/ui/src/static/locales/ko-KR/messages.json
@@ -37,6 +37,7 @@
       "MILLI_SECS": "{{duration}}밀리초"
     },
     "SHOW_DATA_BTN": "데이터 보기",
+    "SHOW_PROGRESS_BTN": "진행 보기",
     "SHOW_OPTIONS_BTN": "옵션 보기",
     "SHOW_ERRORS_BTN": "오류 보기",
     "NA": "해당 없음",
@@ -58,6 +59,7 @@
     "TABS": {
       "DEFAULT": "기본",
       "DATA": "데이터",
+      "PROGRESS": "진행",
       "OPTIONS": "옵션",
       "LOGS": "로그",
       "ERROR": "오류",
@@ -142,6 +144,7 @@
     "CONFIRM_JOB_ACTIONS": "작업 확인",
     "COLLAPSE_JOB": "작업 접기",
     "COLLAPSE_JOB_DATA": "작업 데이터 접기",
+    "COLLAPSE_JOB_PROGRESS": "작업 진행 접기",
     "COLLAPSE_JOB_OPTIONS": "작업 옵션 접기",
     "COLLAPSE_JOB_ERROR": "작업 오류 접기",
     "DARK_MODE": "다크 모드"

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -39,6 +39,7 @@
       "MILLI_SECS": "{{duration}} milisegundos"
     },
     "SHOW_DATA_BTN": "Ver dados",
+    "SHOW_PROGRESS_BTN": "Ver progresso",
     "SHOW_OPTIONS_BTN": "Ver opções",
     "SHOW_ERRORS_BTN": "Ver erros",
     "NA": "NA",
@@ -60,6 +61,7 @@
     "TABS": {
       "DEFAULT": "Padrão",
       "DATA": "Dados",
+      "PROGRESS": "Progresso",
       "OPTIONS": "Opções",
       "LOGS": "Logs",
       "ERROR": "Erros",
@@ -146,6 +148,7 @@
     "CONFIRM_JOB_ACTIONS": "Confirma ações da tarefa",
     "COLLAPSE_JOB": "Recolher tarefa",
     "COLLAPSE_JOB_DATA": "Recolher dados da tarefa",
+    "COLLAPSE_JOB_PROGRESS": "Recolher progresso da tarefa",
     "COLLAPSE_JOB_OPTIONS": "Recolher opções da tarefa",
     "COLLAPSE_JOB_ERROR": "Recolher erros da tarefa",
     "DARK_MODE": "Modo escuro"

--- a/packages/ui/src/static/locales/tr-TR/messages.json
+++ b/packages/ui/src/static/locales/tr-TR/messages.json
@@ -37,6 +37,7 @@
       "MILLI_SECS": "{{duration}} milisaniye"
     },
     "SHOW_DATA_BTN": "Veriyi göster",
+    "SHOW_PROGRESS_BTN": "İlerlemeyi göster",
     "SHOW_OPTIONS_BTN": "Seçenekleri göster",
     "SHOW_ERRORS_BTN": "Hataları göster",
     "NA": "Mevcut değil",
@@ -58,6 +59,7 @@
     "TABS": {
       "DEFAULT": "Varsayılan",
       "DATA": "Veri",
+      "PROGRESS": "İlerleme",
       "OPTIONS": "Seçenekler",
       "LOGS": "Kayıtlar",
       "ERROR": "Hata",
@@ -142,6 +144,7 @@
     "CONFIRM_JOB_ACTIONS": "İş işlemlerini onayla",
     "COLLAPSE_JOB": "İşi daralt",
     "COLLAPSE_JOB_DATA": "İş verisini daralt",
+    "COLLAPSE_JOB_PROGRESS": "İş ilerlemesini daralt",
     "COLLAPSE_JOB_OPTIONS": "İş seçeneklerini daralt",
     "COLLAPSE_JOB_ERROR": "İş hatasını daralt",
     "DARK_MODE": "Karanlık mod"

--- a/packages/ui/src/static/locales/zh-CN/messages.json
+++ b/packages/ui/src/static/locales/zh-CN/messages.json
@@ -36,6 +36,7 @@
       "MILLI_SECS": "{{duration}} 毫秒"
     },
     "SHOW_DATA_BTN": "显示数据",
+    "SHOW_PROGRESS_BTN": "显示进度",
     "SHOW_OPTIONS_BTN": "显示选项",
     "SHOW_ERRORS_BTN": "显示错误",
     "NA": "无",
@@ -57,6 +58,7 @@
     "TABS": {
       "DEFAULT": "默认",
       "DATA": "数据",
+      "PROGRESS": "进度",
       "OPTIONS": "选项",
       "LOGS": "日志",
       "ERROR": "错误",
@@ -140,6 +142,7 @@
     "CONFIRM_JOB_ACTIONS": "确认作业操作",
     "COLLAPSE_JOB": "折叠作业",
     "COLLAPSE_JOB_DATA": "折叠作业数据",
+    "COLLAPSE_JOB_PROGRESS": "折叠作业进度",
     "COLLAPSE_JOB_OPTIONS": "折叠作业选项",
     "COLLAPSE_JOB_ERROR": "折叠作业错误",
     "DARK_MODE": "黑暗模式"


### PR DESCRIPTION
Closes [#1066](https://github.com/felixmosh/bull-board/issues/1066)

Add a new "Progress" tab to the job detail view, positioned between "Data" and "Options" tabs. This tab displays the job's progress data when it's an object or string, and shows "N/A" when progress is a number (since the circular progress indicator already displays it).

Changes:
- Add 'progress' to FormatterField type for custom formatting support
- Apply progress formatter in queues handler
- Add Progress tab with collapsible option in settings
- Add translations for all 10 supported locales
- Update example.ts to use object progress with message instead of number