### PR TITLE
chore: upgrade ejs to v5

### DIFF
--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@bull-board/api": "6.21.0",
     "@bull-board/ui": "6.21.0",
-    "ejs": "^3.1.10"
+    "ejs": "^5.0.1"
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@bull-board/api": "6.21.0",
     "@bull-board/ui": "6.21.0",
-    "ejs": "^3.1.10",
+    "ejs": "^5.0.1",
     "mime": "^4.1.0"
   },
   "peerDependencies": {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@bull-board/api": "6.21.0",
     "@bull-board/ui": "6.21.0",
-    "ejs": "^3.1.10",
+    "ejs": "^5.0.1",
     "express": "^5.2.1"
   },
   "devDependencies": {

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -32,7 +32,7 @@
     "@bull-board/ui": "6.21.0",
     "@fastify/static": "^9.0.0",
     "@fastify/view": "^11.1.1",
-    "ejs": "^3.1.10"
+    "ejs": "^5.0.1"
   },
   "devDependencies": {
     "fastify": "^5.8.3"

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bull-board/api": "6.21.0",
     "@bull-board/ui": "6.21.0",
-    "ejs": "^3.1.10",
+    "ejs": "^5.0.1",
     "h3": "^1.15.11"
   },
   "publishConfig": {

--- a/packages/hapi/package.json
+++ b/packages/hapi/package.json
@@ -33,7 +33,7 @@
     "@bull-board/ui": "6.21.0",
     "@hapi/inert": "^7.1.0",
     "@hapi/vision": "^7.0.3",
-    "ejs": "^3.1.10"
+    "ejs": "^5.0.1"
   },
   "devDependencies": {
     "@hapi/hapi": "^21.4.4",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@bull-board/api": "6.21.0",
     "@bull-board/ui": "6.21.0",
-    "ejs": "^3.1.10"
+    "ejs": "^5.0.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260207.0",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -32,7 +32,7 @@
     "@bull-board/ui": "6.21.0",
     "@koa/bodyparser": "^6.1.0",
     "@ladjs/koa-views": "^9.0.0",
-    "ejs": "^3.1.10",
+    "ejs": "^5.0.1",
     "koa": "^3.1.2",
     "koa-mount": "^4.2.0",
     "koa-router": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,7 +430,7 @@ __metadata:
     "@bull-board/ui": "npm:6.21.0"
     "@types/ejs": "npm:^3.1.5"
     bun-types: "npm:^1.3.9"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
   peerDependencies:
     bun-types: "*"
   languageName: unknown
@@ -444,7 +444,7 @@ __metadata:
     "@bull-board/ui": "npm:6.21.0"
     "@types/ejs": "npm:^3.1.5"
     "@types/node": "npm:^22.19.10"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
     elysia: "npm:^1.4.28"
     mime: "npm:^4.1.0"
   peerDependencies:
@@ -460,7 +460,7 @@ __metadata:
     "@bull-board/ui": "npm:6.21.0"
     "@types/ejs": "npm:^3.1.5"
     "@types/express": "npm:^4.17.21 || ^5.0.0"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
     express: "npm:^5.2.1"
   languageName: unknown
   linkType: soft
@@ -473,7 +473,7 @@ __metadata:
     "@bull-board/ui": "npm:6.21.0"
     "@fastify/static": "npm:^9.0.0"
     "@fastify/view": "npm:^11.1.1"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
     fastify: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -485,7 +485,7 @@ __metadata:
     "@bull-board/api": "npm:6.21.0"
     "@bull-board/ui": "npm:6.21.0"
     "@types/ejs": "npm:^3.1.5"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
     h3: "npm:^1.15.11"
   languageName: unknown
   linkType: soft
@@ -502,7 +502,7 @@ __metadata:
     "@types/hapi__hapi": "npm:^20.0.13"
     "@types/hapi__inert": "npm:^5.2.10"
     "@types/hapi__vision": "npm:^5.5.8"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
 
@@ -514,7 +514,7 @@ __metadata:
     "@bull-board/ui": "npm:6.21.0"
     "@cloudflare/workers-types": "npm:^4.20260207.0"
     "@hono/node-server": "npm:^1.19.13"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
     hono: "npm:^4.12.12"
   peerDependencies:
     hono: ^4
@@ -535,7 +535,7 @@ __metadata:
     "@types/koa-router": "npm:^7.4.9"
     "@types/koa-static": "npm:^4.0.4"
     "@types/koa-views": "npm:^7.0.0"
-    ejs: "npm:^3.1.10"
+    ejs: "npm:^5.0.1"
     koa: "npm:^3.1.2"
     koa-mount: "npm:^4.2.0"
     koa-router: "npm:^14.0.0"
@@ -4871,13 +4871,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.3":
-  version: 3.2.6
-  resolution: "async@npm:3.2.6"
-  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
-  languageName: node
-  linkType: hard
-
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -5279,7 +5272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.0.2, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6055,14 +6048,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:^3.1.10":
-  version: 3.1.10
-  resolution: "ejs@npm:3.1.10"
-  dependencies:
-    jake: "npm:^10.8.5"
+"ejs@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ejs@npm:5.0.1"
   bin:
     ejs: bin/cli.js
-  checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
+  checksum: 10c0/7791e4d621e1c050b4310b87b75b43bb18de20cbe4560ee4640693ec052a19ae884df838ed4e391c26ec25530af90b58c35a3465462b6b1734e4b084ce45f872
   languageName: node
   linkType: hard
 
@@ -6566,15 +6557,6 @@ __metadata:
     token-types: "npm:^6.1.1"
     uint8array-extras: "npm:^1.4.0"
   checksum: 10c0/6f15e7538c5d73f9308d2e897365d253a6647a6751bb1b0d85c78aebc02b8976afb7c6c9b3759687a064b1b3d60246e5504746b8f11e38b0d5a1b339087e00d2
-  languageName: node
-  linkType: hard
-
-"filelist@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "filelist@npm:1.0.4"
-  dependencies:
-    minimatch: "npm:^5.0.1"
-  checksum: 10c0/426b1de3944a3d153b053f1c0ebfd02dccd0308a4f9e832ad220707a6d1f1b3c9784d6cadf6b2f68f09a57565f63ebc7bcdc913ccf8012d834f472c46e596f41
   languageName: node
   linkType: hard
 
@@ -7729,20 +7711,6 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10c0/6acc10d139eaefdbe04d2f679e6191b3abf073f111edf10b1de5302c97ec93fffeb2fdd8681ed17f16268aa9dd4f8c588ed9d1d3bffbbfa6e8bf897cbb3149b9
-  languageName: node
-  linkType: hard
-
-"jake@npm:^10.8.5":
-  version: 10.9.2
-  resolution: "jake@npm:10.9.2"
-  dependencies:
-    async: "npm:^3.2.3"
-    chalk: "npm:^4.0.2"
-    filelist: "npm:^1.0.4"
-    minimatch: "npm:^3.1.2"
-  bin:
-    jake: bin/cli.js
-  checksum: 10c0/c4597b5ed9b6a908252feab296485a4f87cba9e26d6c20e0ca144fb69e0c40203d34a2efddb33b3d297b8bd59605e6c1f44f6221ca1e10e69175ecbf3ff5fe31
   languageName: node
   linkType: hard
 
@@ -8968,7 +8936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:


### PR DESCRIPTION
2 major versions bump, which for what I can tell is safe to do as most of the change between these version are around removing dependencies, change to esm generation and about an option not used in this repo.

V4 notes: https://github.com/mde/ejs/blob/main/RELEASE_NOTES_v4.md
V5 notes: https://github.com/mde/ejs/blob/main/RELEASE_NOTES_v5.md


Making this upgrade would remove a "security" issue created by one of package down the ejs dependency tree which was removed.

