### PR TITLE
fix: allow jobFlow handler on read-only queues

### DIFF
--- a/packages/api/src/handlers/jobFlow.ts
+++ b/packages/api/src/handlers/jobFlow.ts
@@ -69,4 +69,6 @@ async function getJobFlow(
   };
 }
 
-export const jobFlowHandler = queueProvider(jobProvider(getJobFlow));
+export const jobFlowHandler = queueProvider(jobProvider(getJobFlow), {
+  skipReadOnlyModeCheck: true,
+});


### PR DESCRIPTION
## Summary

- `jobFlowHandler` was registered without `skipReadOnlyModeCheck`, so the polling `GET /queues/:name/:jobId/flow` request returned 405 on queues with `readOnlyMode: true`, surfacing "Method not allowed on read only queue" in the UI every poll interval on the job detail page.
- The flow endpoint only reads state (`getState`, `findFlowRoot`, `getFlowTree`), so it should behave like the other read-only endpoints (`job.ts`, `jobLogs.ts`) that already pass `{ skipReadOnlyModeCheck: true }`.

Closes #1154

## Test plan

- [x] Rebuilt `@bull-board/api` locally and verified the error no longer appears when loading a job detail page on a queue configured with `readOnlyMode: true`.