### PR TITLE
fix(nestjs): support queues with the same name but different prefix

### DIFF
--- a/packages/api/tests/api/same-name-different-prefix.spec.ts
+++ b/packages/api/tests/api/same-name-different-prefix.spec.ts
@@ -1,0 +1,52 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { Queue } from 'bullmq';
+import request from 'supertest';
+
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: +(process.env.REDIS_PORT || 6379),
+};
+
+// Regression test for https://github.com/felixmosh/bull-board/issues/1229
+describe('queues with the same name but a different prefix', () => {
+  let serverAdapter: ExpressAdapter;
+  const queueList: Queue[] = [];
+
+  beforeEach(() => {
+    serverAdapter = new ExpressAdapter();
+    queueList.length = 0;
+  });
+
+  afterEach(async () => {
+    for (const queue of queueList) {
+      await queue.close();
+    }
+  });
+
+  it('keeps both queues as distinct board entries', async () => {
+    const emailsTenantA = new Queue('emails', { connection, prefix: 'tenant-a' });
+    const emailsTenantB = new Queue('emails', { connection, prefix: 'tenant-b' });
+    queueList.push(emailsTenantA, emailsTenantB);
+
+    createBullBoard({
+      queues: [
+        new BullMQAdapter(emailsTenantA, { prefix: 'tenant-a:' }),
+        new BullMQAdapter(emailsTenantB, { prefix: 'tenant-b:' }),
+      ],
+      serverAdapter,
+    });
+
+    await request(serverAdapter.getRouter())
+      .get('/api/queues')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then((res) => {
+        const respQueues = JSON.parse(res.text).queues as Array<{ name: string }>;
+        const names = respQueues.map((queue) => queue.name).sort();
+
+        expect(names).toEqual(['tenant-a:emails', 'tenant-b:emails']);
+      });
+  });
+});

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -144,9 +144,31 @@ export class FeatureModule {}
 
 The `forFeature` method registers the given queues to the bull-board instance.
 The following options are available.
-- `name` the queue name to register
+- `name` the queue name to resolve from the Nest DI container.
+- `queue` a queue instance to register directly, instead of resolving it by `name`.
 - `adapter` either `BullAdapter` or `BullMQAdapter` depending on which package you use.
 - `options` queue adapter options as found in the bull-board package, such as `readOnlyMode`, `description` etc.
+
+Provide either `name` or `queue`.
+
+### Registering queue instances directly
+
+`@nestjs/bullmq` generates the DI token for a queue from its `name` only, ignoring the
+`prefix`. Two queues that share a name but use different prefixes therefore collapse onto a
+single DI token, and a `name`-based lookup cannot tell them apart. Pass the queue instances
+directly via `queue` to register them as distinct board entries:
+
+```typescript
+@Module({
+  imports: [
+    BullBoardModule.forFeature(
+      { queue: emailsTenantA, adapter: BullMQAdapter, options: { prefix: 'tenant-a:' } },
+      { queue: emailsTenantB, adapter: BullMQAdapter, options: { prefix: 'tenant-b:' } },
+    ),
+  ],
+})
+export class FeatureModule {}
+```
 
 ##  Using the bull-board instance in your controllers and/or services.
 The created bull-board instance is available via the `@InjectBullBoard()` decorator.

--- a/packages/nestjs/src/bull-board.feature-module.ts
+++ b/packages/nestjs/src/bull-board.feature-module.ts
@@ -15,7 +15,9 @@ export class BullBoardFeatureModule implements OnModuleInit {
 
   onModuleInit(): any {
     for (const queueOption of this.queues) {
-      const queue = this.moduleRef.get<Queue>(getQueueToken(queueOption.name), { strict: false });
+      const queue =
+        queueOption.queue ??
+        this.moduleRef.get<Queue>(getQueueToken(queueOption.name), { strict: false });
       const queueAdapter = new queueOption.adapter(queue, queueOption.options);
       this.board.addQueue(queueAdapter);
     }

--- a/packages/nestjs/src/bull-board.types.ts
+++ b/packages/nestjs/src/bull-board.types.ts
@@ -22,11 +22,32 @@ export type BullBoardModuleAsyncOptions = {
   inject?: Array<InjectionToken | OptionalFactoryDependency>;
 };
 
-export type BullBoardQueueOptions = {
-  name: string;
+type BullBoardQueueCommonOptions = {
   adapter: { new (queue: any, options?: Partial<QueueAdapterOptions>): BaseAdapter };
   options?: Partial<QueueAdapterOptions>;
 };
+
+export type BullBoardQueueOptions = BullBoardQueueCommonOptions &
+  (
+    | {
+        /**
+         * The queue name to resolve from the Nest DI container (via `getQueueToken`).
+         */
+        name: string;
+        queue?: undefined;
+      }
+    | {
+        /**
+         * A queue instance to register directly, bypassing the DI container lookup.
+         *
+         * Use this when the name-based lookup cannot disambiguate the queue — e.g. two
+         * queues sharing the same name but using different prefixes, which `@nestjs/bullmq`
+         * collapses onto a single DI token.
+         */
+        queue: unknown;
+        name?: string;
+      }
+  );
 
 //create our own types with the needed functions, so we don't need to include express/fastify libraries here.
 export type BullBoardServerAdapter = IServerAdapter & { setBasePath(path: string): any };

--- a/packages/nestjs/tests/same-name-prefix.spec.ts
+++ b/packages/nestjs/tests/same-name-prefix.spec.ts
@@ -1,0 +1,87 @@
+import 'reflect-metadata';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter as BullBoardExpressAdapter } from '@bull-board/express';
+import { uiFixtureBasePath } from '@bull-board/test-utils';
+import { BullModule } from '@nestjs/bullmq';
+import { INestApplication, Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { ExpressAdapter } from '@nestjs/platform-express';
+import { Queue } from 'bullmq';
+import request from 'supertest';
+import { BullBoardModule } from '../src';
+
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: +(process.env.REDIS_PORT || 6379),
+};
+
+describe('forFeature with queue instances (same name, different prefix)', () => {
+  const queues: Queue[] = [];
+  let app: INestApplication | undefined;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+      app = undefined;
+    }
+    await Promise.all(queues.map((queue) => queue.close()));
+    queues.length = 0;
+  });
+
+  it('registers both queues as distinct board entries', async () => {
+    const emailsA = new Queue('emails', { connection, prefix: 'tenant-a' });
+    const emailsB = new Queue('emails', { connection, prefix: 'tenant-b' });
+    queues.push(emailsA, emailsB);
+
+    @Module({
+      imports: [
+        BullBoardModule.forRoot({
+          route: '/queues',
+          adapter: BullBoardExpressAdapter,
+          boardOptions: { uiBasePath: uiFixtureBasePath },
+        }),
+        BullBoardModule.forFeature(
+          { queue: emailsA, adapter: BullMQAdapter, options: { prefix: 'tenant-a:' } },
+          { queue: emailsB, adapter: BullMQAdapter, options: { prefix: 'tenant-b:' } }
+        ),
+      ],
+    })
+    class AppModule {}
+
+    app = await NestFactory.create(AppModule, new ExpressAdapter(), { logger: false });
+    await app.init();
+
+    const res = await request(app.getHttpServer()).get('/queues/api/queues').expect(200);
+    const names = (JSON.parse(res.text).queues as Array<{ name: string }>)
+      .map((queue) => queue.name)
+      .sort();
+
+    expect(names).toEqual(['tenant-a:emails', 'tenant-b:emails']);
+  });
+
+  it('still resolves a queue from the DI container when only a name is given', async () => {
+    @Module({
+      imports: [
+        BullModule.forRoot({ connection }),
+        BullModule.registerQueue({ name: 'reports' }),
+        BullBoardModule.forRoot({
+          route: '/queues',
+          adapter: BullBoardExpressAdapter,
+          boardOptions: { uiBasePath: uiFixtureBasePath },
+        }),
+        BullBoardModule.forFeature({ name: 'reports', adapter: BullMQAdapter }),
+      ],
+    })
+    class AppModule {}
+
+    app = await NestFactory.create(AppModule, new ExpressAdapter(), { logger: false });
+    await app.init();
+
+    const res = await request(app.getHttpServer()).get('/queues/api/queues').expect(200);
+    const names = (JSON.parse(res.text).queues as Array<{ name: string }>).map(
+      (queue) => queue.name
+    );
+
+    expect(names).toEqual(['reports']);
+  });
+});

--- a/website/docs/server-adapters/nestjs.md
+++ b/website/docs/server-adapters/nestjs.md
@@ -69,9 +69,10 @@ export class FeatureModule {}
 - `boardOptions`: forwarded to `createBullBoard` (e.g. `uiConfig`, `uiBasePath`).
 - `middleware`: optional Express/Fastify middleware (basic auth, etc.).
 
-`forFeature()` options:
+`forFeature()` options (pass either `name` or `queue`):
 
-- `name`: queue name registered with `BullModule.registerQueue`.
+- `name`: queue name registered with `BullModule.registerQueue`. The module resolves the instance from Nest's DI container.
+- `queue`: a queue instance to register directly, instead of resolving it by `name`. See [Queues with the same name](#queues-with-the-same-name) below.
 - `adapter`: `BullMQAdapter` or `BullAdapter`.
 - `options`: queue adapter options like `readOnlyMode` or `description`.
 
@@ -83,6 +84,26 @@ BullBoardModule.forFeature(
   { name: 'billing', adapter: BullMQAdapter },
 );
 ```
+
+### Queues with the same name
+
+`@nestjs/bullmq` builds a queue's DI token from its `name` alone — the `prefix` is not part of it. So if you run the same queue name under two prefixes (a common multi-tenant setup), both share one DI token and a `name` lookup can only ever return one of them. Registering both by `name` makes one queue shadow the other on the board.
+
+Pass the instances directly via `queue` instead. Hold the queues somewhere you control — a provider, a service, wherever you created them — and hand them to `forFeature`:
+
+```ts
+@Module({
+  imports: [
+    BullBoardModule.forFeature(
+      { queue: emailsTenantA, adapter: BullMQAdapter, options: { prefix: 'tenant-a:' } },
+      { queue: emailsTenantB, adapter: BullMQAdapter, options: { prefix: 'tenant-b:' } },
+    ),
+  ],
+})
+export class FeatureModule {}
+```
+
+The board keys entries by `prefix` + name, so the two show up as `tenant-a:emails` and `tenant-b:emails`. Set each adapter's `prefix` to match the queue's own prefix so the labels line up.
 
 There's also `BullBoardModule.forRootAsync()` which accepts `useFactory`, `imports`, `inject` for dynamic config.
 


### PR DESCRIPTION
Fixes #1229

## The problem

Register two queues with the same `name` but a different `prefix` (a normal multi-tenant setup) and only one of them shows real data on the board. The other is a ghost.

It comes down to the lookup. `BullBoardFeatureModule` resolves each queue from Nest's DI container by name, and `@nestjs/bullmq` builds that token from the name alone, ignoring `prefix`. Two same-named queues collide on one token, so the lookup hands back the same instance twice. You can't fix that in the lookup; the second instance never gets a token of its own.

The `@bull-board/api` core is fine, by the way. It keys queues by `getName()` (`prefix` + name), so every other adapter already handles this. NestJS was the odd one out because it goes through DI.

## The fix

`forFeature` now takes a queue instance directly via a new `queue` field, skipping the DI lookup. `BullBoardQueueOptions` is now a union: pass `name` (DI lookup, same as before) or `queue` (your own instance). Nothing existing breaks.

## Tests

- `packages/api`: a regression test pinning the core behavior. Same name, different prefix, both stay distinct. Covers every non-Nest adapter in one shot.
- `packages/nestjs`: one test for the new `queue` path (both queues register separately), one for the old `name` path so it can't regress.

Docs updated too: `packages/nestjs/README.md` and the NestJS adapter page on the docs site.
