### PR TITLE
feat(nestjs): add basePath option to decouple UI base path from mount route

### DIFF
--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -61,6 +61,7 @@ The following options are available.
 - `adapter` The routing adapter to be used, either the Express Adapter or Fastify Adapter provided by bull-board.
 - `boardOptions` options as provided by the bull-board package, such as `uiBasePath` and `uiConfig`
 - `middleware` optional middleware for the express adapter (e.g. basic authentication)
+- `basePath` the public base path the UI uses for assets, routing and API calls. Defaults to `route`. Set it when a reverse proxy / gateway rewrites the path, so the public URL differs from the mounted `route`.
 
 
 ### Express Authentication

--- a/packages/nestjs/src/bull-board.root-module.ts
+++ b/packages/nestjs/src/bull-board.root-module.ts
@@ -48,7 +48,10 @@ export class BullBoardRootModule implements NestModule {
       ? addForwardSlash(this.options.route)
       : addForwardSlash(this.applicationConfig.getGlobalPrefix() + this.options.route);
 
-    this.adapter.setBasePath(prefix);
+    const basePath =
+      this.options.basePath != null ? addForwardSlash(this.options.basePath) : prefix;
+
+    this.adapter.setBasePath(basePath);
 
     if (isExpressAdapter(this.adapter)) {
       return consumer

--- a/packages/nestjs/src/bull-board.types.ts
+++ b/packages/nestjs/src/bull-board.types.ts
@@ -14,6 +14,7 @@ export type BullBoardModuleOptions = {
   adapter: { new (): BullBoardServerAdapter };
   boardOptions?: BoardOptions;
   middleware?: any;
+  basePath?: string;
 };
 
 export type BullBoardModuleAsyncOptions = {

--- a/packages/nestjs/tests/base-path.spec.ts
+++ b/packages/nestjs/tests/base-path.spec.ts
@@ -1,0 +1,57 @@
+import 'reflect-metadata';
+import { ExpressAdapter as BullBoardExpressAdapter } from '@bull-board/express';
+import { uiFixtureBasePath } from '@bull-board/test-utils';
+import { INestApplication } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { ExpressAdapter } from '@nestjs/platform-express';
+import { json } from 'express';
+import request from 'supertest';
+import { BullBoardModule } from '../src';
+
+async function bootBoard(options: { route: string; basePath?: string }): Promise<INestApplication> {
+  const appModule = BullBoardModule.forRoot({
+    route: options.route,
+    basePath: options.basePath,
+    adapter: BullBoardExpressAdapter,
+    boardOptions: { uiBasePath: uiFixtureBasePath },
+    middleware: json(),
+  });
+
+  const app = await NestFactory.create(appModule, new ExpressAdapter(), { logger: false });
+  await app.init();
+  return app;
+}
+
+describe('BullBoardModule basePath option', () => {
+  it('injects options.basePath into the UI while still serving at the mount route', async () => {
+    const app = await bootBoard({ route: '/queues', basePath: '/public/queues' });
+
+    const entry = await request(app.getHttpServer()).get('/queues/');
+    expect(entry.status).toBe(200);
+    expect(entry.text).toContain('<base href="/public/queues/" />');
+
+    // The route the app listens on is unchanged; assets are still served there.
+    const asset = await request(app.getHttpServer()).get('/queues/static/test-asset.txt');
+    expect(asset.status).toBe(200);
+
+    await app.close();
+  });
+
+  it('normalizes a basePath that is missing a leading slash', async () => {
+    const app = await bootBoard({ route: '/queues', basePath: 'public/queues' });
+
+    const entry = await request(app.getHttpServer()).get('/queues/');
+    expect(entry.text).toContain('<base href="/public/queues/" />');
+
+    await app.close();
+  });
+
+  it('falls back to the mount route when basePath is not provided', async () => {
+    const app = await bootBoard({ route: '/queues' });
+
+    const entry = await request(app.getHttpServer()).get('/queues/');
+    expect(entry.text).toContain('<base href="/queues/" />');
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## What

Add an optional `basePath` to `BullBoardModule.forRoot(...)` (and `forRootAsync`) for `@bull-board/nestjs`. It overrides the base path injected into the dashboard UI (used for assets, the client-side router and API calls) **without** changing the route the app mounts on.

```ts
BullBoardModule.forRoot({
  route: '/queues',          // where Nest mounts/serves the board
  basePath: '/admin/queues', // public path the browser sees
  adapter: ExpressAdapter,
});
```

When omitted, behavior is unchanged (`basePath` defaults to `route`, prefixed with the app's global prefix), so this is fully backward compatible.

## Why

Today the wrapper derives the UI base path from the mount route:

```ts
const prefix = addForwardSlash(this.applicationConfig.getGlobalPrefix() + this.options.route);
this.adapter.setBasePath(prefix);
```

There is no way to set the base path independently of the route. That breaks when the board sits behind a reverse proxy / API gateway that **rewrites the path** — the public URL differs from the route the app listens on:

- Gateway exposes the board at `https://host/admin/queues` and strips `/admin` before forwarding, so the app must mount at `/queues`.
- But the UI then emits `<base href="/queues/">`, so the browser requests assets at `/queues/static/...` instead of `/admin/queues/static/...` → 404 → the dashboard hangs on "Loading".

This is a recurring report (e.g. #428, #788). The raw adapters already expose `setBasePath()` for exactly this, but the NestJS wrapper calls it internally and gives no way to override. This PR exposes it as an option:

- `route: '/queues'` → app serves and assets are served here (after the gateway strips the prefix).
- `basePath: '/admin/queues'` → UI references its assets/API at the public path; the gateway strips `/admin` back to `/queues` where the app serves them.

The fastify mount prefix is intentionally left on the computed `route`-based prefix; only the UI base path uses the override.

## Tests

Added `packages/nestjs/tests/base-path.spec.ts`:
- injects `options.basePath` into the UI while still serving at the mount route,
- normalizes a `basePath` missing a leading slash,
- falls back to the mount route when `basePath` is not provided.

All `@bull-board/nestjs` tests pass (11/11), lint clean.
