### PR TITLE
fix(ui): improve autoscroll behavior in JobLogs component

### DIFF
--- a/packages/ui/src/components/JobCard/Details/DetailsContent/JobLogs/JobLogs.tsx
+++ b/packages/ui/src/components/JobCard/Details/DetailsContent/JobLogs/JobLogs.tsx
@@ -66,8 +66,9 @@ export const JobLogs = ({ actions, job }: JobLogsProps) => {
       const logs = await actions.getJobLogs();
       setLogs(formatLogs(logs));
       requestAnimationFrame(() => {
-        logsContainer.current?.scrollTo({
-          top: logsContainer.current?.scrollHeight,
+        const scrollableElement = logsContainer.current?.querySelector(`.${s.preWrapper}`);
+        scrollableElement?.scrollTo({
+          top: scrollableElement.scrollHeight,
           behavior: 'smooth',
         });
       });


### PR DESCRIPTION
## Fix auto-scroll in job logs panel

### Summary
Fixes the play button auto-scroll feature that stopped working in v6.15.0.

### Solution
The `scrollTo()` call was targeting the outer container which has `overflow: hidden`, making it non-scrollable. Changed to use `querySelector` to target the inner `.preWrapper` element that actually has `overflow: auto`:

```typescript
const scrollableElement = logsContainer.current?.querySelector(`.${s.preWrapper}`);
scrollableElement?.scrollTo({
  top: scrollableElement.scrollHeight,
  behavior: 'smooth',
});
```

The view now correctly scrolls to the bottom when live logs are enabled.

---