### PR TITLE
fix: resolve job retry state server-side

### DIFF
--- a/packages/api/src/handlers/retryAll.ts
+++ b/packages/api/src/handlers/retryAll.ts
@@ -1,12 +1,23 @@
-import { BullBoardRequest, ControllerHandlerReturnType } from '../../typings/app';
+import { BullBoardRequest, ControllerHandlerReturnType, JobRetryStatus } from '../../typings/app';
 import { BaseAdapter } from '../queueAdapters/base';
 import { queueProvider } from '../providers/queue';
+
+function isRetriableState(state: string): state is JobRetryStatus {
+  return state === 'failed' || state === 'completed';
+}
 
 async function retryAll(
   req: BullBoardRequest,
   queue: BaseAdapter,
 ): Promise<ControllerHandlerReturnType> {
   const { queueStatus } = req.params;
+
+  if (!isRetriableState(queueStatus)) {
+    return {
+      status: 400,
+      body: { error: `"${queueStatus}" is not a retriable status` },
+    };
+  }
 
   const jobs = await queue.getJobs([queueStatus]);
   await Promise.all(jobs.map((job) => job.retry(queueStatus)));

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -88,7 +88,7 @@ export const appRoutes: AppRouteDefs = {
     },
     {
       method: 'put',
-      route: '/api/queues/:queueName/:jobId/retry/:queueStatus',
+      route: '/api/queues/:queueName/:jobId/retry',
       handler: retryJobHandler,
     },
     {

--- a/packages/api/tests/api/retry-all.spec.ts
+++ b/packages/api/tests/api/retry-all.spec.ts
@@ -1,0 +1,91 @@
+import { Queue, Worker } from 'bullmq';
+import request from 'supertest';
+
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+
+describe('Retry All', () => {
+  let serverAdapter: ExpressAdapter;
+  let testQueue: Queue;
+  let worker: Worker;
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    testQueue = new Queue('RetryAllTest', { connection });
+    await testQueue.obliterate({ force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    if (worker) {
+      await worker.close();
+    }
+    try {
+      await testQueue.obliterate({ force: true });
+    } catch (_error) {
+      // Queue might already be obliterated
+    }
+    await testQueue.close();
+  });
+
+  function setupBoard(options: Partial<{ readOnlyMode: boolean }> = {}) {
+    createBullBoard({
+      queues: [new BullMQAdapter(testQueue, options)],
+      serverAdapter,
+    });
+    return request(serverAdapter.getRouter());
+  }
+
+  async function failMultipleJobs(count: number): Promise<string[]> {
+    const jobs = await Promise.all(
+      Array.from({ length: count }, (_, i) => testQueue.add(`test-job-${i}`, { index: i }))
+    );
+
+    let failedCount = 0;
+    await new Promise<void>((resolve) => {
+      worker = new Worker(
+        'RetryAllTest',
+        async (): Promise<void> => {
+          throw new Error('deliberate failure');
+        },
+        { connection }
+      );
+      worker.on('failed', () => {
+        failedCount++;
+        if (failedCount >= count) resolve();
+      });
+    });
+
+    return jobs.map((job) => job.id!);
+  }
+
+  it('should retry all failed jobs', async () => {
+    const jobIds = await failMultipleJobs(3);
+    await worker.close();
+    const agent = setupBoard();
+
+    await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(200);
+
+    for (const jobId of jobIds) {
+      const job = await testQueue.getJob(jobId);
+      expect(await job!.getState()).toBe('waiting');
+    }
+  });
+
+  it('should return 400 for non-retriable status', async () => {
+    const agent = setupBoard();
+
+    const res = await agent.put(`/api/queues/${testQueue.name}/retry/active`).expect(400);
+    expect(JSON.parse(res.text).error).toContain('not a retriable status');
+  });
+
+  it('should return 405 in read-only mode', async () => {
+    const agent = setupBoard({ readOnlyMode: true });
+
+    await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(405);
+  });
+});

--- a/packages/api/tests/api/retry-job.spec.ts
+++ b/packages/api/tests/api/retry-job.spec.ts
@@ -1,0 +1,90 @@
+import { Queue, Worker } from 'bullmq';
+import request from 'supertest';
+
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+
+describe('Retry Job', () => {
+  let serverAdapter: ExpressAdapter;
+  let testQueue: Queue;
+  let worker: Worker;
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    testQueue = new Queue('RetryJobTest', { connection });
+    await testQueue.obliterate({ force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    if (worker) {
+      await worker.close();
+    }
+    try {
+      await testQueue.obliterate({ force: true });
+    } catch (_error) {
+      // Queue might already be obliterated
+    }
+    await testQueue.close();
+  });
+
+  function setupBoard(options: Partial<{ readOnlyMode: boolean }> = {}) {
+    createBullBoard({
+      queues: [new BullMQAdapter(testQueue, options)],
+      serverAdapter,
+    });
+    return request(serverAdapter.getRouter());
+  }
+
+  async function failAJob(): Promise<string> {
+    const job = await testQueue.add('test-job', { foo: 'bar' });
+
+    await new Promise<void>((resolve) => {
+      worker = new Worker(
+        'RetryJobTest',
+        async (): Promise<void> => {
+          throw new Error('deliberate failure');
+        },
+        { connection }
+      );
+      worker.on('failed', () => resolve());
+    });
+
+    return job.id!;
+  }
+
+  it('should retry a failed job and move it back to waiting', async () => {
+    const jobId = await failAJob();
+    await worker.close();
+    const agent = setupBoard();
+
+    await agent.put(`/api/queues/${testQueue.name}/${jobId}/retry`).expect(204);
+
+    const job = await testQueue.getJob(jobId);
+    expect(await job!.getState()).toBe('waiting');
+  });
+
+  it('should return 400 when job is not in a retriable state', async () => {
+    const job = await testQueue.add('waiting-job', { foo: 'bar' });
+    const agent = setupBoard();
+
+    const res = await agent.put(`/api/queues/${testQueue.name}/${job.id}/retry`).expect(400);
+    expect(JSON.parse(res.text).error).toContain('cannot be retried');
+  });
+
+  it('should return 404 for a non-existent job', async () => {
+    const agent = setupBoard();
+    await agent.put(`/api/queues/${testQueue.name}/non-existent-job/retry`).expect(404);
+  });
+
+  it('should return 405 in read-only mode', async () => {
+    const jobId = await failAJob();
+    const agent = setupBoard({ readOnlyMode: true });
+
+    await agent.put(`/api/queues/${testQueue.name}/${jobId}/retry`).expect(405);
+  });
+});

--- a/packages/ui/src/hooks/useJob.ts
+++ b/packages/ui/src/hooks/useJob.ts
@@ -1,4 +1,4 @@
-import type { AppJob, JobRetryStatus } from '@bull-board/api/typings/app';
+import type { AppJob } from '@bull-board/api/typings/app';
 import { useTranslation } from 'react-i18next';
 import { create } from 'zustand';
 import { JobActions, Status } from '../../typings/app';
@@ -60,9 +60,9 @@ export function useJob(): Omit<JobState, 'updateJob'> & { actions: JobActions } 
       confirmJobActions
     );
 
-  const retryJob = (queueName: string, status: JobRetryStatus) => (job: AppJob) =>
+  const retryJob = (queueName: string) => (job: AppJob) =>
     withConfirmAndUpdate(
-      () => api.retryJob(queueName, job.id, status),
+      () => api.retryJob(queueName, job.id),
       t('JOB.ACTIONS.CONFIRM.RETRY'),
       confirmJobActions
     );

--- a/packages/ui/src/pages/JobPage/JobPage.tsx
+++ b/packages/ui/src/pages/JobPage/JobPage.tsx
@@ -1,4 +1,3 @@
-import type { JobRetryStatus } from '@bull-board/api/typings/app';
 import cn from 'clsx';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -73,7 +72,7 @@ export const JobPage = () => {
         actions={{
           cleanJob,
           promoteJob: actions.promoteJob(queue.name)(job),
-          retryJob: actions.retryJob(queue.name, status as JobRetryStatus)(job),
+          retryJob: actions.retryJob(queue.name)(job),
           getJobLogs: actions.getJobLogs(queue.name)(job),
           updateJobData: () => modal.open('updateJobData'),
           duplicateJob: () => modal.open('addJob'),

--- a/packages/ui/src/pages/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/pages/QueuePage/QueuePage.tsx
@@ -1,5 +1,5 @@
 import { STATUSES } from '@bull-board/api/constants/statuses';
-import type { AppJob, JobRetryStatus } from '@bull-board/api/typings/app';
+import type { AppJob } from '@bull-board/api/typings/app';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { JobCard } from '../../components/JobCard/JobCard';
@@ -97,7 +97,7 @@ export const QueuePage = () => {
           actions={{
             cleanJob: jobActions.cleanJob(queue.name)(job),
             promoteJob: jobActions.promoteJob(queue.name)(job),
-            retryJob: jobActions.retryJob(queue.name, status as JobRetryStatus)(job),
+            retryJob: jobActions.retryJob(queue.name)(job),
             getJobLogs: jobActions.getJobLogs(queue.name)(job),
             updateJobData: () => {
               setEditJob(job);

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -53,11 +53,9 @@ export class Api {
     );
   }
 
-  public retryJob(queueName: string, jobId: AppJob['id'], status: JobRetryStatus): Promise<void> {
+  public retryJob(queueName: string, jobId: AppJob['id']): Promise<void> {
     return this.axios.put(
-      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(
-        `${jobId}`
-      )}/retry/${encodeURIComponent(status)}`
+      `/queues/${encodeURIComponent(queueName)}/${encodeURIComponent(`${jobId}`)}/retry`
     );
   }
 

--- a/packages/ui/typings/app.d.ts
+++ b/packages/ui/typings/app.d.ts
@@ -33,7 +33,7 @@ export interface QueueActions {
 
 export interface JobActions {
   promoteJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
-  retryJob: (queueName: string, status: JobRetryStatus) => (job: AppJob) => () => Promise<void>;
+  retryJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
   cleanJob: (queueName: string) => (job: AppJob) => () => Promise<void>;
   updateJobData: (
     queueName: string,


### PR DESCRIPTION
Closes [#1071](https://github.com/felixmosh/bull-board/issues/1071)

Retrying a failed job from any tab other than "Failed" (e.g. "Latest" or "Active") caused a `Job is not in the latest state. reprocessJob` error because the UI tab status was passed to BullMQ's `job.retry()` instead of the job's actual state in Redis.

Changes:
- Resolve job state via `job.getState()` in `retryJob` handler instead of using the URL param
- Remove `:queueStatus` from the single-job retry route (no longer needed)
- Remove `status` param from `retryJob` across the UI call chain (`Api`, `useJob`, `JobActions`, `QueuePage`, `JobPage`)
- Add input validation to `retryAll` handler to reject non-retriable statuses
- Add tests for both `retryJob` and `retryAll` handlers