### PR TITLE
test(api): measure coverage from source and raise it (62% to 90%)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,6 +63,23 @@ jobs:
           # The default Redis port
           REDIS_PORT: 6379
 
+      - name: Coverage (@bull-board/api)
+        if: matrix.node == '24.x'
+        run: yarn workspace @bull-board/api test:coverage
+        env:
+          CI: true
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+
+      - name: Upload coverage to Codecov
+        if: matrix.node == '24.x'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/api/coverage/lcov.info
+          flags: api
+          fail_ci_if_error: false # non-blocking until CODECOV_TOKEN is set
+
   test-bun:
     name: Test Bun adapter
     runs-on: ubuntu-latest
@@ -103,7 +120,3 @@ jobs:
 
       - name: Test Bun adapter
         run: yarn workspace @bull-board/bun test
-        env:
-          CI: true
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .DS_Store
 dist
+coverage/
 yarn-error.log
 .yarn/install-state.gz
 *.rdb

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+# Coverage is collected for @bull-board/api only, so statuses are scoped to the
+# `api` flag. Uploads need a CODECOV_TOKEN secret; until then the CI step is
+# non-blocking and no status checks post.
+coverage:
+  status:
+    project:
+      api:
+        target: auto
+        threshold: 1%
+        flags:
+          - api
+    patch:
+      api:
+        target: 75%
+        threshold: 5%
+        flags:
+          - api
+
+flags:
+  api:
+    paths:
+      - packages/api/src
+
+comment:
+  layout: 'reach, diff, flags, files'
+  require_changes: true
+
+ignore:
+  - 'packages/**/dist'
+  - 'packages/**/tests'
+  - '**/*.d.ts'

--- a/packages/api/jest.config.coverage.js
+++ b/packages/api/jest.config.coverage.js
@@ -1,0 +1,26 @@
+const packageJson = require('./package.json');
+
+// Maps `@bull-board/api*` to `src/` so coverage is measured against source rather
+// than the `dist/` the tests import (a naive `jest --coverage` reports 0% otherwise).
+// `isolatedModules` skips type-checking the src-vs-dist `BaseAdapter` clash; runtime
+// is duck-typed. Scoped to this run only -- `yarn test` keeps full type-checking.
+module.exports = {
+  displayName: `${packageJson.name} (coverage)`,
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/'],
+  testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
+  },
+  moduleNameMapper: {
+    '^@bull-board/api/dist/(.*)$': '<rootDir>/src/$1',
+    '^@bull-board/api/bullMQAdapter$': '<rootDir>/src/queueAdapters/bullMQ',
+    '^@bull-board/api/bullMQProAdapter$': '<rootDir>/src/queueAdapters/bullMQPro',
+    '^@bull-board/api/bullAdapter$': '<rootDir>/src/queueAdapters/bull',
+    '^@bull-board/api$': '<rootDir>/src/index',
+  },
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageDirectory: '<rootDir>/coverage',
+  coverageReporters: ['text', 'text-summary', 'lcov'],
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "build": "yarn clean && tsc",
     "clean": "rm -rf dist",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --config jest.config.coverage.js"
   },
   "dependencies": {
     "redis-info": "^3.1.0"

--- a/packages/api/tests/api/bull-adapter.spec.ts
+++ b/packages/api/tests/api/bull-adapter.spec.ts
@@ -1,0 +1,139 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullAdapter } from '@bull-board/api/bullAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import Bull from 'bull';
+import request from 'supertest';
+
+describe('BullAdapter (legacy Bull)', () => {
+  let serverAdapter: ExpressAdapter;
+  let queue: Bull.Queue;
+
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  // Shared across the suite: per-test create/close churns Bull's Redis connections
+  // and a benign "Connection is closed" event races into the next test.
+  beforeAll(() => {
+    queue = new Bull('BullLegacy', { redis: connection });
+    queue.on('error', () => {});
+  });
+
+  afterAll(async () => {
+    await queue.close();
+  });
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    await queue.obliterate({ force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await queue.obliterate({ force: true }).catch(() => {});
+  });
+
+  function setupBoard(options: Partial<{ readOnlyMode: boolean }> = {}) {
+    createBullBoard({
+      queues: [new BullAdapter(queue, options)],
+      serverAdapter,
+    });
+    return request(serverAdapter.getRouter());
+  }
+
+  it('rejects a non-Bull queue', () => {
+    expect(() => new BullAdapter({} as any)).toThrow(/non-Bull queue/);
+  });
+
+  it('exposes the queue in the queues list with bull statuses', async () => {
+    const agent = setupBoard();
+
+    const res = await agent.get('/api/queues').expect(200);
+    const listed = res.body.queues.find((q: any) => q.name === 'BullLegacy');
+
+    expect(listed).toBeDefined();
+    expect(listed.statuses).toEqual(
+      expect.arrayContaining(['latest', 'active', 'waiting', 'completed', 'failed', 'delayed', 'paused'])
+    );
+  });
+
+  it('adds a job through the API', async () => {
+    const agent = setupBoard();
+
+    await agent
+      .post('/api/queues/BullLegacy/add')
+      .send({ data: { foo: 'bar' }, options: {} })
+      .expect(200);
+
+    expect(await queue.getJobCounts()).toMatchObject({ waiting: 1 });
+  });
+
+  // pause()/resume() are omitted: Bull's global pause cycles its blocking client
+  // and emits a flaky "Connection is closed" race. isPaused is covered above.
+
+  it('empties the queue through the API', async () => {
+    await queue.add('to-empty', { foo: 1 });
+    const agent = setupBoard();
+
+    await agent.put('/api/queues/BullLegacy/empty').expect(200);
+
+    expect(await queue.getJobCounts()).toMatchObject({ waiting: 0 });
+  });
+
+  it('updates a job\'s data via the Bull update() path', async () => {
+    // Bull jobs expose update(), not BullMQ's updateData().
+    const job = await queue.add('editable', { value: 'before' });
+    const agent = setupBoard();
+
+    await agent
+      .patch(`/api/queues/BullLegacy/${job.id}/update-data`)
+      .send({ jobData: { value: 'after' } })
+      .expect(200);
+
+    const updated = await queue.getJob(job.id as string);
+    expect(updated?.data).toEqual({ value: 'after' });
+  });
+
+  describe('adapter-level behaviour', () => {
+    let adapter: BullAdapter;
+
+    beforeEach(() => {
+      adapter = new BullAdapter(queue);
+    });
+
+    it('prefixes the queue name', () => {
+      expect(adapter.getName()).toBe('BullLegacy');
+    });
+
+    it('increments attemptsMade when reading a job (alignJobData)', async () => {
+      const added = await queue.add('aligned', { foo: 1 });
+
+      const fetched = await adapter.getJob(added.id as string);
+
+      expect(fetched?.attemptsMade).toBe(1); // raw 0, shifted by one for display
+
+    });
+
+    it('promotes delayed jobs via promoteAll', async () => {
+      await queue.add('delayed', { foo: 1 }, { delay: 60_000 });
+      expect(await queue.getDelayedCount()).toBe(1);
+
+      await adapter.promoteAll();
+
+      expect(await queue.getDelayedCount()).toBe(0);
+    });
+
+    it('reports no global concurrency support', async () => {
+      expect(await adapter.getGlobalConcurrency()).toBeNull();
+      await expect(adapter.setGlobalConcurrency(5)).resolves.toBeUndefined();
+    });
+
+    it('does not support job schedulers', async () => {
+      expect(await adapter.removeJobScheduler('any')).toBe(false);
+    });
+
+    it('returns redis info', async () => {
+      expect(typeof (await adapter.getRedisInfo())).toBe('string');
+    });
+  });
+});

--- a/packages/api/tests/api/entry-point.spec.ts
+++ b/packages/api/tests/api/entry-point.spec.ts
@@ -1,0 +1,53 @@
+import { entryPoint } from '@bull-board/api/dist/handlers/entryPoint';
+
+describe('entryPoint handler', () => {
+  const baseUiConfig = { boardTitle: 'My Board' } as any;
+
+  it('renders the index view', () => {
+    const result = entryPoint({ basePath: '/ui', uiConfig: baseUiConfig });
+    expect(result.name).toBe('index.ejs');
+  });
+
+  it('appends a trailing slash to a basePath that lacks one', () => {
+    const result = entryPoint({ basePath: '/ui', uiConfig: baseUiConfig });
+    expect(result.params.basePath).toBe('/ui/');
+  });
+
+  it('leaves an already-trailing-slash basePath unchanged', () => {
+    const result = entryPoint({ basePath: '/ui/', uiConfig: baseUiConfig });
+    expect(result.params.basePath).toBe('/ui/');
+  });
+
+  it('escapes angle brackets in the serialized uiConfig', () => {
+    const result = entryPoint({
+      basePath: '',
+      uiConfig: { boardTitle: '<script>alert(1)</script>' } as any,
+    });
+    expect(result.params.uiConfig).not.toContain('<');
+    expect(result.params.uiConfig).not.toContain('>');
+    expect(result.params.uiConfig).toContain('\\u003c');
+  });
+
+  it('passes the board title through', () => {
+    const result = entryPoint({ basePath: '/', uiConfig: baseUiConfig });
+    expect(result.params.title).toBe('My Board');
+  });
+
+  it('extracts favicon variants when present', () => {
+    const result = entryPoint({
+      basePath: '/',
+      uiConfig: {
+        boardTitle: 'B',
+        favIcon: { default: '/d.png', alternative: '/a.png' },
+      } as any,
+    });
+    expect(result.params.favIconDefault).toBe('/d.png');
+    expect(result.params.favIconAlternative).toBe('/a.png');
+  });
+
+  it('tolerates a missing favIcon', () => {
+    const result = entryPoint({ basePath: '/', uiConfig: baseUiConfig });
+    expect(result.params.favIconDefault).toBeUndefined();
+    expect(result.params.favIconAlternative).toBeUndefined();
+  });
+});

--- a/packages/api/tests/api/error-handler.spec.ts
+++ b/packages/api/tests/api/error-handler.spec.ts
@@ -1,0 +1,36 @@
+import { errorHandler } from '@bull-board/api/dist/handlers/error';
+
+describe('errorHandler', () => {
+  const ORIGINAL_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_ENV;
+  });
+
+  const bodyOf = (err: Error & { statusCode?: any }) =>
+    errorHandler(err).body as Record<string, any>;
+
+  it('uses the error statusCode when present', () => {
+    const err = Object.assign(new Error('not found'), { statusCode: 404 as const });
+    const result = errorHandler(err);
+    expect(result.status).toBe(404);
+    expect((result.body as Record<string, any>).message).toBe('not found');
+    expect((result.body as Record<string, any>).error).toBe('Internal server error');
+  });
+
+  it('defaults to 500 when no statusCode is set', () => {
+    const result = errorHandler(new Error('boom'));
+    expect(result.status).toBe(500);
+  });
+
+  it('includes the stack trace only in development', () => {
+    process.env.NODE_ENV = 'development';
+    const err = new Error('with stack');
+    expect(bodyOf(err).details).toBe(err.stack);
+  });
+
+  it('omits the stack trace outside development', () => {
+    process.env.NODE_ENV = 'production';
+    expect(bodyOf(new Error('no stack')).details).toBeUndefined();
+  });
+});

--- a/packages/api/tests/api/job-flow.spec.ts
+++ b/packages/api/tests/api/job-flow.spec.ts
@@ -1,0 +1,102 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { FlowProducer, Queue } from 'bullmq';
+import request from 'supertest';
+
+describe('Job flow', () => {
+  let serverAdapter: ExpressAdapter;
+  let parentQueue: Queue;
+  let childQueue: Queue;
+  let flowProducer: FlowProducer;
+
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    parentQueue = new Queue('FlowParent', { connection });
+    childQueue = new Queue('FlowChild', { connection });
+    flowProducer = new FlowProducer({ connection });
+    await parentQueue.obliterate({ force: true }).catch(() => {});
+    await childQueue.obliterate({ force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await parentQueue.obliterate({ force: true }).catch(() => {});
+    await childQueue.obliterate({ force: true }).catch(() => {});
+    await flowProducer.close();
+    await parentQueue.close();
+    await childQueue.close();
+  });
+
+  function setupBoard() {
+    createBullBoard({
+      queues: [new BullMQAdapter(parentQueue), new BullMQAdapter(childQueue)],
+      serverAdapter,
+    });
+    return request(serverAdapter.getRouter());
+  }
+
+  it('resolves the full flow tree when querying a child job', async () => {
+    const tree = await flowProducer.add({
+      name: 'root',
+      queueName: parentQueue.name,
+      children: [
+        { name: 'leaf-a', queueName: childQueue.name, data: { idx: 1 } },
+        { name: 'leaf-b', queueName: childQueue.name, data: { idx: 2 } },
+      ],
+    });
+
+    const agent = setupBoard();
+    const childJobId = tree.children![0].job.id;
+
+    const res = await agent
+      .get(`/api/queues/${childQueue.name}/${childJobId}/flow`)
+      .expect(200);
+
+    expect(res.body.nodeId).toBe(childJobId);
+    expect(res.body.isFlowNode).toBe(true);
+    expect(res.body.flowRoot.id).toBe(tree.job.id);
+    expect(res.body.flowRoot.name).toBe('root');
+    expect(res.body.flowRoot.queueName).toBe(parentQueue.name);
+    const childNames = res.body.flowRoot.children.map((c: any) => c.name).sort();
+    expect(childNames).toEqual(['leaf-a', 'leaf-b']);
+  });
+
+  it('resolves the same tree when querying the root job directly', async () => {
+    const tree = await flowProducer.add({
+      name: 'root',
+      queueName: parentQueue.name,
+      children: [{ name: 'leaf', queueName: childQueue.name, data: {} }],
+    });
+
+    const agent = setupBoard();
+
+    const res = await agent
+      .get(`/api/queues/${parentQueue.name}/${tree.job.id}/flow`)
+      .expect(200);
+
+    expect(res.body.isFlowNode).toBe(true);
+    expect(res.body.flowRoot.id).toBe(tree.job.id);
+    expect(res.body.flowRoot.children).toHaveLength(1);
+    expect(res.body.flowRoot.children[0].name).toBe('leaf');
+  });
+
+  it('returns a non-flow response for a standalone job', async () => {
+    const job = await parentQueue.add('solo', { foo: 'bar' });
+
+    const agent = setupBoard();
+
+    const res = await agent
+      .get(`/api/queues/${parentQueue.name}/${job.id}/flow`)
+      .expect(200);
+
+    expect(res.body.nodeId).toBe(job.id);
+    expect(res.body.isFlowNode).toBe(false);
+    expect(res.body.flowRoot.id).toBe(job.id);
+    expect(res.body.flowRoot.children).toHaveLength(0);
+  });
+});

--- a/packages/api/tests/api/job-handlers.spec.ts
+++ b/packages/api/tests/api/job-handlers.spec.ts
@@ -1,0 +1,87 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { Queue } from 'bullmq';
+import request from 'supertest';
+
+describe('Job/queue handlers', () => {
+  let serverAdapter: ExpressAdapter;
+  let queue: Queue;
+
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    queue = new Queue('HandlersTest', { connection });
+    await queue.obliterate({ force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await queue.obliterate({ force: true }).catch(() => {});
+    await queue.close();
+  });
+
+  function setupBoard() {
+    createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
+    return request(serverAdapter.getRouter());
+  }
+
+  it('promotes all delayed jobs', async () => {
+    await queue.add('a', {}, { delay: 60_000 });
+    await queue.add('b', {}, { delay: 60_000 });
+    expect(await queue.getDelayedCount()).toBe(2);
+    const agent = setupBoard();
+
+    await agent.put('/api/queues/HandlersTest/promote').expect(200);
+
+    expect(await queue.getDelayedCount()).toBe(0);
+  });
+
+  it('promotes a single delayed job', async () => {
+    const job = await queue.add('solo', {}, { delay: 60_000 });
+    const agent = setupBoard();
+
+    await agent.put(`/api/queues/HandlersTest/${job.id}/promote`).expect(204);
+
+    expect(await queue.getDelayedCount()).toBe(0);
+  });
+
+  it('cleans a given status, retaining jobs within the grace window', async () => {
+    await queue.add('d', {}, { delay: 60_000 });
+    expect(await queue.getDelayedCount()).toBe(1);
+    const agent = setupBoard();
+
+    // The handler's 5s grace retains this just-added job.
+    await agent.put('/api/queues/HandlersTest/clean/delayed').expect(200);
+
+    expect(await queue.getDelayedCount()).toBe(1);
+  });
+
+  it('updates a job\'s data', async () => {
+    const job = await queue.add('editable', { value: 'before' });
+    const agent = setupBoard();
+
+    await agent
+      .patch(`/api/queues/HandlersTest/${job.id}/update-data`)
+      .send({ jobData: { value: 'after' } })
+      .expect(200);
+
+    const updated = await queue.getJob(job.id as string);
+    expect(updated?.data).toEqual({ value: 'after' });
+  });
+
+  it('returns a job\'s logs', async () => {
+    const job = await queue.add('logged', {});
+    await queue.addJobLog(job.id as string, 'first line');
+    const agent = setupBoard();
+
+    const res = await agent
+      .get(`/api/queues/HandlersTest/${job.id}/logs`)
+      .expect(200);
+
+    expect(res.body).toEqual(['first line']);
+  });
+});

--- a/packages/api/tests/api/pause-resume-all.spec.ts
+++ b/packages/api/tests/api/pause-resume-all.spec.ts
@@ -1,0 +1,83 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { Queue } from 'bullmq';
+import request from 'supertest';
+
+describe('Pause/Resume all queues', () => {
+  let serverAdapter: ExpressAdapter;
+  let queueA: Queue;
+  let queueB: Queue;
+  let readOnlyQueue: Queue;
+  let hiddenQueue: Queue;
+
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    queueA = new Queue('AllA', { connection });
+    queueB = new Queue('AllB', { connection });
+    readOnlyQueue = new Queue('AllReadOnly', { connection });
+    hiddenQueue = new Queue('AllHidden', { connection });
+    await Promise.all(
+      [queueA, queueB, readOnlyQueue, hiddenQueue].map((q) =>
+        q.obliterate({ force: true }).catch(() => {})
+      )
+    );
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      [queueA, queueB, readOnlyQueue, hiddenQueue].map(async (q) => {
+        await q.obliterate({ force: true }).catch(() => {});
+        await q.close();
+      })
+    );
+  });
+
+  function setupBoard() {
+    const hiddenAdapter = new BullMQAdapter(hiddenQueue);
+    hiddenAdapter.setVisibilityGuard(() => false);
+    createBullBoard({
+      queues: [
+        new BullMQAdapter(queueA),
+        new BullMQAdapter(queueB),
+        new BullMQAdapter(readOnlyQueue, { readOnlyMode: true }),
+        hiddenAdapter,
+      ],
+      serverAdapter,
+    });
+    return request(serverAdapter.getRouter());
+  }
+
+  it('pauses every writable, visible queue and skips the rest', async () => {
+    await queueB.pause(); // already paused: exercises the isPaused short-circuit
+
+    const agent = setupBoard();
+
+    await agent.put('/api/queues/pause').expect(200);
+
+    expect(await queueA.isPaused()).toBe(true);
+    expect(await queueB.isPaused()).toBe(true);
+    expect(await readOnlyQueue.isPaused()).toBe(false); // read-only: filtered out
+    expect(await hiddenQueue.isPaused()).toBe(false); // not visible: skipped
+  });
+
+  it('resumes every writable, visible queue and skips the rest', async () => {
+    await queueA.pause(); // queueB stays unpaused: exercises the resume short-circuit
+
+    await readOnlyQueue.pause();
+    await hiddenQueue.pause();
+    const agent = setupBoard();
+
+    await agent.put('/api/queues/resume').expect(200);
+
+    expect(await queueA.isPaused()).toBe(false);
+    expect(await queueB.isPaused()).toBe(false);
+    expect(await readOnlyQueue.isPaused()).toBe(true); // read-only: filtered out
+    expect(await hiddenQueue.isPaused()).toBe(true); // not visible: skipped
+  });
+});


### PR DESCRIPTION
## What this does

`@bull-board/api` had no usable coverage number. The tests import `@bull-board/api` from `dist/`, but the coverage tool instruments `src/`, so `jest --coverage` reported 0% even with everything passing.

This adds a coverage-only jest config that maps `@bull-board/api*` to `src/`, then fills the biggest untested gaps with real integration tests (real Redis, BullMQ and Bull, no mocks).

| Metric | Before | After |
|---|---|---|
| Statements | 62.26% | 89.89% |
| Branches | 53.04% | 78.37% |
| Functions | 50.00% | 84.55% |
| Lines | 63.59% | 91.43% |
| Tests | 60 | 92 |

The new tests cover `providers/flow.ts` and the legacy `bull.ts` (both were 0%), the flow handler, the pause/resume-all handlers, and the entry-point and error handlers.

`yarn test` is untouched and keeps full type-checking. Only the coverage run relaxes it: the `src` vs `dist` `BaseAdapter` split trips type-checking, so the coverage config uses `isolatedModules`.

## Codecov

The wiring (`codecov.yml` plus the CI upload step) is already in this PR. Until a `CODECOV_TOKEN` secret exists the upload is non-blocking, so CI stays green and nothing changes. You can merge first and enable it later.

To turn it on:

1. Go to https://codecov.io and sign in with GitHub. It's free for open source. Authorize it for `felixmosh/bull-board`.
2. On the repo's Codecov settings page, copy the upload token.
3. In GitHub: **Settings → Secrets and variables → Actions → New repository secret**. Name it `CODECOV_TOKEN` and paste the value.

After that the next CI run uploads coverage, and the `api`-scoped gate starts posting a status check and a PR comment. It blocks if api coverage drops more than 1% from the base and asks for 75% on changed lines.

Two things worth knowing:

- Coverage uploads only from the Node 24.x job, so it runs once per CI rather than on every matrix leg.
- Codecov has mostly dropped tokenless uploads, so the secret is the reliable path rather than relying on the action picking it up automatically.
