### PR TITLE
Add per-queue throughput metrics

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -5,7 +5,7 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
 import * as Bull from 'bull';
 import Queue3 from 'bull';
-import { FlowProducer, Queue as QueueMQ, Worker } from 'bullmq';
+import { FlowProducer, MetricsTime, Queue as QueueMQ, Worker } from 'bullmq';
 import express from 'express';
 
 const redisOptions = {
@@ -16,7 +16,8 @@ const redisOptions = {
 
 const sleep = (t: number) => new Promise((resolve) => setTimeout(resolve, t * 1000));
 
-const createQueue3 = (name: string) => new Queue3(name, { redis: redisOptions });
+const createQueue3 = (name: string) =>
+  new Queue3(name, { redis: redisOptions, metrics: { maxDataPoints: MetricsTime.ONE_WEEK } });
 const createQueueMQ = (name: string) => new QueueMQ(name, { connection: redisOptions });
 
 function setupBullProcessor(bullQueue: Bull.Queue) {
@@ -48,7 +49,12 @@ function setupBullMQProcessor(queueName: string) {
 
       return { jobId: `This is the return value of job (${job.id})` };
     },
-    { connection: redisOptions }
+    {
+      connection: redisOptions,
+      metrics: {
+        maxDataPoints: MetricsTime.ONE_WEEK,
+      },
+    }
   );
 }
 

--- a/packages/api/src/handlers/metrics.ts
+++ b/packages/api/src/handlers/metrics.ts
@@ -1,0 +1,22 @@
+import { BaseAdapter } from '../queueAdapters/base';
+import { BullBoardRequest, ControllerHandlerReturnType } from '../../typings/app';
+import { queueProvider } from '../providers/queue';
+
+async function getMetrics(
+  _req: BullBoardRequest,
+  queue: BaseAdapter
+): Promise<ControllerHandlerReturnType> {
+  const [completed, failed] = await Promise.all([
+    queue.getMetrics('completed').catch(() => null),
+    queue.getMetrics('failed').catch(() => null),
+  ]);
+
+  return {
+    status: 200,
+    body: { completed, failed },
+  };
+}
+
+export const metricsHandler = queueProvider(getMetrics, {
+  skipReadOnlyModeCheck: true,
+});

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -4,9 +4,11 @@ import {
   JobCleanStatus,
   JobCounts,
   JobStatus,
+  MetricsType,
   QueueAdapterOptions,
   QueueJob,
   QueueJobOptions,
+  QueueMetrics,
   QueueType,
   Status,
 } from '../../typings/app';
@@ -82,6 +84,12 @@ export abstract class BaseAdapter {
   ): Promise<QueueJob[]>;
 
   public abstract getJobLogs(id: string): Promise<string[]>;
+
+  public abstract getMetrics(
+    type: MetricsType,
+    start?: number,
+    end?: number
+  ): Promise<QueueMetrics>;
 
   public abstract getName(): string;
 

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -4,8 +4,10 @@ import {
   JobCleanStatus,
   JobCounts,
   JobStatus,
+  MetricsType,
   QueueAdapterOptions,
   QueueJobOptions,
+  QueueMetrics,
   Status,
 } from '../../typings/app';
 import { STATUSES } from '../constants/statuses';
@@ -59,6 +61,11 @@ export class BullAdapter extends BaseAdapter {
 
   public getJobLogs(id: string): Promise<string[]> {
     return this.queue.getJobLogs(id).then(({ logs }) => logs);
+  }
+
+  public async getMetrics(type: MetricsType, start?: number, end?: number): Promise<QueueMetrics> {
+    const metrics = await this.queue.getMetrics(type, start, end);
+    return { ...metrics, data: metrics.data.map((point) => +point || 0) };
   }
 
   public isPaused(): Promise<boolean> {

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -4,8 +4,10 @@ import {
   JobCleanStatus,
   JobCounts,
   JobStatus,
+  MetricsType,
   QueueAdapterOptions,
   QueueJobOptions,
+  QueueMetrics,
   Status,
 } from '../../typings/app';
 import { STATUSES } from '../constants/statuses';
@@ -56,6 +58,10 @@ export class BullMQAdapter extends BaseAdapter {
 
   public getJobLogs(id: string): Promise<string[]> {
     return this.queue.getJobLogs(id).then(({ logs }) => logs);
+  }
+
+  public getMetrics(type: MetricsType, start?: number, end?: number): Promise<QueueMetrics> {
+    return this.queue.getMetrics(type, start, end);
   }
 
   public isPaused(): Promise<boolean> {

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -6,6 +6,7 @@ import { emptyQueueHandler } from './handlers/emptyQueue';
 import { obliterateQueueHandler } from './handlers/obliterateQueue';
 import { entryPoint } from './handlers/entryPoint';
 import { jobLogsHandler } from './handlers/jobLogs';
+import { metricsHandler } from './handlers/metrics';
 import { jobHandler } from './handlers/job';
 import { jobFlowHandler } from './handlers/jobFlow';
 import { pauseQueueHandler } from './handlers/pauseQueue';
@@ -30,6 +31,11 @@ export const appRoutes: AppRouteDefs = {
   api: [
     { method: 'get', route: '/api/redis/stats', handler: redisStatsHandler },
     { method: 'get', route: '/api/queues', handler: queuesHandler },
+    {
+      method: 'get',
+      route: '/api/queues/:queueName/metrics',
+      handler: metricsHandler,
+    },
     { method: 'put', route: '/api/queues/pause', handler: pauseAllHandler },
     { method: 'put', route: '/api/queues/resume', handler: resumeAllHandler },
     {

--- a/packages/api/tests/api/metrics.spec.ts
+++ b/packages/api/tests/api/metrics.spec.ts
@@ -1,0 +1,58 @@
+import { Queue } from 'bullmq';
+import request from 'supertest';
+
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+
+describe('metrics', () => {
+  let serverAdapter: ExpressAdapter;
+  const queueList: Queue[] = [];
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(() => {
+    serverAdapter = new ExpressAdapter();
+    queueList.length = 0;
+  });
+
+  afterEach(async () => {
+    for (const queue of queueList) {
+      await queue.obliterate({ force: true }).catch(() => undefined);
+      await queue.close();
+    }
+  });
+
+  it('should expose completed and failed metrics for a queue', async () => {
+    const metricsQueue = new Queue('MetricsQueue', { connection });
+    queueList.push(metricsQueue);
+
+    createBullBoard({ queues: [new BullMQAdapter(metricsQueue)], serverAdapter });
+
+    await request(serverAdapter.getRouter())
+      .get(`/api/queues/${metricsQueue.name}/metrics`)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        const body = JSON.parse(res.text);
+        expect(body).toHaveProperty('completed');
+        expect(body).toHaveProperty('failed');
+        expect(Array.isArray(body.completed.data)).toBe(true);
+        expect(Array.isArray(body.failed.data)).toBe(true);
+      });
+  });
+
+  it('should return 404 for an unknown queue', async () => {
+    const metricsQueue = new Queue('KnownQueue', { connection });
+    queueList.push(metricsQueue);
+
+    createBullBoard({ queues: [new BullMQAdapter(metricsQueue)], serverAdapter });
+
+    await request(serverAdapter.getRouter())
+      .get('/api/queues/UnknownQueue/metrics')
+      .expect('Content-Type', /json/)
+      .expect(404);
+  });
+});

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -6,6 +6,18 @@ export type JobCleanStatus = 'completed' | 'wait' | 'active' | 'delayed' | 'fail
 
 export type JobRetryStatus = 'completed' | 'failed';
 
+export type MetricsType = 'completed' | 'failed';
+
+export interface QueueMetrics {
+  meta: {
+    count: number;
+    prevTS: number;
+    prevCount: number;
+  };
+  data: number[];
+  count: number;
+}
+
 type Library = 'bull' | 'bullmq';
 
 type BullMQStatuses = STATUSES;

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -269,6 +269,7 @@ export type UIConfig = Partial<{
   menu?: { width?: string };
   sortQueues?: boolean;
   hideRedisDetails?: boolean;
+  showMetrics?: boolean;
   environment?: {
     label: string;
     color: string;

--- a/packages/api/typings/responses.d.ts
+++ b/packages/api/typings/responses.d.ts
@@ -1,4 +1,4 @@
-import { AppJob, AppQueue, Status } from './app';
+import { AppJob, AppQueue, QueueMetrics, Status } from './app';
 
 export interface GetQueuesResponse {
   queues: AppQueue[];
@@ -7,4 +7,9 @@ export interface GetQueuesResponse {
 export interface GetJobResponse {
   job: AppJob;
   status: Status;
+}
+
+export interface GetQueueMetricsResponse {
+  completed: QueueMetrics | null;
+  failed: QueueMetrics | null;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,6 +74,7 @@
     "react-paginate": "^8.3.0",
     "react-router-dom": "^5.3.4",
     "react-toastify": "^7.0.4",
+    "recharts": "^2.15.4",
     "zustand": "4.5.7"
   },
   "publishConfig": {

--- a/packages/ui/src/components/QueueMetrics/QueueMetrics.module.css
+++ b/packages/ui/src/components/QueueMetrics/QueueMetrics.module.css
@@ -100,7 +100,6 @@
   gap: 1.5rem;
   margin-top: 0.75rem;
   padding-top: 0.75rem;
-  border-top: 1px solid var(--separator-color);
 }
 
 .stat {
@@ -125,4 +124,17 @@
   margin: 0;
   font-size: 0.8rem;
   color: var(--accent-color);
+}
+
+@media (max-width: 768px) {
+  .metricsCard {
+    flex-direction: column;
+    padding: 0.875rem 1rem;
+  }
+
+  .summary {
+    gap: 0.75rem 1.5rem;
+    margin-top: 0.5rem;
+    padding-top: 0.75rem;
+  }
 }

--- a/packages/ui/src/components/QueueMetrics/QueueMetrics.module.css
+++ b/packages/ui/src/components/QueueMetrics/QueueMetrics.module.css
@@ -1,0 +1,128 @@
+.metricsCard {
+  margin-bottom: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.legend {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: var(--accent-color);
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.swatch {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 2px;
+}
+
+.tooltip {
+  pointer-events: none;
+  background-color: var(--card-bg);
+  border: 1px solid var(--separator-color);
+  border-radius: 6px;
+  padding: 0.4rem 0.55rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  white-space: nowrap;
+  font-size: 0.72rem;
+}
+
+.metricsCard :global(.recharts-surface) {
+  outline: none;
+}
+
+.tooltipTime {
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 0.3rem;
+}
+
+.tooltipRow {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--accent-color);
+}
+
+.tooltipRow + .tooltipRow {
+  margin-top: 0.15rem;
+}
+
+.tooltipSwatch {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 2px;
+}
+
+.tooltipName {
+  flex: 1;
+}
+
+.tooltipValue {
+  font-weight: 600;
+  color: var(--text-color);
+  margin-left: 0.5rem;
+}
+
+.tooltipUnit {
+  font-weight: 400;
+  color: var(--accent-color);
+  margin-left: 0.15rem;
+}
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--separator-color);
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.statValue {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  line-height: 1.2;
+}
+
+.statLabel {
+  font-size: 0.7rem;
+  color: var(--accent-color);
+  white-space: nowrap;
+}
+
+.empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--accent-color);
+}

--- a/packages/ui/src/components/QueueMetrics/QueueMetrics.tsx
+++ b/packages/ui/src/components/QueueMetrics/QueueMetrics.tsx
@@ -1,0 +1,192 @@
+import type { AppQueue, QueueMetrics as QueueMetricsData } from '@bull-board/api/typings/app';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import type { TooltipProps } from 'recharts';
+import { useMetrics } from '../../hooks/useMetrics';
+import { Card } from '../Card/Card';
+import s from './QueueMetrics.module.css';
+
+interface QueueMetricsProps {
+  queue: AppQueue;
+}
+
+const WINDOW = 60;
+
+interface MetricsPoint {
+  index: number;
+  minutesAgo: number;
+  completed: number;
+  failed: number;
+}
+
+function toSeries(metrics: QueueMetricsData | null | undefined, nowMs: number): number[] {
+  const series: number[] = Array.from({ length: WINDOW }, () => 0);
+  if (!metrics) {
+    return series;
+  }
+  const prevTS = metrics.meta?.prevTS || nowMs;
+  const live = Math.max(0, (metrics.meta?.count ?? 0) - (metrics.meta?.prevCount ?? 0));
+  const idleMinutes = Math.max(0, Math.floor(nowMs / 60000) - Math.floor(prevTS / 60000));
+  const newestFirst = [live, ...(metrics.data ?? [])];
+  for (let j = 0; j < newestFirst.length; j++) {
+    const minutesAgo = idleMinutes + j;
+    if (minutesAgo >= WINDOW) {
+      break;
+    }
+    series[WINDOW - 1 - minutesAgo] = newestFirst[j];
+  }
+  return series;
+}
+
+const sum = (values: number[]) => values.reduce((acc, value) => acc + value, 0);
+
+export const QueueMetrics = ({ queue }: QueueMetricsProps) => {
+  const { t } = useTranslation();
+  const { metrics, loading } = useMetrics(queue.name);
+
+  const now = Date.now();
+  const completed = toSeries(metrics?.completed, now);
+  const failed = toSeries(metrics?.failed, now);
+
+  if (loading && !metrics) {
+    return null;
+  }
+
+  const hasMetrics = [metrics?.completed, metrics?.failed].some(
+    (m) => (m?.meta?.count ?? 0) > 0 || (m?.data?.length ?? 0) > 0
+  );
+
+  if (!hasMetrics) {
+    return (
+      <Card className={s.metricsCard}>
+        <div className={s.header}>
+          <h3 className={s.title}>{t('METRICS.TITLE')}</h3>
+        </div>
+        <p className={s.empty}>{t('METRICS.EMPTY')}</p>
+      </Card>
+    );
+  }
+
+  const data: MetricsPoint[] = completed.map((value, index) => ({
+    index,
+    minutesAgo: WINDOW - 1 - index,
+    completed: value,
+    failed: failed[index] ?? 0,
+  }));
+
+  const renderTooltip = ({ active, payload }: TooltipProps<number, string>) => {
+    if (!active || !payload || payload.length === 0) {
+      return null;
+    }
+    const point = payload[0].payload as MetricsPoint;
+    return (
+      <div className={s.tooltip}>
+        <div className={s.tooltipTime}>
+          {point.minutesAgo === 0
+            ? t('METRICS.NOW')
+            : t('METRICS.MINUTES_AGO', { minutes: point.minutesAgo })}
+        </div>
+        <div className={s.tooltipRow}>
+          <span className={s.tooltipSwatch} style={{ backgroundColor: 'var(--completed)' }} />
+          <span className={s.tooltipName}>{t('METRICS.COMPLETED')}</span>
+          <span className={s.tooltipValue}>
+            {point.completed}
+            <span className={s.tooltipUnit}>{t('METRICS.PER_MIN_UNIT')}</span>
+          </span>
+        </div>
+        <div className={s.tooltipRow}>
+          <span className={s.tooltipSwatch} style={{ backgroundColor: 'var(--failed)' }} />
+          <span className={s.tooltipName}>{t('METRICS.FAILED')}</span>
+          <span className={s.tooltipValue}>
+            {point.failed}
+            <span className={s.tooltipUnit}>{t('METRICS.PER_MIN_UNIT')}</span>
+          </span>
+        </div>
+      </div>
+    );
+  };
+
+  const completedRate = completed[WINDOW - 2] ?? 0;
+  const failedRate = failed[WINDOW - 2] ?? 0;
+  const peak = Math.max(0, ...completed, ...failed);
+
+  return (
+    <Card className={s.metricsCard}>
+      <div className={s.header}>
+        <h3 className={s.title}>{t('METRICS.TITLE')}</h3>
+        <div className={s.legend}>
+          <span className={s.legendItem}>
+            <span className={s.swatch} style={{ backgroundColor: 'var(--completed)' }} />
+            {t('METRICS.COMPLETED')}
+          </span>
+          <span className={s.legendItem}>
+            <span className={s.swatch} style={{ backgroundColor: 'var(--failed)' }} />
+            {t('METRICS.FAILED')}
+          </span>
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={140}>
+        <AreaChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: 4 }}>
+          <defs>
+            <linearGradient id="metric-completed" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--completed)" stopOpacity={0.35} />
+              <stop offset="100%" stopColor="var(--completed)" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="metric-failed" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--failed)" stopOpacity={0.35} />
+              <stop offset="100%" stopColor="var(--failed)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis dataKey="index" hide />
+          <YAxis hide domain={[0, 'dataMax']} />
+          <Tooltip
+            content={renderTooltip}
+            cursor={{ stroke: 'var(--accent-color)', strokeWidth: 1, strokeOpacity: 0.6 }}
+            isAnimationActive={false}
+          />
+          <Area
+            type="monotone"
+            dataKey="completed"
+            stroke="var(--completed)"
+            strokeWidth={1.5}
+            fill="url(#metric-completed)"
+            dot={false}
+            activeDot={{ r: 3, strokeWidth: 0 }}
+            isAnimationActive={false}
+          />
+          <Area
+            type="monotone"
+            dataKey="failed"
+            stroke="var(--failed)"
+            strokeWidth={1.5}
+            fill="url(#metric-failed)"
+            dot={false}
+            activeDot={{ r: 3, strokeWidth: 0 }}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+
+      <div className={s.summary}>
+        <div className={s.stat}>
+          <span className={s.statValue}>{completedRate}</span>
+          <span className={s.statLabel}>{t('METRICS.COMPLETED_PER_MIN')}</span>
+        </div>
+        <div className={s.stat}>
+          <span className={s.statValue}>{failedRate}</span>
+          <span className={s.statLabel}>{t('METRICS.FAILED_PER_MIN')}</span>
+        </div>
+        <div className={s.stat}>
+          <span className={s.statValue}>{peak}</span>
+          <span className={s.statLabel}>{t('METRICS.PEAK_PER_MIN')}</span>
+        </div>
+        <div className={s.stat}>
+          <span className={s.statValue}>{sum(completed)}</span>
+          <span className={s.statLabel}>{t('METRICS.WINDOW_COMPLETED', { minutes: WINDOW })}</span>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/packages/ui/src/hooks/useMetrics.ts
+++ b/packages/ui/src/hooks/useMetrics.ts
@@ -1,0 +1,32 @@
+import { GetQueueMetricsResponse } from '@bull-board/api/typings/responses';
+import { useState } from 'react';
+import { useApi } from './useApi';
+import { useInterval } from './useInterval';
+import { useSettingsStore } from './useSettings';
+
+export function useMetrics(queueName: string | null) {
+  const api = useApi();
+  const [metrics, setMetrics] = useState<GetQueueMetricsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const pollingInterval = useSettingsStore(({ pollingInterval }) => pollingInterval);
+
+  const getMetrics = () => {
+    if (!queueName) {
+      return Promise.resolve();
+    }
+
+    return api
+      .getMetrics(queueName)
+      .then((data) => setMetrics(data))
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch metrics', error);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useInterval(getMetrics, pollingInterval > 0 ? pollingInterval * 1000 : null, [queueName]);
+
+  return { metrics, loading };
+}

--- a/packages/ui/src/pages/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/pages/QueuePage/QueuePage.tsx
@@ -6,6 +6,7 @@ import { JobCard } from '../../components/JobCard/JobCard';
 import { Pagination } from '../../components/Pagination/Pagination';
 import { QueueActions } from '../../components/QueueActions/QueueActions';
 import { QueueDropdownActions } from '../../components/QueueDropdownActions/QueueDropdownActions';
+import { QueueMetrics } from '../../components/QueueMetrics/QueueMetrics';
 import { StatusMenu } from '../../components/StatusMenu/StatusMenu';
 import { StickyHeader } from '../../components/StickyHeader/StickyHeader';
 import { useActiveQueue } from '../../hooks/useActiveQueue';
@@ -88,6 +89,7 @@ export const QueuePage = () => {
           )}
         </StatusMenu>
       </StickyHeader>
+      <QueueMetrics queue={queue} />
       {queue.jobs.length > 0 ? (
         queue.jobs.map((job) => (
           <JobCard

--- a/packages/ui/src/pages/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/pages/QueuePage/QueuePage.tsx
@@ -6,7 +6,6 @@ import { JobCard } from '../../components/JobCard/JobCard';
 import { Pagination } from '../../components/Pagination/Pagination';
 import { QueueActions } from '../../components/QueueActions/QueueActions';
 import { QueueDropdownActions } from '../../components/QueueDropdownActions/QueueDropdownActions';
-import { QueueMetrics } from '../../components/QueueMetrics/QueueMetrics';
 import { StatusMenu } from '../../components/StatusMenu/StatusMenu';
 import { StickyHeader } from '../../components/StickyHeader/StickyHeader';
 import { useActiveQueue } from '../../hooks/useActiveQueue';
@@ -14,6 +13,7 @@ import { useJob } from '../../hooks/useJob';
 import { useModal } from '../../hooks/useModal';
 import { useQueues } from '../../hooks/useQueues';
 import { useSelectedStatuses } from '../../hooks/useSelectedStatuses';
+import { useUIConfig } from '../../hooks/useUIConfig';
 import { links } from '../../utils/links';
 
 const AddJobModalLazy = React.lazy(() =>
@@ -36,8 +36,15 @@ const ConcurrencyModalLazy = React.lazy(() =>
   }))
 );
 
+const QueueMetricsLazy = React.lazy(() =>
+  import('../../components/QueueMetrics/QueueMetrics').then(({ QueueMetrics }) => ({
+    default: QueueMetrics,
+  }))
+);
+
 export const QueuePage = () => {
   const { t } = useTranslation();
+  const { showMetrics = false } = useUIConfig();
   const selectedStatus = useSelectedStatuses();
   const { actions } = useQueues();
   const { actions: jobActions } = useJob();
@@ -89,7 +96,11 @@ export const QueuePage = () => {
           )}
         </StatusMenu>
       </StickyHeader>
-      <QueueMetrics queue={queue} />
+      {showMetrics && (
+        <Suspense fallback={null}>
+          <QueueMetricsLazy queue={queue} />
+        </Suspense>
+      )}
       {queue.jobs.length > 0 ? (
         queue.jobs.map((job) => (
           <JobCard

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -6,7 +6,11 @@ import {
   RedisStats,
   Status,
 } from '@bull-board/api/typings/app';
-import { GetJobResponse, GetQueuesResponse } from '@bull-board/api/typings/responses';
+import {
+  GetJobResponse,
+  GetQueueMetricsResponse,
+  GetQueuesResponse,
+} from '@bull-board/api/typings/responses';
 import Axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { toast } from 'react-toastify';
 
@@ -138,6 +142,10 @@ export class Api {
 
   public getStats(): Promise<RedisStats> {
     return this.axios.get(`/redis/stats`);
+  }
+
+  public getMetrics(queueName: string): Promise<GetQueueMetricsResponse> {
+    return this.axios.get(`/queues/${encodeURIComponent(queueName)}/metrics`);
   }
 
   private handleResponse(response: AxiosResponse): any {

--- a/packages/ui/src/static/locales/da-DK/messages.json
+++ b/packages/ui/src/static/locales/da-DK/messages.json
@@ -1,13 +1,19 @@
 {
   "LOADING": "Indlæser...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "KØER",
     "SEARCH_INPUT_PLACEHOLDER": "Filtrer køer",
-    "PAUSED": "Pauset"
+    "PAUSED": "Pauset",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Job",
+    "JOBS_COUNT_other": "{{count}} Job",
     "JOBS_COUNT": "{{count}} Jobs",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "Sortér efter",
       "FAILED": "Fejlede Jobs",
@@ -41,6 +47,9 @@
     "SHOW_OPTIONS_BTN": "Vis indstillinger",
     "SHOW_ERRORS_BTN": "Vis fejl",
     "NA": "N/A",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "Filtre"
     },
@@ -68,6 +77,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "Kø ikke fundet",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "Prøv alle igen",
@@ -105,6 +115,19 @@
       "PAUSED": "Pauset"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "Er du sikker?",
     "CONFIRM_BTN": "Bekræft",
@@ -136,17 +159,21 @@
       "OFF": "Fra",
       "SECS": "{{count}} sekunder",
       "MINS": "{{count}} minutter",
-      "MINS_one": "{{count}} minut"
+      "MINS_one": "{{count}} minut",
+      "MINS_other": "{{count}} minute"
     },
     "DEFAULT_JOB_TAB": "Standard job fane",
     "JOBS_PER_PAGE": "Jobs per side (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Bekræft køhandlinger",
     "CONFIRM_JOB_ACTIONS": "Bekræft jobhandlinger",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "Sammenfold job",
     "COLLAPSE_JOB_DATA": "Sammenfold jobdata",
     "COLLAPSE_JOB_PROGRESS": "Sammenfold jobfremskridt",
     "COLLAPSE_JOB_OPTIONS": "Sammenfold jobindstillinger",
     "COLLAPSE_JOB_ERROR": "Sammenfold jobfejl",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "Mørk tilstand"
   },
   "CONCURRENCY": {
@@ -169,5 +196,8 @@
     "TITLE": "Opdater jobdata",
     "UPDATE": "Opdater",
     "JOB_DATA": "Jobdata"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/packages/ui/src/static/locales/en-GB/messages.json
+++ b/packages/ui/src/static/locales/en-GB/messages.json
@@ -1,12 +1,16 @@
 {
   "LOADING": "Loading...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "QUEUES",
     "SEARCH_INPUT_PLACEHOLDER": "Filter queues",
-    "PAUSED": "Paused"
+    "PAUSED": "Paused",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Job",
+    "JOBS_COUNT_other": "{{count}} Job",
     "JOBS_COUNT": "{{count}} Jobs",
     "EMPTY_STATE": "No queues to display.",
     "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
@@ -111,6 +115,19 @@
       "PAUSED": "Paused"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "Are you sure?",
     "CONFIRM_BTN": "Confirm",
@@ -142,17 +159,20 @@
       "OFF": "Off",
       "SECS": "{{count}} seconds",
       "MINS": "{{count}} minutes",
-      "MINS_one": "{{count}} minute"
+      "MINS_one": "{{count}} minute",
+      "MINS_other": "{{count}} minute"
     },
     "DEFAULT_JOB_TAB": "Default job tab",
     "JOBS_PER_PAGE": "Jobs per page (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Confirm queue actions",
     "CONFIRM_JOB_ACTIONS": "Confirm job actions",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "Collapse job",
     "COLLAPSE_JOB_DATA": "Collapse job data",
     "COLLAPSE_JOB_PROGRESS": "Collapse job progress",
     "COLLAPSE_JOB_OPTIONS": "Collapse job options",
     "COLLAPSE_JOB_ERROR": "Collapse job error",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
     "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "Dark mode"
   },

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -114,6 +114,19 @@
       "PAUSED": "Paused"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "Are you sure?",
     "CONFIRM_BTN": "Confirm",

--- a/packages/ui/src/static/locales/es-ES/messages.json
+++ b/packages/ui/src/static/locales/es-ES/messages.json
@@ -1,15 +1,20 @@
 {
   "LOADING": "Cargando...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "COLAS",
     "SEARCH_INPUT_PLACEHOLDER": "Filtrar colas",
-    "PAUSED": "Pausada"
+    "PAUSED": "Pausada",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Tarea",
     "JOBS_COUNT_many": "{{count}} Tareas",
     "JOBS_COUNT_other": "{{count}} Tareas",
     "JOBS_COUNT": "{{count}} Tareas",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "Ordenar por",
       "FAILED": "Trabajos fallidos",
@@ -43,6 +48,9 @@
     "SHOW_OPTIONS_BTN": "Mostrar opciones",
     "SHOW_ERRORS_BTN": "Mostrar errores",
     "NA": "N/A",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "Filtros"
     },
@@ -70,6 +78,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "Cola no encontrada",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "Reintentar todas",
@@ -106,6 +115,19 @@
       "DELAYED": "Retrasadas",
       "PAUSED": "Pausadas"
     }
+  },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
   },
   "CONFIRM": {
     "DEFAULT_TITLE": "¿Estás seguro?",
@@ -146,11 +168,14 @@
     "JOBS_PER_PAGE": "Tareas por página (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Confirmar acciones de cola",
     "CONFIRM_JOB_ACTIONS": "Confirmar acciones de tarea",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "Contraer tarea",
     "COLLAPSE_JOB_DATA": "Contraer datos de tarea",
     "COLLAPSE_JOB_PROGRESS": "Contraer progreso de tarea",
     "COLLAPSE_JOB_OPTIONS": "Contraer opciones de tarea",
     "COLLAPSE_JOB_ERROR": "Contraer error de tarea",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "Modo oscuro"
   },
   "CONCURRENCY": {
@@ -173,5 +198,8 @@
     "TITLE": "Actualizar datos de la tarea",
     "UPDATE": "Actualizar",
     "JOB_DATA": "Datos de la tarea"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/packages/ui/src/static/locales/fr-FR/messages.json
+++ b/packages/ui/src/static/locales/fr-FR/messages.json
@@ -1,15 +1,20 @@
 {
   "LOADING": "Chargement...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "FILES",
     "SEARCH_INPUT_PLACEHOLDER": "Filtrer les files",
-    "PAUSED": "En pause"
+    "PAUSED": "En pause",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Tâche",
     "JOBS_COUNT_many": "{{count}} Tâches",
     "JOBS_COUNT_other": "{{count}} Tâches",
     "JOBS_COUNT": "{{count}} Tâches",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "Trier par",
       "FAILED": "Tâches échouées",
@@ -43,6 +48,9 @@
     "SHOW_OPTIONS_BTN": "Afficher les options",
     "SHOW_ERRORS_BTN": "Afficher les erreurs",
     "NA": "N/A",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "Filtres"
     },
@@ -70,6 +78,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "File non trouvée",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "Tout réessayer",
@@ -106,6 +115,19 @@
       "DELAYED": "Retardées",
       "PAUSED": "En pause"
     }
+  },
+  "METRICS": {
+    "TITLE": "Débit (jobs / min)",
+    "COMPLETED": "Terminés",
+    "FAILED": "Échoués",
+    "COMPLETED_PER_MIN": "Terminés / min",
+    "FAILED_PER_MIN": "Échoués / min",
+    "PEAK_PER_MIN": "Pic / min",
+    "WINDOW_COMPLETED": "Terminés ({{minutes}} dernières min)",
+    "NOW": "Maintenant",
+    "MINUTES_AGO": "il y a {{minutes}} min",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "Aucune métrique collectée pour l'instant. Activez les métriques sur votre worker (ex. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) pour afficher le débit."
   },
   "CONFIRM": {
     "DEFAULT_TITLE": "Êtes-vous sûr ?",
@@ -146,11 +168,14 @@
     "JOBS_PER_PAGE": "Tâches par page (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Confirmer les actions de file",
     "CONFIRM_JOB_ACTIONS": "Confirmer les actions de tâche",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "Réduire la tâche",
     "COLLAPSE_JOB_DATA": "Réduire les données de la tâche",
     "COLLAPSE_JOB_PROGRESS": "Réduire la progression de la tâche",
     "COLLAPSE_JOB_OPTIONS": "Réduire les options de la tâche",
     "COLLAPSE_JOB_ERROR": "Réduire l'erreur de la tâche",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "Mode sombre"
   },
   "CONCURRENCY": {
@@ -173,5 +198,8 @@
     "TITLE": "Mettre à jour les données de tâche",
     "UPDATE": "Mettre à jour",
     "JOB_DATA": "Données de tâche"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/packages/ui/src/static/locales/ja-JP/messages.json
+++ b/packages/ui/src/static/locales/ja-JP/messages.json
@@ -1,15 +1,18 @@
 {
   "LOADING": "読み込み中...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "キュー",
     "SEARCH_INPUT_PLACEHOLDER": "キューを絞り込み",
-    "PAUSED": "一時停止中"
+    "PAUSED": "一時停止中",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
-    "JOBS_COUNT_one": "{{count}} ジョブ",
-    "JOBS_COUNT_many": "{{count}} ジョブ",
-    "JOBS_COUNT_other": "{{count}} ジョブ",
     "JOBS_COUNT": "{{count}} ジョブ",
+    "JOBS_COUNT_other": "{{count}} ジョブ",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "並び順",
       "FAILED": "失敗したジョブ",
@@ -43,6 +46,9 @@
     "SHOW_OPTIONS_BTN": "オプションを表示",
     "SHOW_ERRORS_BTN": "エラーを表示",
     "NA": "N/A",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "フィルター"
     },
@@ -70,6 +76,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "キューが見つかりません",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "すべて再試行",
@@ -107,6 +114,19 @@
       "PAUSED": "一時停止"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "実行してもよろしいですか？",
     "CONFIRM_BTN": "確認",
@@ -138,19 +158,20 @@
       "OFF": "オフ",
       "SECS": "{{count}} 秒",
       "MINS": "{{count}} 分",
-      "MINS_one": "{{count}} 分",
-      "MINS_many": "{{count}} 分",
       "MINS_other": "{{count}} 分"
     },
     "DEFAULT_JOB_TAB": "デフォルトジョブタブ",
     "JOBS_PER_PAGE": "ページあたりのジョブ数 (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "キューアクションの確認",
     "CONFIRM_JOB_ACTIONS": "ジョブアクションの確認",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "ジョブを折りたたむ",
     "COLLAPSE_JOB_DATA": "ジョブデータを折りたたむ",
     "COLLAPSE_JOB_PROGRESS": "ジョブ進捗を折りたたむ",
     "COLLAPSE_JOB_OPTIONS": "ジョブオプションを折りたたむ",
     "COLLAPSE_JOB_ERROR": "ジョブエラーを折りたたむ",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "ダークモード"
   },
   "CONCURRENCY": {
@@ -173,5 +194,8 @@
     "TITLE": "ジョブデータを更新",
     "UPDATE": "更新",
     "JOB_DATA": "ジョブデータ"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/packages/ui/src/static/locales/ko-KR/messages.json
+++ b/packages/ui/src/static/locales/ko-KR/messages.json
@@ -1,13 +1,17 @@
 {
   "LOADING": "로딩 중...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "큐 목록",
     "SEARCH_INPUT_PLACEHOLDER": "큐 필터",
-    "PAUSED": "일시정지됨"
+    "PAUSED": "일시정지됨",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
-    "JOBS_COUNT_one": "{{count}}개의 작업",
     "JOBS_COUNT": "{{count}}개의 작업",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "정렬 기준",
       "FAILED": "실패한 작업",
@@ -41,6 +45,9 @@
     "SHOW_OPTIONS_BTN": "옵션 보기",
     "SHOW_ERRORS_BTN": "오류 보기",
     "NA": "해당 없음",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "필터"
     },
@@ -68,6 +75,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "큐를 찾을 수 없습니다",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "모두 재시도",
@@ -105,6 +113,19 @@
       "PAUSED": "일시정지됨"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "확실합니까?",
     "CONFIRM_BTN": "확인",
@@ -135,18 +156,20 @@
     "POLLING_OPTIONS": {
       "OFF": "끄기",
       "SECS": "{{count}}초",
-      "MINS": "{{count}}분",
-      "MINS_one": "{{count}}분"
+      "MINS": "{{count}}분"
     },
     "DEFAULT_JOB_TAB": "기본 작업 탭",
     "JOBS_PER_PAGE": "페이지당 작업 수 (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "큐 작업 확인",
     "CONFIRM_JOB_ACTIONS": "작업 확인",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "작업 접기",
     "COLLAPSE_JOB_DATA": "작업 데이터 접기",
     "COLLAPSE_JOB_PROGRESS": "작업 진행 접기",
     "COLLAPSE_JOB_OPTIONS": "작업 옵션 접기",
     "COLLAPSE_JOB_ERROR": "작업 오류 접기",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "다크 모드"
   },
   "CONCURRENCY": {
@@ -169,6 +192,8 @@
     "TITLE": "작업 데이터 업데이트",
     "UPDATE": "업데이트",
     "JOB_DATA": "작업 데이터"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }
-

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -1,15 +1,20 @@
 {
   "LOADING": "Carregando...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "FILAS",
     "SEARCH_INPUT_PLACEHOLDER": "Filtrar filas",
-    "PAUSED": "Em Pausa"
+    "PAUSED": "Em Pausa",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Tarefa",
     "JOBS_COUNT_many": "{{count}} Tarefas",
     "JOBS_COUNT_other": "{{count}} Tarefas",
     "JOBS_COUNT": "{{count}} Tarefas",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "Ordenar por",
       "FAILED": "Trabalhos com falha",
@@ -43,6 +48,9 @@
     "SHOW_OPTIONS_BTN": "Ver opções",
     "SHOW_ERRORS_BTN": "Ver erros",
     "NA": "NA",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "Filtros"
     },
@@ -70,6 +78,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "Fila não encontrada",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "Tentar novamente todos",
@@ -106,6 +115,19 @@
       "DELAYED": "Atrasado",
       "PAUSED": "Pausado"
     }
+  },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
   },
   "CONFIRM": {
     "DEFAULT_TITLE": "Tem certeza?",
@@ -146,11 +168,14 @@
     "JOBS_PER_PAGE": "Tarefas por página (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Confirma ações da fila",
     "CONFIRM_JOB_ACTIONS": "Confirma ações da tarefa",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "Recolher tarefa",
     "COLLAPSE_JOB_DATA": "Recolher dados da tarefa",
     "COLLAPSE_JOB_PROGRESS": "Recolher progresso da tarefa",
     "COLLAPSE_JOB_OPTIONS": "Recolher opções da tarefa",
     "COLLAPSE_JOB_ERROR": "Recolher erros da tarefa",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "Modo escuro"
   },
   "CONCURRENCY": {
@@ -173,5 +198,8 @@
     "TITLE": "Atualizar dados do tarefa",
     "UPDATE": "Atualizar",
     "JOB_DATA": "Dados do tarefa"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/packages/ui/src/static/locales/tr-TR/messages.json
+++ b/packages/ui/src/static/locales/tr-TR/messages.json
@@ -1,13 +1,19 @@
 {
   "LOADING": "Yükleniyor...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "KUYRUKLAR",
     "SEARCH_INPUT_PLACEHOLDER": "Kuyrukları filtrele",
-    "PAUSED": "Durduruldu"
+    "PAUSED": "Durduruldu",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} İş",
+    "JOBS_COUNT_other": "{{count}} Job",
     "JOBS_COUNT": "{{count}} İş",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "Sırala",
       "FAILED": "Başarısız İşler",
@@ -41,6 +47,9 @@
     "SHOW_OPTIONS_BTN": "Seçenekleri göster",
     "SHOW_ERRORS_BTN": "Hataları göster",
     "NA": "Mevcut değil",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "Filtreler"
     },
@@ -68,6 +77,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "Kuyruk bulunamadı",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "Hepsini yeniden dene",
@@ -105,6 +115,19 @@
       "PAUSED": "Durduruldu"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "Emin misiniz?",
     "CONFIRM_BTN": "Onayla",
@@ -136,17 +159,21 @@
       "OFF": "Kapalı",
       "SECS": "{{count}} saniye",
       "MINS": "{{count}} dakika",
-      "MINS_one": "{{count}} dakika"
+      "MINS_one": "{{count}} dakika",
+      "MINS_other": "{{count}} minute"
     },
     "DEFAULT_JOB_TAB": "Varsayılan iş sekmesi",
     "JOBS_PER_PAGE": "Sayfa başına iş (1-50)",
     "CONFIRM_QUEUE_ACTIONS": "Kuyruk işlemlerini onayla",
     "CONFIRM_JOB_ACTIONS": "İş işlemlerini onayla",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "İşi daralt",
     "COLLAPSE_JOB_DATA": "İş verisini daralt",
     "COLLAPSE_JOB_PROGRESS": "İş ilerlemesini daralt",
     "COLLAPSE_JOB_OPTIONS": "İş seçeneklerini daralt",
     "COLLAPSE_JOB_ERROR": "İş hatasını daralt",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "Karanlık mod"
   },
   "CONCURRENCY": {
@@ -169,5 +196,8 @@
     "TITLE": "İş verisini güncelle",
     "UPDATE": "Güncelle",
     "JOB_DATA": "İş verisi"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/packages/ui/src/static/locales/zh-CN/messages.json
+++ b/packages/ui/src/static/locales/zh-CN/messages.json
@@ -1,12 +1,17 @@
 {
   "LOADING": "加载中...",
   "MENU": {
+    "OVERVIEW": "Overview",
     "QUEUES": "队列",
     "SEARCH_INPUT_PLACEHOLDER": "筛选队列",
-    "PAUSED": "已暂停"
+    "PAUSED": "已暂停",
+    "EXPAND_ALL": "Expand all groups",
+    "COLLAPSE_ALL": "Collapse all groups"
   },
   "DASHBOARD": {
     "JOBS_COUNT": "{{count}} 个作业",
+    "EMPTY_STATE": "No queues to display.",
+    "EMPTY_STATE_FILTERED": "No queues have {{status}} jobs.",
     "SORTING": {
       "TITLE": "排序方式",
       "FAILED": "失败的任务",
@@ -40,6 +45,9 @@
     "SHOW_OPTIONS_BTN": "显示选项",
     "SHOW_ERRORS_BTN": "显示错误",
     "NA": "无",
+    "NO_PROGRESS": "No progress data available",
+    "NO_ERRORS": "No errors recorded",
+    "NO_LOGS": "No logs available",
     "LOGS": {
       "FILTER_PLACEHOLDER": "筛选器"
     },
@@ -67,6 +75,7 @@
   },
   "QUEUE": {
     "NOT_FOUND": "未找到队列",
+    "EMPTY_STATE": "No {{status}} jobs in this queue.",
     "ACTIONS": {
       "MODAL_TITLE": "",
       "RETRY_ALL": "重试全部",
@@ -104,6 +113,19 @@
       "PAUSED": "已暂停"
     }
   },
+  "METRICS": {
+    "TITLE": "Throughput (jobs / min)",
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "COMPLETED_PER_MIN": "Completed / min",
+    "FAILED_PER_MIN": "Failed / min",
+    "PEAK_PER_MIN": "Peak / min",
+    "WINDOW_COMPLETED": "Completed (last {{minutes}} min)",
+    "NOW": "Now",
+    "MINUTES_AGO": "{{minutes}} min ago",
+    "PER_MIN_UNIT": "/min",
+    "EMPTY": "No metrics collected yet. Enable metrics on your worker (e.g. metrics: { maxDataPoints: MetricsTime.ONE_WEEK }) to see throughput."
+  },
   "CONFIRM": {
     "DEFAULT_TITLE": "您确定吗？",
     "CONFIRM_BTN": "确认",
@@ -140,11 +162,14 @@
     "JOBS_PER_PAGE": "每页作业数量（1-50）",
     "CONFIRM_QUEUE_ACTIONS": "确认队列操作",
     "CONFIRM_JOB_ACTIONS": "确认作业操作",
+    "USE_COLLAPSIBLE_JSON": "Use collapsible JSON",
     "COLLAPSE_JOB": "折叠作业",
     "COLLAPSE_JOB_DATA": "折叠作业数据",
     "COLLAPSE_JOB_PROGRESS": "折叠作业进度",
     "COLLAPSE_JOB_OPTIONS": "折叠作业选项",
     "COLLAPSE_JOB_ERROR": "折叠作业错误",
+    "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
+    "SORT_QUEUES": "Sort queues (A-Z, groups first)",
     "DARK_MODE": "黑暗模式"
   },
   "CONCURRENCY": {
@@ -167,5 +192,8 @@
     "TITLE": "更新工作数据",
     "UPDATE": "更新",
     "JOB_DATA": "作业数据"
+  },
+  "CLIPBOARD": {
+    "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,6 +345,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/template@npm:7.28.6"
@@ -618,6 +625,7 @@ __metadata:
     react-paginate: "npm:^8.3.0"
     react-router-dom: "npm:^5.3.4"
     react-toastify: "npm:^7.0.4"
+    recharts: "npm:^2.15.4"
     zustand: "npm:4.5.7"
   languageName: unknown
   linkType: soft
@@ -4016,6 +4024,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-array@npm:^3.0.3":
+  version: 3.2.2
+  resolution: "@types/d3-array@npm:3.2.2"
+  checksum: 10c0/6137cb97302f8a4f18ca22c0560c585cfcb823f276b23d89f2c0c005d72697ec13bca671c08e68b4b0cabd622e3f0e91782ee221580d6774074050be96dd7028
+  languageName: node
+  linkType: hard
+
+"@types/d3-color@npm:*":
+  version: 3.1.3
+  resolution: "@types/d3-color@npm:3.1.3"
+  checksum: 10c0/65eb0487de606eb5ad81735a9a5b3142d30bc5ea801ed9b14b77cb14c9b909f718c059f13af341264ee189acf171508053342142bdf99338667cea26a2d8d6ae
+  languageName: node
+  linkType: hard
+
+"@types/d3-ease@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-ease@npm:3.0.2"
+  checksum: 10c0/aff5a1e572a937ee9bff6465225d7ba27d5e0c976bd9eacdac2e6f10700a7cb0c9ea2597aff6b43a6ed850a3210030870238894a77ec73e309b4a9d0333f099c
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:^3.0.1":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "npm:*"
+  checksum: 10c0/066ebb8da570b518dd332df6b12ae3b1eaa0a7f4f0c702e3c57f812cf529cc3500ec2aac8dc094f31897790346c6b1ebd8cd7a077176727f4860c2b181a65ca4
+  languageName: node
+  linkType: hard
+
+"@types/d3-path@npm:*":
+  version: 3.1.1
+  resolution: "@types/d3-path@npm:3.1.1"
+  checksum: 10c0/2c36eb31ebaf2ce4712e793fd88087117976f7c4ed69cc2431825f999c8c77cca5cea286f3326432b770739ac6ccd5d04d851eb65e7a4dbcc10c982b49ad2c02
+  languageName: node
+  linkType: hard
+
+"@types/d3-scale@npm:^4.0.2":
+  version: 4.0.9
+  resolution: "@types/d3-scale@npm:4.0.9"
+  dependencies:
+    "@types/d3-time": "npm:*"
+  checksum: 10c0/4ac44233c05cd50b65b33ecb35d99fdf07566bcdbc55bc1306b2f27d1c5134d8c560d356f2c8e76b096e9125ffb8d26d95f78d56e210d1c542cb255bdf31d6c8
+  languageName: node
+  linkType: hard
+
+"@types/d3-shape@npm:^3.1.0":
+  version: 3.1.8
+  resolution: "@types/d3-shape@npm:3.1.8"
+  dependencies:
+    "@types/d3-path": "npm:*"
+  checksum: 10c0/49ec2172b9eb66fc1d036e2a23966216bb972e9af51ddbed134df24bd71aedf207bb1ef81903a119eb4e1f5e927cf44beacaf64c9af86474e5548594b102b574
+  languageName: node
+  linkType: hard
+
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@types/d3-time@npm:3.0.4"
+  checksum: 10c0/6d9e2255d63f7a313a543113920c612e957d70da4fb0890931da6c2459010291b8b1f95e149a538500c1c99e7e6c89ffcce5554dd29a31ff134a38ea94b6d174
+  languageName: node
+  linkType: hard
+
+"@types/d3-timer@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-timer@npm:3.0.2"
+  checksum: 10c0/c644dd9571fcc62b1aa12c03bcad40571553020feeb5811f1d8a937ac1e65b8a04b759b4873aef610e28b8714ac71c9885a4d6c127a048d95118f7e5b506d9e1
+  languageName: node
+  linkType: hard
+
 "@types/ejs@npm:^3.1.5":
   version: 3.1.5
   resolution: "@types/ejs@npm:3.1.5"
@@ -5340,7 +5417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
@@ -5693,6 +5770,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:^3.1.6":
+  version: 3.2.4
+  resolution: "d3-array@npm:3.2.4"
+  dependencies:
+    internmap: "npm:1 - 2"
+  checksum: 10c0/08b95e91130f98c1375db0e0af718f4371ccacef7d5d257727fe74f79a24383e79aba280b9ffae655483ffbbad4fd1dec4ade0119d88c4749f388641c8bf8c50
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 10c0/a4e20e1115fa696fce041fbe13fbc80dc4c19150fa72027a7c128ade980bc0eeeba4bcf28c9e21f0bce0e0dbfe7ca5869ef67746541dcfda053e4802ad19783c
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: 10c0/fec8ef826c0cc35cda3092c6841e07672868b1839fcaf556e19266a3a37e6bc7977d8298c0fcb9885e7799bfdcef7db1baaba9cd4dcf4bc5e952cf78574a88b0
+  languageName: node
+  linkType: hard
+
+"d3-format@npm:1 - 3":
+  version: 3.1.2
+  resolution: "d3-format@npm:3.1.2"
+  checksum: 10c0/0de452ae07585238e7f01607a7e0066665c34609652188b6ac7dc9f424f69465a425e07d16d79bd0e5955202ac7f241c66d0c76f68a79fc6f4857c94cf420652
+  languageName: node
+  linkType: hard
+
+"d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+  checksum: 10c0/19f4b4daa8d733906671afff7767c19488f51a43d251f8b7f484d5d3cfc36c663f0a66c38fe91eee30f40327443d799be17169f55a293a3ba949e84e57a33e6a
+  languageName: node
+  linkType: hard
+
+"d3-path@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-path@npm:3.1.0"
+  checksum: 10c0/dc1d58ec87fa8319bd240cf7689995111a124b141428354e9637aa83059eb12e681f77187e0ada5dedfce346f7e3d1f903467ceb41b379bfd01cd8e31721f5da
+  languageName: node
+  linkType: hard
+
+"d3-scale@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "d3-scale@npm:4.0.2"
+  dependencies:
+    d3-array: "npm:2.10.0 - 3"
+    d3-format: "npm:1 - 3"
+    d3-interpolate: "npm:1.2.0 - 3"
+    d3-time: "npm:2.1.1 - 3"
+    d3-time-format: "npm:2 - 4"
+  checksum: 10c0/65d9ad8c2641aec30ed5673a7410feb187a224d6ca8d1a520d68a7d6eac9d04caedbff4713d1e8545be33eb7fec5739983a7ab1d22d4e5ad35368c6729d362f1
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "d3-shape@npm:3.2.0"
+  dependencies:
+    d3-path: "npm:^3.1.0"
+  checksum: 10c0/f1c9d1f09926daaf6f6193ae3b4c4b5521e81da7d8902d24b38694517c7f527ce3c9a77a9d3a5722ad1e3ff355860b014557b450023d66a944eabf8cfde37132
+  languageName: node
+  linkType: hard
+
+"d3-time-format@npm:2 - 4":
+  version: 4.1.0
+  resolution: "d3-time-format@npm:4.1.0"
+  dependencies:
+    d3-time: "npm:1 - 3"
+  checksum: 10c0/735e00fb25a7fd5d418fac350018713ae394eefddb0d745fab12bbff0517f9cdb5f807c7bbe87bb6eeb06249662f8ea84fec075f7d0cd68609735b2ceb29d206
+  languageName: node
+  linkType: hard
+
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "d3-time@npm:3.1.0"
+  dependencies:
+    d3-array: "npm:2 - 3"
+  checksum: 10c0/a984f77e1aaeaa182679b46fbf57eceb6ebdb5f67d7578d6f68ef933f8eeb63737c0949991618a8d29472dbf43736c7d7f17c452b2770f8c1271191cba724ca1
+  languageName: node
+  linkType: hard
+
+"d3-timer@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 10c0/d4c63cb4bb5461d7038aac561b097cd1c5673969b27cbdd0e87fa48d9300a538b9e6f39b4a7f0e3592ef4f963d858c8a9f0e92754db73116770856f2fc04561a
+  languageName: node
+  linkType: hard
+
 "data-uri-to-buffer@npm:^6.0.2":
   version: 6.0.2
   resolution: "data-uri-to-buffer@npm:6.0.2"
@@ -5727,6 +5897,13 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
+  languageName: node
+  linkType: hard
+
+"decimal.js-light@npm:^2.4.1":
+  version: 2.5.1
+  resolution: "decimal.js-light@npm:2.5.1"
+  checksum: 10c0/4fd33f535aac9e5bd832796831b65d9ec7914ad129c7437b3ab991b0c2eaaa5a57e654e6174c4a17f1b3895ea366f0c1ab4955cdcdf7cfdcf3ad5a58b456c020
   languageName: node
   linkType: hard
 
@@ -5912,6 +6089,16 @@ __metadata:
   version: 1.0.0
   resolution: "discontinuous-range@npm:1.0.0"
   checksum: 10c0/487b105f83c1cc528e25e65d3c4b73958ec79769b7bd0e264414702a23a7e2b282c72982b4bef4af29fcab53f47816c3f0a5c40d85a99a490f4bc35b83dc00f8
+  languageName: node
+  linkType: hard
+
+"dom-helpers@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "dom-helpers@npm:5.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.8.7"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/f735074d66dd759b36b158fa26e9d00c9388ee0e8c9b16af941c38f014a37fc80782de83afefd621681b19ac0501034b4f1c4a3bff5caa1b8667f0212b5e124c
   languageName: node
   linkType: hard
 
@@ -6205,6 +6392,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^4.0.1":
+  version: 4.0.7
+  resolution: "eventemitter3@npm:4.0.7"
+  checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
+  languageName: node
+  linkType: hard
+
 "exact-mirror@npm:^0.2.7":
   version: 0.2.7
   resolution: "exact-mirror@npm:0.2.7"
@@ -6356,6 +6550,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
+"fast-equals@npm:^5.0.1":
+  version: 5.4.0
+  resolution: "fast-equals@npm:5.4.0"
+  checksum: 10c0/4fdce3a8f814e78af7296ca4ebe82f4765074a6dfe557ee98c18f5d2958c3de59025fbff7556d65f250165ccef424d37f9952ee159400f8ebe5f2edb704ec80e
   languageName: node
   linkType: hard
 
@@ -7272,6 +7473,13 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/b275a400ddc80c138cef2c741f74463b1bdbeccb3351ab38bdf14b46ce53a186077beec24330e81f1cbfa7bd5c1933267c38d14d567b63c86b101436a3b705f7
+  languageName: node
+  linkType: hard
+
+"internmap@npm:1 - 2":
+  version: 2.0.3
+  resolution: "internmap@npm:2.0.3"
+  checksum: 10c0/8cedd57f07bbc22501516fbfc70447f0c6812871d471096fad9ea603516eacc2137b633633daf432c029712df0baefd793686388ddf5737e3ea15074b877f7ed
   languageName: node
   linkType: hard
 
@@ -9743,7 +9951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15, prop-types@npm:^15.6.2":
+"prop-types@npm:^15, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -10056,6 +10264,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-smooth@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "react-smooth@npm:4.0.4"
+  dependencies:
+    fast-equals: "npm:^5.0.1"
+    prop-types: "npm:^15.8.1"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/d94cb27f808721ec040d320ca1927919199495fd212e54eb9dc8ee3f73ff1d808a34be9f4b09fe49b01f411ac2387fdf0e4bee297f18faf56f94bfbef5fd204c
+  languageName: node
+  linkType: hard
+
 "react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
   version: 2.2.3
   resolution: "react-style-singleton@npm:2.2.3"
@@ -10081,6 +10303,21 @@ __metadata:
     react: ">=16"
     react-dom: ">=16"
   checksum: 10c0/2aa396f2aefe4c30498eca3e4bbb560c1b6503065808c98003711cc6273bc1328160cb2a2e844e05ff29ee8d52ad9094d0ebd6ea233d32e38f8516c859c009d6
+  languageName: node
+  linkType: hard
+
+"react-transition-group@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "react-transition-group@npm:4.4.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.5.5"
+    dom-helpers: "npm:^5.0.1"
+    loose-envify: "npm:^1.4.0"
+    prop-types: "npm:^15.6.2"
+  peerDependencies:
+    react: ">=16.6.0"
+    react-dom: ">=16.6.0"
+  checksum: 10c0/2ba754ba748faefa15f87c96dfa700d5525054a0141de8c75763aae6734af0740e77e11261a1e8f4ffc08fd9ab78510122e05c21c2d79066c38bb6861a886c82
   languageName: node
   linkType: hard
 
@@ -10114,6 +10351,34 @@ __metadata:
   version: 0.2.0
   resolution: "real-require@npm:0.2.0"
   checksum: 10c0/23eea5623642f0477412ef8b91acd3969015a1501ed34992ada0e3af521d3c865bb2fe4cdbfec5fe4b505f6d1ef6a03e5c3652520837a8c3b53decff7e74b6a0
+  languageName: node
+  linkType: hard
+
+"recharts-scale@npm:^0.4.4":
+  version: 0.4.5
+  resolution: "recharts-scale@npm:0.4.5"
+  dependencies:
+    decimal.js-light: "npm:^2.4.1"
+  checksum: 10c0/64ce1fc4ebe62001787bf4dc4cbb779452d33831619309c71c50277c58e8968ffe98941562d9d0d5ffdb02588ebd62f4fe6548fa826110fd458db9c3cc6dadc1
+  languageName: node
+  linkType: hard
+
+"recharts@npm:^2.15.4":
+  version: 2.15.4
+  resolution: "recharts@npm:2.15.4"
+  dependencies:
+    clsx: "npm:^2.0.0"
+    eventemitter3: "npm:^4.0.1"
+    lodash: "npm:^4.17.21"
+    react-is: "npm:^18.3.1"
+    react-smooth: "npm:^4.0.4"
+    recharts-scale: "npm:^0.4.4"
+    tiny-invariant: "npm:^1.3.1"
+    victory-vendor: "npm:^36.6.8"
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/45bf1e1f56d881696aa55c1a019f16dee559b46d0024254584424d518e7f2887eb76e8ac22a203d02939fbbeabd2c297fc55c0c5a6534879d60f5caad8a97f37
   languageName: node
   linkType: hard
 
@@ -11018,7 +11283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
+"tiny-invariant@npm:^1.0.2, tiny-invariant@npm:^1.3.1":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
@@ -11725,6 +11990,28 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10c0/e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
+  languageName: node
+  linkType: hard
+
+"victory-vendor@npm:^36.6.8":
+  version: 36.9.2
+  resolution: "victory-vendor@npm:36.9.2"
+  dependencies:
+    "@types/d3-array": "npm:^3.0.3"
+    "@types/d3-ease": "npm:^3.0.0"
+    "@types/d3-interpolate": "npm:^3.0.1"
+    "@types/d3-scale": "npm:^4.0.2"
+    "@types/d3-shape": "npm:^3.1.0"
+    "@types/d3-time": "npm:^3.0.0"
+    "@types/d3-timer": "npm:^3.0.0"
+    d3-array: "npm:^3.1.6"
+    d3-ease: "npm:^3.0.1"
+    d3-interpolate: "npm:^3.0.1"
+    d3-scale: "npm:^4.0.2"
+    d3-shape: "npm:^3.1.0"
+    d3-time: "npm:^3.0.0"
+    d3-timer: "npm:^3.0.1"
+  checksum: 10c0/bad36de3bf4d406834743c2e99a8281d786af324d7e84b7f7a2fc02c27a3779034fb0c3c4707d4c8e68683334d924a67100cfa13985235565e83b9877f8e2ffd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a throughput chart (jobs/min) to each queue page, backed by BullMQ/Bull getMetrics. Builds on the work started in #619 .

New endpoint GET /api/queues/:queueName/metrics → { completed, failed } per-minute series
New QueueMetrics card: recharts area chart (completed vs failed) + hover tooltip + summary (rate, peak, window total)

<img width="881" height="192" alt="image" src="https://github.com/user-attachments/assets/01d6b0be-8e64-420c-a3d7-7a755761cdf1" />

Notes

Series are wall-clock aligned over a 60-min window (meta.prevTS, idle minutes zero-filled).
Bull adapter coerces Redis string data points to numbers; BullMQProAdapter inherits the BullMQ impl.
recharts ^2.15.4 (React 17 compatible; v3 needs React 18).
i18n added for all locales; example.ts enables metrics for the demo.
Test: metrics.spec.ts (endpoint shape + 404).