### PR TITLE
fix(ui): wrap long values in CollapsibleJSON to prevent overflow

### DIFF
--- a/packages/ui/src/components/CollapsibleJSON/CollapsibleJSON.module.css
+++ b/packages/ui/src/components/CollapsibleJSON/CollapsibleJSON.module.css
@@ -67,10 +67,12 @@
 
 .stringValue {
   color: var(--hl-string);
+  overflow-wrap: anywhere;
 }
 
 .numberValue {
   color: var(--hl-number);
+  overflow-wrap: anywhere;
 }
 
 .booleanValue {
@@ -84,6 +86,7 @@
 
 .otherValue {
   color: var(--text-color);
+  overflow-wrap: anywhere;
 }
 
 .copyBtn {

--- a/packages/ui/src/components/CollapsibleJSON/CollapsibleJSON.module.css
+++ b/packages/ui/src/components/CollapsibleJSON/CollapsibleJSON.module.css
@@ -38,11 +38,11 @@
 }
 
 .expandIcon::after {
-  content: '\25B8';
+  content: "\25B8";
 }
 
 .collapseIcon::after {
-  content: '\25BE';
+  content: "\25BE";
 }
 
 .collapsedContent {
@@ -52,7 +52,7 @@
 }
 
 .collapsedContent::after {
-  content: '...';
+  content: "...";
   font-size: 0.8em;
 }
 
@@ -65,14 +65,16 @@
   color: var(--card-text-secondary-color);
 }
 
+.value {
+  overflow-wrap: anywhere;
+}
+
 .stringValue {
   color: var(--hl-string);
-  overflow-wrap: anywhere;
 }
 
 .numberValue {
   color: var(--hl-number);
-  overflow-wrap: anywhere;
 }
 
 .booleanValue {
@@ -86,7 +88,6 @@
 
 .otherValue {
   color: var(--text-color);
-  overflow-wrap: anywhere;
 }
 
 .copyBtn {
@@ -115,4 +116,3 @@
     opacity: 0.5;
   }
 }
-

--- a/packages/ui/src/components/CollapsibleJSON/CollapsibleJSON.tsx
+++ b/packages/ui/src/components/CollapsibleJSON/CollapsibleJSON.tsx
@@ -1,3 +1,4 @@
+import cn from 'clsx';
 import React, { useCallback, useMemo } from 'react';
 import { JsonView, collapseAllNested } from 'react-json-view-lite';
 import 'react-json-view-lite/dist/index.css';
@@ -18,12 +19,12 @@ const customStyles = {
   label: s.label,
   clickableLabel: s.label,
   punctuation: s.punctuation,
-  stringValue: s.stringValue,
-  numberValue: s.numberValue,
-  booleanValue: s.booleanValue,
-  nullValue: s.nullValue,
-  undefinedValue: s.undefinedValue,
-  otherValue: s.otherValue,
+  stringValue: cn(s.stringValue, s.value),
+  numberValue: cn(s.numberValue, s.value),
+  booleanValue: cn(s.booleanValue, s.value),
+  nullValue: cn(s.nullValue, s.value),
+  undefinedValue: cn(s.undefinedValue, s.value),
+  otherValue: cn(s.otherValue, s.value),
   noQuotesForStringValues: false,
 };
 


### PR DESCRIPTION
## What

Long unbreakable string values (JWTs, IDs, tokens…) in the `CollapsibleJSON` job-data viewer overflowed their container instead of wrapping.

## Fix

Added `overflow-wrap: anywhere` to the value classes (`stringValue`, `numberValue`, `otherValue`) in `CollapsibleJSON.module.css`.

## Before

<img width="1451" height="788" alt="image" src="https://github.com/user-attachments/assets/8d153af7-403f-4e92-b77f-32d72f48bf06" />

## After

<img width="1451" height="788" alt="image" src="https://github.com/user-attachments/assets/1d071bbd-eb8c-4dd5-a327-8a1d562ef447" />

