### PR TITLE
docs: remove redundant arrow glyph from demo links

### DIFF
--- a/website/docs/configuration/ui-config.md
+++ b/website/docs/configuration/ui-config.md
@@ -68,7 +68,7 @@ All fields are optional. Defaults are applied by `createBullBoard` where noted.
 
 ![Header with the amber demo environment badge](/screenshots/environment-badge.png)
 
-The demo site uses this exact configuration — `{ label: 'demo', color: '#f59f00', textColor: '#000' }`. <a href="/bull-board/demo/" target="_blank" rel="noopener">See it live ↗</a>.
+The demo site uses this exact configuration — `{ label: 'demo', color: '#f59f00', textColor: '#000' }`. <a href="/bull-board/demo/" target="_blank" rel="noopener">See it live</a>.
 
 ## Source of truth
 

--- a/website/docs/guide/introduction.md
+++ b/website/docs/guide/introduction.md
@@ -2,7 +2,7 @@
 
 Bull-Board is a dashboard for [BullMQ](https://docs.bullmq.io/) and [Bull](https://github.com/OptimalBits/bull). It mounts into your existing HTTP server and shows you what's in Redis. You still use Bull or BullMQ to enqueue and process jobs, bull-board only visualises them.
 
-Want to see it before installing? <a href="/bull-board/demo/" target="_blank" rel="noopener">Open the live demo ↗</a>.
+Want to see it before installing? <a href="/bull-board/demo/" target="_blank" rel="noopener">Open the live demo</a>.
 
 ## What you get
 

--- a/website/docs/recipes/index.md
+++ b/website/docs/recipes/index.md
@@ -1,6 +1,6 @@
 # Recipes
 
-Most recipes link into the <a href="/bull-board/demo/" target="_blank" rel="noopener">live demo ↗</a> so you can see the shape before porting it.
+Most recipes link into the <a href="/bull-board/demo/" target="_blank" rel="noopener">live demo</a> so you can see the shape before porting it.
 
 Short, code-first walkthroughs for common setups. Each recipe is a page; each page ties back to a runnable example in the repo.
 

--- a/website/docs/recipes/job-logs-and-flows.md
+++ b/website/docs/recipes/job-logs-and-flows.md
@@ -20,7 +20,7 @@ Open the job in the dashboard, switch to the Logs tab.
 
 ![Job detail with Logs tab, showing timestamped worker output](/screenshots/job-logs.png)
 
-Live example: <a href="/bull-board/demo/" target="_blank" rel="noopener">open the demo ↗</a> and drill into a worker-processed job in `emails:welcome`.
+Live example: <a href="/bull-board/demo/" target="_blank" rel="noopener">open the demo</a> and drill into a worker-processed job in `emails:welcome`.
 
 ## Job flows
 
@@ -45,6 +45,6 @@ Bull-board renders the tree on the parent job's detail view. Click through to ju
 
 ![Parent job with Job Flow panel showing children across queues](/screenshots/flow-tree.png)
 
-Live example: <a href="/bull-board/demo/" target="_blank" rel="noopener">open the demo ↗</a> and scroll to `reports:nightly` for a parent job with children.
+Live example: <a href="/bull-board/demo/" target="_blank" rel="noopener">open the demo</a> and scroll to `reports:nightly` for a parent job with children.
 
 Caveat: `job.log()` is BullMQ-only. Bull has no equivalent.

--- a/website/docs/server-adapters/index.md
+++ b/website/docs/server-adapters/index.md
@@ -3,7 +3,7 @@
 One server adapter per framework. The core `@bull-board/api` package is shared. Pick your framework below.
 
 ::: tip
-<a href="/bull-board/demo/" target="_blank" rel="noopener">Try the live demo ↗</a> first — all 9 adapters serve the same UI.
+<a href="/bull-board/demo/" target="_blank" rel="noopener">Try the live demo</a> first — all 9 adapters serve the same UI.
 :::
 
 ## Adapter matrix


### PR DESCRIPTION
## What

The docs theme (rspress) auto-renders an external-link arrow icon for `target="_blank"` links. The demo links also include a literal `↗` glyph in their text, so they render with two arrows (`↗↗`).

This removes the manual `↗` from the six demo links; the theme's own icon remains, so each link shows exactly one arrow.

<img width="885" height="143" alt="Safari – 2026-06-17 at 10 42 41" src="https://github.com/user-attachments/assets/511baee1-377b-43c4-821e-b47906dbfcea" />

## Files

- `guide/introduction.md`
- `server-adapters/index.md`
- `configuration/ui-config.md`
- `recipes/job-logs-and-flows.md` (×2)
- `recipes/index.md`

Text-only change, no behavior affected.