### PR TITLE
feat: add textColor and fontSize options to environment badge

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -169,6 +169,16 @@ const run = async () => {
       }),
     ],
     serverAdapter,
+    options: {
+      uiConfig: {
+        environment: {
+          label: 'Production',
+          color: '#e90e20',
+          textColor: '#fff',
+          fontSize: '0.85rem',
+        },
+      },
+    },
   });
 
   app.use('/ui', serverAdapter.getRouter());

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -259,6 +259,8 @@ export type UIConfig = Partial<{
   environment?: {
     label: string;
     color: string;
+    textColor?: string;
+    fontSize?: string | number;
   };
 }>;
 

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -66,13 +66,14 @@
   top: 0;
   left: calc(var(--menu-width) + 1rem);
   right: 1rem;
-  font-size: 0.75rem;
+  font-size: var(--badge-font-size, 0.75rem);
   line-height: 1;
   text-align: center;
   border-radius: 0 0 0.25rem 0.25rem;
   background-color: var(--badge-bg);
+  color: var(--badge-color);
   user-select: none;
-  padding: 0 0.5rem;
+  padding: 0.25em 0.5rem;
 }
 
 /* Mobile styles */

--- a/packages/ui/src/components/Header/Header.tsx
+++ b/packages/ui/src/components/Header/Header.tsx
@@ -18,7 +18,13 @@ export const Header = ({ children }: PropsWithChildren<any>) => {
       {!!uiConfig.environment && (
         <div
           className={s.envBadge}
-          style={{ '--badge-bg': uiConfig.environment.color } as React.CSSProperties}
+          style={
+            {
+              '--badge-bg': uiConfig.environment.color,
+              '--badge-color': uiConfig.environment.textColor,
+              '--badge-font-size': uiConfig.environment.fontSize,
+            } as React.CSSProperties
+          }
         >
           {uiConfig.environment.label}
         </div>


### PR DESCRIPTION
### Why this PR.
Add textColor and fontSize options to the environment UI config

Our team runs bull-board across multiple environments and wanted a more noticeable visual indicator with per-environment color customization. The existing environment config only supported a background color, so we extended it with textColor and fontSize to give teams full control over how each environment badge appears. 😁

The existing environment badge only supported a background color. This extends it with two optional

**fields:** 
  - textColor: controls the label text color
  - fontSize: controls the badge size (padding scales automatically via em)
                                                                                                       
No breaking changes both fields are optional. 
  


Example ui will look like this


<img width="1321" height="332" alt="Screenshot 2569-04-08 at 18 03 46" src="https://github.com/user-attachments/assets/d1a7a58b-6ef6-4a2d-9064-73e04ce3604c" />

Thank you.
