### PR TITLE
Implement support for BullMQ Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ app.listen(3000, () => {
 
 That's it! Now you can access the `/admin/queues` route, and you will be able to monitor everything that is happening in your queues 😁
 
+### BullMQ Pro
+
+If you use [BullMQ Pro](https://docs.bullmq.io/bullmq-pro/introduction), import `BullMQProAdapter` instead of `BullMQAdapter`. It extends `BullMQAdapter` with awareness of Pro groups: group counts are folded into the `waiting`/`delayed`/`paused` job counts, jobs from `waiting`/`limited`/`maxed`/`paused` groups are listed alongside regular jobs in those tabs, and the group id is shown next to the job name in the UI.
+
+```js
+const { QueuePro } = require('@taskforcesh/bullmq-pro');
+const { createBullBoard } = require('@bull-board/api');
+const { BullMQProAdapter } = require('@bull-board/api/bullMQProAdapter');
+
+const queuePro = new QueuePro('queueProName');
+
+createBullBoard({
+  queues: [new BullMQProAdapter(queuePro)],
+  serverAdapter,
+});
+```
+
+All `BullMQAdapter` options (`readOnlyMode`, `allowRetries`, `description`, `prefix`, `setFormatter`, `setVisibilityGuard`) work the same way on `BullMQProAdapter`.
+
 For more advanced usages check the `examples` folder, currently it contains:
 
 1. [Basic authentication example](https://github.com/felixmosh/bull-board/tree/master/examples/with-express-auth)

--- a/packages/api/bullMQProAdapter.d.ts
+++ b/packages/api/bullMQProAdapter.d.ts
@@ -1,0 +1,9 @@
+export { BullMQProAdapter } from './dist/queueAdapters/bullMQPro';
+export type {
+  GroupStatusName,
+  GroupSummary,
+  GroupSummaryWithCount,
+  GroupsCountByStatus,
+  JobProLike,
+  QueueProLike,
+} from './dist/queueAdapters/bullMQProTypes';

--- a/packages/api/bullMQProAdapter.js
+++ b/packages/api/bullMQProAdapter.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/queueAdapters/bullMQPro');

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,6 +28,7 @@
     "./dist/*": "./dist/*",
     "./typings/*": "./typings/*.d.ts",
     "./bullMQAdapter": "./bullMQAdapter.js",
+    "./bullMQProAdapter": "./bullMQProAdapter.js",
     "./bullAdapter": "./bullAdapter.js",
     "./baseAdapter": "./baseAdapter.d.ts",
     "./constants/statuses": "./dist/constants/statuses.js"

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -35,6 +35,7 @@ export const formatJob = (job: QueueJob, queue: BaseAdapter): AppJob => {
     isFailed: !!jobProps.failedReason || (Array.isArray(stacktrace) && stacktrace.length > 0),
     externalUrl:
       typeof queue.externalJobUrl === 'function' ? queue.externalJobUrl(jobProps) : undefined,
+    groupId: jobProps.opts?.group?.id,
   };
 };
 

--- a/packages/api/src/queueAdapters/bullMQPro.ts
+++ b/packages/api/src/queueAdapters/bullMQPro.ts
@@ -1,0 +1,192 @@
+import type { Job, Queue } from 'bullmq';
+
+import {
+  JobCleanStatus,
+  JobCounts,
+  JobStatus,
+  QueueAdapterOptions,
+  QueueJobOptions,
+} from '../../typings/app';
+import { STATUSES } from '../constants/statuses';
+import { BullMQAdapter } from './bullMQ';
+import type {
+  GroupsCountByStatus,
+  GroupStatusName,
+  JobProLike,
+  QueueProLike,
+} from './bullMQProTypes';
+
+const GROUP_COUNTS_TTL_MS = 5_000;
+
+const BUCKET_TO_GROUP_STATUSES: Partial<Record<JobStatus, GroupStatusName[]>> = {
+  [STATUSES.waiting]: ['waiting'],
+  [STATUSES.delayed]: ['limited', 'maxed'],
+  [STATUSES.paused]: ['paused'],
+};
+
+interface CachedGroupCounts {
+  fetchedAt: number;
+  value: GroupsCountByStatus;
+}
+
+export class BullMQProAdapter extends BullMQAdapter {
+  public readonly isPro = true;
+  private readonly proQueue: QueueProLike;
+  private groupCountsCache: CachedGroupCounts | null = null;
+
+  constructor(queue: QueueProLike, options: Partial<QueueAdapterOptions> = {}) {
+    super(queue as unknown as Queue, options);
+    this.proQueue = queue;
+
+    this.setFormatter('name', (jobProps: any) => {
+      const gid = jobProps?.opts?.group?.id;
+      const baseName = jobProps?.name ?? '';
+      return gid != null ? `${baseName} (group: ${gid})` : baseName;
+    });
+  }
+
+  public async getJobCounts(): Promise<JobCounts> {
+    const [base, groups] = await Promise.all([super.getJobCounts(), this.getGroupCounts()]);
+    return {
+      ...base,
+      [STATUSES.waiting]: (base[STATUSES.waiting] ?? 0) + groups.waiting,
+      [STATUSES.delayed]: (base[STATUSES.delayed] ?? 0) + groups.limited + groups.maxed,
+      [STATUSES.paused]: (base[STATUSES.paused] ?? 0) + groups.paused,
+    };
+  }
+
+  public async getJobs(
+    jobStatuses: JobStatus[],
+    start = 0,
+    end = -1
+  ): Promise<Job[]> {
+    const requestedEnd = end;
+    const normalizedEnd = end === -1 ? Number.MAX_SAFE_INTEGER : end;
+    const pageSize = normalizedEnd - start + 1;
+
+    const groupStatuses = this.getRelevantGroupStatuses(jobStatuses);
+
+    if (groupStatuses.length === 0) {
+      return super.getJobs(jobStatuses, start, requestedEnd);
+    }
+
+    const counts = await super.getJobCounts();
+    const regularCount = jobStatuses.reduce((sum, status) => sum + (counts[status] ?? 0), 0);
+
+    const regularJobs: Job[] =
+      start < regularCount
+        ? await super.getJobs(jobStatuses, start, Math.min(normalizedEnd, regularCount - 1))
+        : [];
+
+    const groupSkip = Math.max(0, start - regularCount);
+    const groupTake = pageSize - regularJobs.length;
+
+    if (groupTake <= 0) {
+      return regularJobs;
+    }
+
+    const groupJobs = await this.fetchJobsFromGroups(groupStatuses, groupSkip, groupTake);
+    return [...regularJobs, ...groupJobs];
+  }
+
+  public addJob(name: string, data: any, options: QueueJobOptions) {
+    this.invalidateGroupCounts();
+    return super.addJob(name, data, options);
+  }
+
+  public async clean(jobStatus: JobCleanStatus, graceTimeMs: number): Promise<void> {
+    this.invalidateGroupCounts();
+    return super.clean(jobStatus, graceTimeMs);
+  }
+
+  public async empty(): Promise<void> {
+    this.invalidateGroupCounts();
+    return super.empty();
+  }
+
+  public async obliterate(): Promise<void> {
+    this.invalidateGroupCounts();
+    return super.obliterate();
+  }
+
+  public async pause(): Promise<void> {
+    this.invalidateGroupCounts();
+    return super.pause();
+  }
+
+  public async resume(): Promise<void> {
+    this.invalidateGroupCounts();
+    return super.resume();
+  }
+
+  public async promoteAll(): Promise<void> {
+    this.invalidateGroupCounts();
+    return super.promoteAll();
+  }
+
+  private invalidateGroupCounts(): void {
+    this.groupCountsCache = null;
+  }
+
+  private async getGroupCounts(): Promise<GroupsCountByStatus> {
+    const now = Date.now();
+    if (this.groupCountsCache && now - this.groupCountsCache.fetchedAt < GROUP_COUNTS_TTL_MS) {
+      return this.groupCountsCache.value;
+    }
+    const value = await this.proQueue.getGroupsCountByStatus();
+    this.groupCountsCache = { fetchedAt: now, value };
+    return value;
+  }
+
+  private getRelevantGroupStatuses(jobStatuses: JobStatus[]): GroupStatusName[] {
+    const result = new Set<GroupStatusName>();
+    for (const status of jobStatuses) {
+      const mapped = BUCKET_TO_GROUP_STATUSES[status];
+      if (mapped) {
+        for (const groupStatus of mapped) {
+          result.add(groupStatus);
+        }
+      }
+    }
+    return [...result];
+  }
+
+  private async fetchJobsFromGroups(
+    groupStatuses: GroupStatusName[],
+    skip: number,
+    take: number
+  ): Promise<JobProLike[]> {
+    const collected: JobProLike[] = [];
+    let remainingSkip = skip;
+    let remainingTake = take;
+
+    for (const groupStatus of groupStatuses) {
+      if (remainingTake <= 0) break;
+
+      const groups = await this.proQueue.getGroupsByStatus(groupStatus);
+
+      for (const group of groups) {
+        if (remainingTake <= 0) break;
+
+        if (remainingSkip >= group.count) {
+          remainingSkip -= group.count;
+          continue;
+        }
+
+        const groupStart = remainingSkip;
+        const groupEnd = Math.min(group.count - 1, groupStart + remainingTake - 1);
+        const jobs = await this.proQueue.getGroupJobs(group.id, groupStart, groupEnd);
+
+        collected.push(...jobs);
+        remainingSkip = 0;
+        remainingTake -= jobs.length;
+      }
+    }
+
+    return collected;
+  }
+}
+
+// Provide a no-op reference to keep the import live for downstream tooling
+// that walks the JobProLike type. Required because TS-only imports get erased.
+export type { JobProLike, QueueProLike } from './bullMQProTypes';

--- a/packages/api/src/queueAdapters/bullMQProTypes.ts
+++ b/packages/api/src/queueAdapters/bullMQProTypes.ts
@@ -1,0 +1,40 @@
+import type { Job, Queue } from 'bullmq';
+
+export type GroupStatusName = 'waiting' | 'limited' | 'maxed' | 'paused';
+
+export interface GroupSummary {
+  id: string;
+  status: GroupStatusName;
+}
+
+export interface GroupSummaryWithCount {
+  id: string;
+  count: number;
+}
+
+export interface GroupsCountByStatus {
+  waiting: number;
+  limited: number;
+  maxed: number;
+  paused: number;
+}
+
+export interface QueueProLike extends Queue {
+  getGroups(start?: number, end?: number): Promise<GroupSummary[]>;
+  getGroupsByStatus(
+    status: GroupStatusName,
+    start?: number,
+    end?: number
+  ): Promise<GroupSummaryWithCount[]>;
+  getGroupsCount(): Promise<number>;
+  getGroupsCountByStatus(): Promise<GroupsCountByStatus>;
+  getGroupJobs(groupId: string | number, start?: number, end?: number): Promise<JobProLike[]>;
+  getGroupJobsCount(groupId: string | number): Promise<number>;
+}
+
+export interface JobProLike extends Job {
+  gid?: string | number;
+  opts: Job['opts'] & {
+    group?: { id: string | number };
+  };
+}

--- a/packages/api/tests/api/bullmq-pro-adapter.spec.ts
+++ b/packages/api/tests/api/bullmq-pro-adapter.spec.ts
@@ -1,0 +1,258 @@
+import { BullMQProAdapter } from '@bull-board/api/bullMQProAdapter';
+import type {
+  GroupsCountByStatus,
+  GroupStatusName,
+  GroupSummaryWithCount,
+  JobProLike,
+  QueueProLike,
+} from '@bull-board/api/bullMQProAdapter';
+import { formatJob } from '@bull-board/api/dist/handlers/queues';
+
+const makeJobProps = (overrides: Partial<any> = {}) => ({
+  id: '1',
+  name: 'send-email',
+  progress: 0,
+  attemptsMade: 0,
+  finishedOn: null,
+  processedOn: null,
+  delay: 0,
+  timestamp: 0,
+  failedReason: '',
+  stacktrace: null,
+  data: {},
+  returnvalue: null,
+  opts: {},
+  ...overrides,
+});
+
+const makeFakeJob = (props: Partial<any> = {}): JobProLike => {
+  const merged = makeJobProps(props);
+  return {
+    toJSON: () => merged,
+    ...merged,
+  } as unknown as JobProLike;
+};
+
+interface MockOverrides {
+  jobCounts?: Record<string, number>;
+  groupCounts?: GroupsCountByStatus;
+  jobsByStatus?: Record<string, JobProLike[]>;
+  groupsByStatus?: Partial<Record<GroupStatusName, GroupSummaryWithCount[]>>;
+  groupJobs?: Record<string, JobProLike[]>;
+}
+
+const makeMockQueue = (overrides: MockOverrides = {}): QueueProLike & { calls: Record<string, number> } => {
+  const calls: Record<string, number> = {
+    getJobCounts: 0,
+    getGroupsCountByStatus: 0,
+    getGroupsByStatus: 0,
+    getGroupJobs: 0,
+  };
+
+  const fake: any = {
+    name: 'pro-queue',
+    metaValues: { version: 'bullmq-pro-7.0.0' },
+    client: Promise.resolve({ info: async () => 'redis_version:7\n' }),
+    async getJobCounts() {
+      calls.getJobCounts++;
+      return overrides.jobCounts ?? { active: 0, waiting: 0, delayed: 0, paused: 0, completed: 0, failed: 0, prioritized: 0, 'waiting-children': 0 };
+    },
+    async getJobs(statuses: string[], _start = 0, _end = -1) {
+      const out: JobProLike[] = [];
+      for (const s of statuses) {
+        if (overrides.jobsByStatus?.[s]) out.push(...overrides.jobsByStatus[s]);
+      }
+      return out;
+    },
+    async getGroupsCountByStatus() {
+      calls.getGroupsCountByStatus++;
+      return overrides.groupCounts ?? { waiting: 0, limited: 0, maxed: 0, paused: 0 };
+    },
+    async getGroupsByStatus(status: GroupStatusName, _start?: number, _end?: number) {
+      calls.getGroupsByStatus++;
+      return overrides.groupsByStatus?.[status] ?? [];
+    },
+    async getGroupJobs(groupId: string | number, _start = 0, _end = -1) {
+      calls.getGroupJobs++;
+      return overrides.groupJobs?.[String(groupId)] ?? [];
+    },
+    async getGroups() { return []; },
+    async getGroupsCount() { return 0; },
+    async getGroupJobsCount() { return 0; },
+    calls,
+  };
+
+  return fake as QueueProLike & { calls: Record<string, number> };
+};
+
+describe('BullMQProAdapter', () => {
+  describe('getJobCounts', () => {
+    it('merges parent counts with group counts', async () => {
+      const queue = makeMockQueue({
+        jobCounts: {
+          active: 1,
+          waiting: 2,
+          delayed: 3,
+          paused: 4,
+          completed: 5,
+          failed: 6,
+          prioritized: 0,
+          'waiting-children': 0,
+        },
+        groupCounts: { waiting: 10, limited: 20, maxed: 30, paused: 40 },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const counts = await adapter.getJobCounts();
+
+      expect(counts.waiting).toBe(2 + 10);
+      expect(counts.delayed).toBe(3 + 20 + 30);
+      expect(counts.paused).toBe(4 + 40);
+      expect(counts.active).toBe(1);
+      expect(counts.completed).toBe(5);
+      expect(counts.failed).toBe(6);
+    });
+
+    it('caches group counts within TTL', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+
+      await adapter.getJobCounts();
+      await adapter.getJobCounts();
+
+      expect(queue.calls.getGroupsCountByStatus).toBe(1);
+    });
+
+    it('invalidates cache after addJob', async () => {
+      const queue = makeMockQueue();
+      // Provide an add method on the underlying queue so super.addJob can call through.
+      (queue as any).add = async (_name: string, _data: any, _opts: any) => makeFakeJob();
+      const adapter = new BullMQProAdapter(queue);
+
+      await adapter.getJobCounts();
+      await adapter.addJob('any', {}, {});
+      await adapter.getJobCounts();
+
+      expect(queue.calls.getGroupsCountByStatus).toBe(2);
+    });
+
+    it('invalidates cache after pause', async () => {
+      const queue = makeMockQueue();
+      (queue as any).pause = async () => undefined;
+      const adapter = new BullMQProAdapter(queue);
+
+      await adapter.getJobCounts();
+      await adapter.pause();
+      await adapter.getJobCounts();
+
+      expect(queue.calls.getGroupsCountByStatus).toBe(2);
+    });
+  });
+
+  describe('getJobs', () => {
+    it('returns regular jobs only when no group-relevant statuses requested', async () => {
+      const queue = makeMockQueue({
+        jobsByStatus: { completed: [makeFakeJob({ id: '1' }), makeFakeJob({ id: '2' })] },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const jobs = await adapter.getJobs(['completed' as any], 0, 9);
+
+      expect(jobs.map((j: any) => j.id)).toEqual(['1', '2']);
+      expect(queue.calls.getGroupsByStatus).toBe(0);
+    });
+
+    it('falls through to groups when regular jobs do not fill page', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 1 } as any,
+        jobsByStatus: { waiting: [makeFakeJob({ id: 'r1' })] },
+        groupsByStatus: { waiting: [{ id: 'g1', count: 3 }] },
+        groupJobs: { g1: [makeFakeJob({ id: 'g1-a' }), makeFakeJob({ id: 'g1-b' })] },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const jobs = await adapter.getJobs(['waiting' as any], 0, 2);
+
+      expect(jobs.map((j: any) => j.id)).toEqual(['r1', 'g1-a', 'g1-b']);
+    });
+
+    it('skips into groups when start exceeds regular count', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 2 } as any,
+        jobsByStatus: { waiting: [] },
+        groupsByStatus: { waiting: [{ id: 'g1', count: 5 }] },
+        groupJobs: { g1: [makeFakeJob({ id: 'g1-x' }), makeFakeJob({ id: 'g1-y' })] },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const jobs = await adapter.getJobs(['waiting' as any], 3, 4);
+
+      expect(jobs.map((j: any) => j.id)).toEqual(['g1-x', 'g1-y']);
+    });
+  });
+
+  describe('default name formatter', () => {
+    it('appends group id suffix when present', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+      const job = makeFakeJob({ name: 'send-email', opts: { group: { id: 'tenant-42' } } });
+
+      const formatted = formatJob(job as any, adapter);
+
+      expect(formatted.name).toBe('send-email (group: tenant-42)');
+    });
+
+    it('leaves name untouched when no group id', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+      const job = makeFakeJob({ name: 'send-email', opts: {} });
+
+      const formatted = formatJob(job as any, adapter);
+
+      expect(formatted.name).toBe('send-email');
+    });
+
+    it('can be overridden by user-supplied formatter', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+      adapter.setFormatter('name', (jobProps: any) => jobProps.name);
+      const job = makeFakeJob({ name: 'send-email', opts: { group: { id: 'tenant-42' } } });
+
+      const formatted = formatJob(job as any, adapter);
+
+      expect(formatted.name).toBe('send-email');
+    });
+  });
+
+  describe('formatJob groupId surfacing', () => {
+    it('populates groupId from opts.group.id', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+      const job = makeFakeJob({ opts: { group: { id: 'tenant-42' } } });
+
+      const formatted = formatJob(job as any, adapter);
+
+      expect(formatted.groupId).toBe('tenant-42');
+    });
+
+    it('leaves groupId undefined when no group', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+      const job = makeFakeJob({ opts: {} });
+
+      const formatted = formatJob(job as any, adapter);
+
+      expect(formatted.groupId).toBeUndefined();
+    });
+  });
+
+  describe('isPro marker', () => {
+    it('exposes isPro = true', () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+
+      expect(adapter.isPro).toBe(true);
+      expect(adapter.type).toBe('bullmq');
+    });
+  });
+});

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -126,6 +126,7 @@ export interface AppJob {
     displayText?: string;
     href: string;
   };
+  groupId?: string | number;
 }
 
 export interface JobFlow {

--- a/packages/ui/src/components/JobCard/JobCard.module.css
+++ b/packages/ui/src/components/JobCard/JobCard.module.css
@@ -142,6 +142,22 @@
   transition: background-color 150ms ease-in-out;
 }
 
+.groupPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.75rem;
+  background-color: var(--button-default-hover-bg);
+  color: var(--card-text-secondary-color);
+  font-size: 0.75rem;
+  font-family: monospace;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  max-width: 14rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .externalLink:hover,
 .externalLink:focus {
   background-color: var(--button-default-hover-bg);

--- a/packages/ui/src/components/JobCard/JobCard.tsx
+++ b/packages/ui/src/components/JobCard/JobCard.tsx
@@ -72,6 +72,12 @@ export const JobCard = ({
               </>
             )}
 
+            {job.groupId != null && (
+              <span className={s.groupPill} title={`Group: ${job.groupId}`}>
+                group: {job.groupId}
+              </span>
+            )}
+
             {job.externalUrl && (
               <a
                 className={s.externalLink}


### PR DESCRIPTION
There is already https://github.com/felixmosh/bull-board/pull/1052 (which gets huge kudos for being a trailblazer and solving a very real problem!), but I believe that it has several improvements over the prior PR:

* Extends BullMQAdapter instead of cloning it (saves ~150 lines of drifting code, auto-inherits global concurrency methods);
* Zero compile-time dependency on @taskforcesh/bullmq-pro (so it works in CI without access to the paid library);
* Surface group identity via a dedicated groupId field and a default formatter instead of mutating Job.name;
* Cache is invalidated on writes; #1052 did not;
* Includes tests; #1052 had none.

I am happy to keep maintaining BullMQ Pro support and build more elaborate UX to support more of its features over the time, we use both BullMQ and bullboard very actively in Lokalise.