### PR TITLE
feat: Next.js & Vercel support (examples, docs, regression tests)

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,0 +1,58 @@
+name: Next.js examples
+
+# Builds the Next.js examples and checks the @bull-board/ui assets get traced into
+# the serverless function (#444). Not run per-commit — building an example is overkill
+# and the adapter has its own tests. Manual, plus once post-merge when the example
+# changes. The library's own resolution is covered by ui-base-path.spec.ts in main CI.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'examples/with-nextjs-app/**'
+      - 'examples/with-nextjs-pages/**'
+      - 'scripts/check-nextjs-trace.mjs'
+      - '.github/workflows/nextjs.yml'
+
+jobs:
+  build-and-trace:
+    name: Build examples and check asset tracing
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Use Node 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+
+      - name: Build each example on each Next.js version and check tracing
+        run: |
+          set -uo pipefail
+          failures=()
+          for example in with-nextjs-app with-nextjs-pages; do
+            for next in 15 16; do
+              echo "::group::$example on next@$next"
+              if (
+                set -e
+                cd "examples/$example"
+                npm install --no-audit --no-fund
+                npm install --no-audit --no-fund "next@$next"
+                rm -rf .next
+                npm run build
+              ) && node scripts/check-nextjs-trace.mjs "examples/$example"; then
+                echo "PASS: $example on next@$next"
+              else
+                echo "FAIL: $example on next@$next"
+                failures+=("$example@next$next")
+              fi
+              echo "::endgroup::"
+            done
+          done
+          if [ ${#failures[@]} -ne 0 ]; then
+            echo "Failed: ${failures[*]}"
+            exit 1
+          fi

--- a/examples/with-nextjs-app/.gitignore
+++ b/examples/with-nextjs-app/.gitignore
@@ -1,0 +1,9 @@
+/node_modules
+/.next
+/out
+next-env.d.ts
+*.tsbuildinfo
+
+# lockfiles (examples are standalone demos)
+package-lock.json
+yarn.lock

--- a/examples/with-nextjs-app/README.md
+++ b/examples/with-nextjs-app/README.md
@@ -1,0 +1,25 @@
+# Next.js (App Router) example
+
+bull-board in a Next.js App Router app using the `@bull-board/hono` adapter, deployable to Vercel. The dashboard is one optional catch-all route handler: `app/api/queues/[[...path]]/route.ts`.
+
+## Run it
+
+```bash
+docker compose up -d        # Redis on localhost:6379
+yarn install
+yarn dev                    # http://localhost:3000
+yarn worker                 # second terminal, processes jobs
+```
+
+- Dashboard: http://localhost:3000/api/queues
+- Add a job: http://localhost:3000/api/add?title=Example
+
+The dashboard has no auth here. Add some before exposing it — see the [basic auth recipe](https://github.com/felixmosh/bull-board/blob/master/website/docs/recipes/basic-auth.md).
+
+## Deploying to Vercel
+
+`@bull-board/api` resolves the UI assets through `eval(require.resolve(...))`, which Next's file tracer can't follow — so the assets get dropped from the serverless function and you hit `Cannot find module '@bull-board/ui/package.json'`. [`next.config.js`](./next.config.js) fixes it with `serverExternalPackages` and `outputFileTracingIncludes`; the [Next.js & Vercel recipe](https://github.com/felixmosh/bull-board/blob/master/website/docs/recipes/nextjs.md) explains why. In a monorepo, also set `outputFileTracingRoot` (commented in the config).
+
+## Workers
+
+BullMQ workers can't run in serverless functions, so `worker.ts` runs as its own process — locally via `yarn worker`, in production on something that stays up. Vercel serves only the dashboard and the job-producing routes.

--- a/examples/with-nextjs-app/app/api/add/route.ts
+++ b/examples/with-nextjs-app/app/api/add/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { queue } from '@/lib/queue';
+
+export const runtime = 'nodejs';
+
+export async function GET(request: Request) {
+  const title = new URL(request.url).searchParams.get('title') ?? 'Example';
+  await queue.add('Add', { title });
+
+  return NextResponse.json({ ok: true });
+}

--- a/examples/with-nextjs-app/app/api/queues/[[...path]]/route.ts
+++ b/examples/with-nextjs-app/app/api/queues/[[...path]]/route.ts
@@ -1,0 +1,30 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { HonoAdapter } from '@bull-board/hono';
+import { serveStatic } from '@hono/node-server/serve-static';
+import { Hono } from 'hono';
+import { handle } from 'hono/vercel';
+import { queue } from '@/lib/queue';
+
+// bull-board reads UI assets from disk, so it can't run on the edge runtime.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const basePath = '/api/queues';
+
+const serverAdapter = new HonoAdapter(serveStatic);
+serverAdapter.setBasePath(basePath);
+
+createBullBoard({
+  queues: [new BullMQAdapter(queue)],
+  serverAdapter,
+});
+
+const app = new Hono();
+app.route(basePath, serverAdapter.registerPlugin());
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PUT = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);

--- a/examples/with-nextjs-app/app/layout.tsx
+++ b/examples/with-nextjs-app/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'bull-board + Next.js (App Router)',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/with-nextjs-app/app/page.tsx
+++ b/examples/with-nextjs-app/app/page.tsx
@@ -1,0 +1,18 @@
+export default function Home() {
+  return (
+    <main style={{ fontFamily: 'system-ui, sans-serif', padding: 40, lineHeight: 1.6 }}>
+      <h1>bull-board + Next.js (App Router)</h1>
+      <ul>
+        <li>
+          <a href="/api/queues">Open the dashboard</a>
+        </li>
+        <li>
+          <a href="/api/add?title=Example">Add a job</a>
+        </li>
+      </ul>
+      <p>
+        Run <code>yarn worker</code> in a second terminal to process the jobs you add.
+      </p>
+    </main>
+  );
+}

--- a/examples/with-nextjs-app/docker-compose.yml
+++ b/examples/with-nextjs-app/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'

--- a/examples/with-nextjs-app/lib/queue.ts
+++ b/examples/with-nextjs-app/lib/queue.ts
@@ -1,0 +1,19 @@
+import { Queue } from 'bullmq';
+
+export const redisOptions = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: Number(process.env.REDIS_PORT) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+};
+
+export const queueName = 'NextjsQueue';
+
+// Reuse one Queue across dev hot-reloads to avoid leaking Redis connections.
+const globalForQueue = globalThis as unknown as { bullQueue?: Queue };
+
+export const queue =
+  globalForQueue.bullQueue ?? new Queue(queueName, { connection: redisOptions });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForQueue.bullQueue = queue;
+}

--- a/examples/with-nextjs-app/next.config.js
+++ b/examples/with-nextjs-app/next.config.js
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  serverExternalPackages: ['@bull-board/api', '@bull-board/ui', '@bull-board/hono', 'bullmq'],
+
+  // The tracer can't follow @bull-board/api's eval(require.resolve), so ship the UI manually (#444).
+  outputFileTracingIncludes: {
+    '/api/queues/*': ['./node_modules/@bull-board/ui/dist/**/*'],
+  },
+
+  // Monorepo: set the tracing root to the workspace root.
+  // outputFileTracingRoot: require('path').join(__dirname, '../../'),
+};
+
+module.exports = nextConfig;

--- a/examples/with-nextjs-app/package.json
+++ b/examples/with-nextjs-app/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bull-board-nextjs-app-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Example of how to install bull-board in a Next.js App Router project (deployable to Vercel)",
+  "author": "felixmosh",
+  "license": "ISC",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "worker": "tsx watch worker.ts"
+  },
+  "dependencies": {
+    "@bull-board/api": "^8.0.0",
+    "@bull-board/hono": "^8.0.0",
+    "@hono/node-server": "^1.13.7",
+    "bullmq": "^5.56.4",
+    "hono": "^4.6.14",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/with-nextjs-app/tsconfig.json
+++ b/examples/with-nextjs-app/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-nextjs-app/worker.ts
+++ b/examples/with-nextjs-app/worker.ts
@@ -1,0 +1,25 @@
+import { Worker } from 'bullmq';
+import { queueName, redisOptions } from './lib/queue';
+
+// Workers can't run in serverless — run this as its own always-on process.
+
+const sleep = (t: number) => new Promise((resolve) => setTimeout(resolve, t * 1000));
+
+const worker = new Worker(
+  queueName,
+  async (job) => {
+    for (let i = 0; i <= 100; i++) {
+      await sleep(Math.random());
+      await job.updateProgress(i);
+      await job.log(`Processing job at interval ${i}`);
+
+      if (Math.random() * 200 < 1) throw new Error(`Random error ${i}`);
+    }
+
+    return { jobId: `This is the return value of job (${job.id})` };
+  },
+  { connection: redisOptions }
+);
+
+worker.on('ready', () => console.log('Worker is ready, processing jobs...'));
+worker.on('failed', (job, err) => console.error(`Job ${job?.id} failed:`, err.message));

--- a/examples/with-nextjs-pages/.gitignore
+++ b/examples/with-nextjs-pages/.gitignore
@@ -1,0 +1,9 @@
+/node_modules
+/.next
+/out
+next-env.d.ts
+*.tsbuildinfo
+
+# lockfiles (examples are standalone demos)
+package-lock.json
+yarn.lock

--- a/examples/with-nextjs-pages/README.md
+++ b/examples/with-nextjs-pages/README.md
@@ -1,0 +1,25 @@
+# Next.js (Pages Router) example
+
+bull-board in a Next.js Pages Router app using the `@bull-board/express` adapter, deployable to Vercel. The dashboard is one optional catch-all API route — `pages/api/queues/[[...path]].ts` — that hands the request to an Express router (`bodyParser` off, `externalResolver` on, so Express owns the response).
+
+## Run it
+
+```bash
+docker compose up -d        # Redis on localhost:6379
+yarn install
+yarn dev                    # http://localhost:3000
+yarn worker                 # second terminal, processes jobs
+```
+
+- Dashboard: http://localhost:3000/api/queues
+- Add a job: http://localhost:3000/api/add?title=Example
+
+The dashboard has no auth here. Add some before exposing it — see the [basic auth recipe](https://github.com/felixmosh/bull-board/blob/master/website/docs/recipes/basic-auth.md).
+
+## Deploying to Vercel
+
+`@bull-board/api` resolves the UI assets through `eval(require.resolve(...))`, which Next's file tracer can't follow — so the assets get dropped from the serverless function and you hit `Cannot find module '@bull-board/ui/package.json'`. [`next.config.js`](./next.config.js) fixes it with `serverExternalPackages` and `outputFileTracingIncludes`; the [Next.js & Vercel recipe](https://github.com/felixmosh/bull-board/blob/master/website/docs/recipes/nextjs.md) explains why. In a monorepo, also set `outputFileTracingRoot` (commented in the config).
+
+## Workers
+
+BullMQ workers can't run in serverless functions, so `worker.ts` runs as its own process — locally via `yarn worker`, in production on something that stays up. Vercel serves only the dashboard and the job-producing routes.

--- a/examples/with-nextjs-pages/docker-compose.yml
+++ b/examples/with-nextjs-pages/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'

--- a/examples/with-nextjs-pages/lib/queue.ts
+++ b/examples/with-nextjs-pages/lib/queue.ts
@@ -1,0 +1,19 @@
+import { Queue } from 'bullmq';
+
+export const redisOptions = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: Number(process.env.REDIS_PORT) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+};
+
+export const queueName = 'NextjsQueue';
+
+// Reuse one Queue across dev hot-reloads to avoid leaking Redis connections.
+const globalForQueue = globalThis as unknown as { bullQueue?: Queue };
+
+export const queue =
+  globalForQueue.bullQueue ?? new Queue(queueName, { connection: redisOptions });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForQueue.bullQueue = queue;
+}

--- a/examples/with-nextjs-pages/next.config.js
+++ b/examples/with-nextjs-pages/next.config.js
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  serverExternalPackages: ['@bull-board/api', '@bull-board/ui', '@bull-board/express', 'bullmq'],
+
+  // The tracer can't follow @bull-board/api's eval(require.resolve), so ship the UI manually (#444).
+  outputFileTracingIncludes: {
+    '/api/queues/*': ['./node_modules/@bull-board/ui/dist/**/*'],
+  },
+
+  // Monorepo: set the tracing root to the workspace root.
+  // outputFileTracingRoot: require('path').join(__dirname, '../../'),
+};
+
+module.exports = nextConfig;

--- a/examples/with-nextjs-pages/package.json
+++ b/examples/with-nextjs-pages/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bull-board-nextjs-pages-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Example of how to install bull-board in a Next.js Pages Router project (deployable to Vercel)",
+  "author": "felixmosh",
+  "license": "ISC",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "worker": "tsx watch worker.ts"
+  },
+  "dependencies": {
+    "@bull-board/api": "^8.0.0",
+    "@bull-board/express": "^8.0.0",
+    "bullmq": "^5.56.4",
+    "express": "^5.2.0",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/with-nextjs-pages/pages/api/add.ts
+++ b/examples/with-nextjs-pages/pages/api/add.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { queue } from '../../lib/queue';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const title = (req.query.title as string) ?? 'Example';
+  await queue.add('Add', { title });
+
+  res.json({ ok: true });
+}

--- a/examples/with-nextjs-pages/pages/api/queues/[[...path]].ts
+++ b/examples/with-nextjs-pages/pages/api/queues/[[...path]].ts
@@ -1,0 +1,31 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import express from 'express';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { queue } from '../../../lib/queue';
+
+const basePath = '/api/queues';
+
+const serverAdapter = new ExpressAdapter();
+serverAdapter.setBasePath(basePath);
+
+createBullBoard({
+  queues: [new BullMQAdapter(queue)],
+  serverAdapter,
+});
+
+const app = express();
+app.use(basePath, serverAdapter.getRouter());
+
+// Let Express handle body parsing and the response.
+export const config = {
+  api: {
+    bodyParser: false,
+    externalResolver: true,
+  },
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return (app as unknown as (req: NextApiRequest, res: NextApiResponse) => void)(req, res);
+}

--- a/examples/with-nextjs-pages/pages/index.tsx
+++ b/examples/with-nextjs-pages/pages/index.tsx
@@ -1,0 +1,18 @@
+export default function Home() {
+  return (
+    <main style={{ fontFamily: 'system-ui, sans-serif', padding: 40, lineHeight: 1.6 }}>
+      <h1>bull-board + Next.js (Pages Router)</h1>
+      <ul>
+        <li>
+          <a href="/api/queues">Open the dashboard</a>
+        </li>
+        <li>
+          <a href="/api/add?title=Example">Add a job</a>
+        </li>
+      </ul>
+      <p>
+        Run <code>yarn worker</code> in a second terminal to process the jobs you add.
+      </p>
+    </main>
+  );
+}

--- a/examples/with-nextjs-pages/tsconfig.json
+++ b/examples/with-nextjs-pages/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-nextjs-pages/worker.ts
+++ b/examples/with-nextjs-pages/worker.ts
@@ -1,0 +1,25 @@
+import { Worker } from 'bullmq';
+import { queueName, redisOptions } from './lib/queue';
+
+// Workers can't run in serverless — run this as its own always-on process.
+
+const sleep = (t: number) => new Promise((resolve) => setTimeout(resolve, t * 1000));
+
+const worker = new Worker(
+  queueName,
+  async (job) => {
+    for (let i = 0; i <= 100; i++) {
+      await sleep(Math.random());
+      await job.updateProgress(i);
+      await job.log(`Processing job at interval ${i}`);
+
+      if (Math.random() * 200 < 1) throw new Error(`Random error ${i}`);
+    }
+
+    return { jobId: `This is the return value of job (${job.id})` };
+  },
+  { connection: redisOptions }
+);
+
+worker.on('ready', () => console.log('Worker is ready, processing jobs...'));
+worker.on('failed', (job, err) => console.error(`Job ${job?.id} failed:`, err.message));

--- a/packages/api/tests/api/ui-base-path.spec.ts
+++ b/packages/api/tests/api/ui-base-path.spec.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { createBullBoard } from '@bull-board/api';
+import type { IServerAdapter } from '../../typings/app';
+
+// Guards the UI-path resolution the Next.js/Vercel integration depends on (#444).
+// createBullBoard doesn't return the path, so capture what it passes the adapter.
+function createCapturingAdapter() {
+  const captured: { viewsPath?: string; staticRoute?: string; staticPath?: string } = {};
+
+  const adapter: IServerAdapter = {
+    setQueues: () => adapter,
+    setViewsPath: (viewPath) => {
+      captured.viewsPath = viewPath;
+      return adapter;
+    },
+    setStaticPath: (staticsRoute, staticsPath) => {
+      captured.staticRoute = staticsRoute;
+      captured.staticPath = staticsPath;
+      return adapter;
+    },
+    setEntryRoute: () => adapter,
+    setErrorHandler: () => adapter,
+    setApiRoutes: () => adapter,
+    setUIConfig: () => adapter,
+  };
+
+  return { adapter, captured };
+}
+
+describe('UI base path resolution', () => {
+  it('resolves the bundled @bull-board/ui assets by default', () => {
+    const { adapter, captured } = createCapturingAdapter();
+
+    createBullBoard({ queues: [], serverAdapter: adapter });
+
+    expect(captured.viewsPath).toMatch(/dist$/);
+    expect(captured.staticPath).toMatch(/dist[\\/]static$/);
+
+    // #444: the paths must point at real files so a bundler can trace them.
+    expect(existsSync(path.join(captured.viewsPath as string, 'index.ejs'))).toBe(true);
+    expect(existsSync(captured.staticPath as string)).toBe(true);
+  });
+
+  it('honors an explicit options.uiBasePath override', () => {
+    const { adapter, captured } = createCapturingAdapter();
+    const uiBasePath = path.join('custom', 'ui', 'base');
+
+    createBullBoard({ queues: [], serverAdapter: adapter, options: { uiBasePath } });
+
+    expect(captured.viewsPath).toBe(path.join(uiBasePath, 'dist'));
+    expect(captured.staticPath).toBe(path.join(uiBasePath, 'dist/static'));
+  });
+});

--- a/scripts/check-nextjs-trace.mjs
+++ b/scripts/check-nextjs-trace.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- CLI script; stdout is its interface */
+// Asserts a built Next.js example ships the @bull-board/ui assets in its serverless
+// function (guards #444). Usage: node scripts/check-nextjs-trace.mjs <example-dir>
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const exampleDir = process.argv[2];
+if (!exampleDir) {
+  console.error('usage: node scripts/check-nextjs-trace.mjs <example-dir>');
+  process.exit(2);
+}
+
+const serverDir = join(exampleDir, '.next', 'server');
+
+let traceRel;
+try {
+  traceRel = readdirSync(serverDir, { recursive: true })
+    .map(String)
+    .find((f) => f.includes('queues') && f.endsWith('.nft.json'));
+} catch {
+  console.error(`Could not read ${serverDir} — did \`next build\` run?`);
+  process.exit(1);
+}
+
+if (!traceRel) {
+  console.error(`No queues route trace (*.nft.json) found under ${serverDir}.`);
+  process.exit(1);
+}
+
+const tracePath = join(serverDir, traceRel);
+const { files = [] } = JSON.parse(readFileSync(tracePath, 'utf8'));
+const uiFiles = files.filter((f) => f.includes('@bull-board/ui/dist'));
+const hasEntry = uiFiles.some((f) => f.endsWith('index.ejs'));
+const hasStatic = uiFiles.some((f) => f.includes('@bull-board/ui/dist/static/'));
+
+console.log(`Trace: ${tracePath}`);
+console.log(`Traced ${uiFiles.length} @bull-board/ui/dist files into the function.`);
+
+if (!hasEntry || !hasStatic) {
+  console.error(
+    '\nFAIL: the @bull-board/ui assets are missing from the serverless trace.\n' +
+      'This is the #444 regression. Check `outputFileTracingIncludes` (and, in a\n' +
+      'monorepo, `outputFileTracingRoot`) in the example\'s next.config.js, and\n' +
+      'whether a newer Next.js changed its file-tracing behavior.'
+  );
+  process.exit(1);
+}
+
+console.log('OK: index.ejs and static assets are bundled into the function.');

--- a/website/docs/recipes/index.md
+++ b/website/docs/recipes/index.md
@@ -16,5 +16,6 @@ Short, code-first walkthroughs for common setups. Each recipe is a page; each pa
 | Change or force the polling interval | [Polling interval](/recipes/change-polling-interval) | All |
 | Link jobs to your own admin pages | [External job URLs](/recipes/external-job-url) | All |
 | Set global concurrency from the UI | [Global concurrency](/recipes/global-concurrency) | All |
+| Deploy the dashboard on Next.js / Vercel | [Next.js & Vercel](/recipes/nextjs) | Hono, Express |
 
 Missing something? Open an issue. felixmosh is responsive, and good recipes become features.

--- a/website/docs/recipes/nextjs.md
+++ b/website/docs/recipes/nextjs.md
@@ -1,0 +1,132 @@
+# Next.js & Vercel
+
+There is no dedicated Next.js adapter — bull-board runs inside a Next.js API
+route using an existing adapter. Two runnable examples:
+
+- [`examples/with-nextjs-app`](https://github.com/felixmosh/bull-board/tree/master/examples/with-nextjs-app) — App Router, `@bull-board/hono` adapter.
+- [`examples/with-nextjs-pages`](https://github.com/felixmosh/bull-board/tree/master/examples/with-nextjs-pages) — Pages Router, `@bull-board/express` adapter.
+
+Both deploy to Vercel. The mounting differs by router; the Vercel-specific
+config is identical and is the part most people miss.
+
+## App Router (Hono)
+
+A single optional catch-all Route Handler at
+`app/api/queues/[[...path]]/route.ts`:
+
+```ts
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { HonoAdapter } from '@bull-board/hono';
+import { serveStatic } from '@hono/node-server/serve-static';
+import { Hono } from 'hono';
+import { handle } from 'hono/vercel';
+import { queue } from '@/lib/queue';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const basePath = '/api/queues';
+const serverAdapter = new HonoAdapter(serveStatic);
+serverAdapter.setBasePath(basePath);
+
+createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
+
+const app = new Hono();
+app.route(basePath, serverAdapter.registerPlugin());
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PUT = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
+```
+
+## Pages Router (Express)
+
+A single optional catch-all API route at `pages/api/queues/[[...path]].ts` that
+delegates to an Express router. Disable `bodyParser` and enable
+`externalResolver` so Express owns the response:
+
+```ts
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import express from 'express';
+import { queue } from '../../../lib/queue';
+
+const basePath = '/api/queues';
+const serverAdapter = new ExpressAdapter();
+serverAdapter.setBasePath(basePath);
+
+createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
+
+const app = express();
+app.use(basePath, serverAdapter.getRouter());
+
+export const config = { api: { bodyParser: false, externalResolver: true } };
+
+export default function handler(req, res) {
+  return app(req, res);
+}
+```
+
+## The Vercel fix (both routers)
+
+`@bull-board/api` finds the UI's compiled assets with
+`eval(require.resolve('@bull-board/ui/package.json'))`. The `eval` deliberately
+hides the require from bundlers — and that includes Next.js's static file tracer
+([`@vercel/nft`](https://github.com/vercel/nft)). On Vercel the UI files are
+never copied into the function, so you get:
+
+```
+Error: Cannot find module '@bull-board/ui/package.json'
+```
+
+Fix it in `next.config.js`:
+
+```js
+/** @type {import('next').NextConfig} */
+module.exports = {
+  // Resolve bull-board and bullmq from node_modules at runtime, not from the bundle.
+  serverExternalPackages: ['@bull-board/api', '@bull-board/ui', 'bullmq'],
+
+  // Force the compiled UI into the serverless function (the tracer can't see the eval).
+  outputFileTracingIncludes: {
+    '/api/queues/*': ['./node_modules/@bull-board/ui/dist/**/*'],
+  },
+};
+```
+
+::: warning Monorepo
+If `node_modules` is hoisted to a workspace root (e.g. `apps/web` in a Turborepo),
+add `outputFileTracingRoot: path.join(__dirname, '../../')` so the included paths
+resolve from the right place.
+:::
+
+`serverExternalPackages` and `outputFileTracingIncludes` are stable top-level
+options in **Next.js 15+** (in 13/14 they lived under `experimental`).
+
+### Alternative: `uiBasePath`
+
+Instead of the trace config you can tell bull-board where the UI lives directly,
+skipping the `eval(require.resolve(...))` entirely:
+
+```ts
+createBullBoard({
+  queues,
+  serverAdapter,
+  options: { uiBasePath: 'node_modules/@bull-board/ui' },
+});
+```
+
+You still need `outputFileTracingIncludes` so the files are actually deployed —
+this only changes how the path is resolved, not whether the files are present.
+
+## Workers
+
+BullMQ workers are long-running and **cannot** run inside serverless functions.
+Next.js (the dashboard and any job-producing routes) deploys to Vercel; the
+worker runs as a separate always-on process — a container, a VM, or a dedicated
+worker service. Both examples ship a standalone `worker.ts` for local
+processing.

--- a/website/docs/server-adapters/index.md
+++ b/website/docs/server-adapters/index.md
@@ -24,6 +24,10 @@ One server adapter per framework. The core `@bull-board/api` package is shared. 
 
 No dedicated Sails adapter. Sails runs on Express, so use `@bull-board/express` inside a Sails controller. Working example: [`examples/with-sails`](https://github.com/felixmosh/bull-board/tree/master/examples/with-sails).
 
+## Next.js
+
+No dedicated Next.js adapter. Mount bull-board inside a Next.js API route using the Hono adapter (App Router) or the Express adapter (Pages Router). The Vercel deployment needs a small bit of `next.config.js` — see [Next.js & Vercel](/recipes/nextjs) and the [`with-nextjs-app`](https://github.com/felixmosh/bull-board/tree/master/examples/with-nextjs-app) / [`with-nextjs-pages`](https://github.com/felixmosh/bull-board/tree/master/examples/with-nextjs-pages) examples.
+
 ## Shape
 
 Most adapters follow the same three steps:

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -101,6 +101,7 @@ export default defineConfig({
             { text: "Polling interval", link: "/recipes/change-polling-interval" },
             { text: "External job URLs", link: "/recipes/external-job-url" },
             { text: "Global concurrency", link: "/recipes/global-concurrency" },
+            { text: "Next.js & Vercel", link: "/recipes/nextjs" },
           ],
         },
         {


### PR DESCRIPTION
Closes #444.

## The problem

Deploying bull-board inside Next.js on Vercel dies at runtime with:

```
Error: Cannot find module '@bull-board/ui/package.json'
```

`@bull-board/api` finds the UI assets with `eval(require.resolve('@bull-board/ui/package.json'))`. The `eval` hides that require from bundlers, and Next's file tracer (`@vercel/nft`) is one of them, so the UI never gets copied into the serverless function. Open since 2022 with only workarounds in the thread (#124, #310, #485 are the same root cause).

## The fix

No library change needed. Next 15+ has the config to deal with this, and `uiBasePath` already exists as an escape hatch. Two settings in `next.config.js`:

- `serverExternalPackages` — keep bull-board and bullmq out of the bundle so they resolve from `node_modules` at runtime.
- `outputFileTracingIncludes` — force `@bull-board/ui/dist` into the function, since the tracer can't follow the `eval`.

This documents the workaround rather than removing the need for it. The root cause is the `eval`; making the tracer able to follow it (package `exports`, or a resolvable UI path) would drop the config requirement entirely, but that touches how every adapter resolves the UI and is a bigger, riskier change. Happy to open a follow-up for it.

## What's in here

- `examples/with-nextjs-app` — App Router, Hono adapter.
- `examples/with-nextjs-pages` — Pages Router, Express adapter (the #124 pattern, made deployable). Both ship a worker, a docker-compose for Redis, and a README.
- A docs recipe (Next.js & Vercel), linked from the recipes and server-adapters pages.
- Tests. This question keeps resurfacing (the issue has sat open since 2022 with a recurring trickle of reports), so it's worth guarding against regressions:
  - `ui-base-path.spec.ts` — a unit test (no Redis) that the default UI path resolves to real files and that `uiBasePath` overrides it.
  - `scripts/check-nextjs-trace.mjs` plus a workflow that builds each example on Next 15 and 16 and asserts the UI assets land in the function's `.nft.json`. This catches the actual bug. `next dev` doesn't, because dev resolves straight from `node_modules` and stays green even when the deployed build is broken.

## What I checked

Both examples build and serve on Node 22 with Next 15 and 16 against a local Redis: dashboard, static assets, API, adding jobs. Pull `outputFileTracingIncludes` back out and the trace check drops to 0 files and fails, which is the whole point of having it.

## Notes

- Next 15+ only (these keys lived under `experimental` in 13/14).
- Workers can't run in serverless, so both examples run `worker.ts` as a separate process.
- The example builds use the published `@bull-board` packages, so they cover Next-version drift; the unit test covers the library's own path resolution against working-tree code.
