### PR TITLE
docs: harden recipes and fix queue-adapter option docs

### DIFF
--- a/website/docs/configuration/production-checklist.md
+++ b/website/docs/configuration/production-checklist.md
@@ -43,3 +43,7 @@ The dashboard talks to your Bull / BullMQ instances. Mismatched versions across 
 ## Logs
 
 Workers that call `job.log()` will have their lines visible in the dashboard under each job's Logs tab. If you're wondering "what did this job do before it failed", that's the answer. See [Job logs and flows](/recipes/job-logs-and-flows).
+
+## Alerting
+
+The dashboard won't page you. It only shows state while a tab is open. Wire failure alerts to BullMQ's own events, not to bull-board. See [Alerting on failed jobs](/recipes/alerting).

--- a/website/docs/guide/ai-agent-setup.md
+++ b/website/docs/guide/ai-agent-setup.md
@@ -1,0 +1,46 @@
+# Set up with an AI agent
+
+If you work with a coding agent (Claude Code, Cursor, Copilot, Windsurf, whatever), you don't have to hand-wire bull-board. Paste the prompt below and let the agent do the mechanical part: install the packages, mount the adapter, match the base path. Then read the diff.
+
+## Copy this prompt
+
+```text
+Add bull-board to my app so I can inspect my Bull/BullMQ queues in a browser.
+
+Use the current docs at https://felixmosh.github.io/bull-board/llms.txt as the
+source of truth. Don't rely on memory, the API has changed across versions.
+
+Requirements:
+- Detect my HTTP framework (Express, Fastify, NestJS, Koa, Hapi, Hono, H3,
+  Elysia, or Bun) and install @bull-board/api plus the matching @bull-board/<framework> adapter.
+- Detect whether I use Bull or BullMQ and wrap each existing queue in the right
+  queue adapter (BullMQAdapter or BullAdapter). Reuse my existing queue
+  instances and Redis connection, don't create new ones.
+- Create the server adapter, call setBasePath('/admin/queues'), pass my queues to
+  createBullBoard, and mount the router at the SAME path ('/admin/queues'). The
+  base path and the mount path must match exactly or the assets 404.
+- Do not expose it unauthenticated. If I have auth middleware, put the dashboard
+  behind it; if I don't, add a TODO and tell me, don't invent credentials.
+- Show me the diff and the URL to open. Don't add options that aren't in the docs.
+```
+
+Swap the base path (`/admin/queues`) for wherever you want the dashboard to live. The agent should handle the rest, including the one thing people get wrong by hand: keeping `setBasePath` and the mount path identical.
+
+## Point your agent at the current docs
+
+This documentation site publishes machine-readable versions of itself, generated on every build:
+
+- [`llms.txt`](https://felixmosh.github.io/bull-board/llms.txt): a concise index of every page.
+- [`llms-full.txt`](https://felixmosh.github.io/bull-board/llms-full.txt): the full text of the docs in one file.
+
+Feed either to an agent (or an "ask the docs" tool) so it works from the current API surface instead of whatever it remembers from training. The `llms-full.txt` version is the one to use when you want it to get option names and defaults exactly right.
+
+## After the agent is done
+
+The agent gets you mounted. These are on you:
+
+- [Add auth](/recipes/basic-auth) before anything reachable from outside localhost. Agents will happily leave the dashboard wide open.
+- [Read-only mode](/recipes/read-only-mode) if the people opening it shouldn't be retrying or obliterating queues.
+- [Alerting](/recipes/alerting): the dashboard shows failures, it doesn't tell you about them. Wire that separately.
+
+If the page loads but looks broken, it's almost always a base-path mismatch. See [Troubleshooting](/recipes/troubleshooting).

--- a/website/docs/guide/getting-started.md
+++ b/website/docs/guide/getting-started.md
@@ -8,6 +8,10 @@ Install the core `@bull-board/api` plus one adapter for your framework.
 - A running Redis instance
 - [Bull](https://github.com/OptimalBits/bull) or [BullMQ](https://docs.bullmq.io/) already set up in your app
 
+::: tip Sharing an ioredis connection?
+bull-board reads your existing Bull/BullMQ queues, so it inherits their Redis connection. If you construct BullMQ with a shared `ioredis` instance rather than a plain `{ host, port }`, BullMQ requires that connection to be created with `maxRetriesPerRequest: null`. This is a BullMQ requirement, not a bull-board one, but it's the most common setup snag. See the [BullMQ connection docs](https://docs.bullmq.io/guide/connections).
+:::
+
 ## Install
 
 Pick the adapter that matches your framework:

--- a/website/docs/guide/your-first-dashboard.md
+++ b/website/docs/guide/your-first-dashboard.md
@@ -54,7 +54,7 @@ await emailQueue.add('welcome', { to: 'you@example.com' });
 
 ## Where to next
 
-- Add more queues: pass them to `createBullBoard({ queues: [...] })` or call `addQueue()` at runtime.
+- Add more queues: pass them to `createBullBoard({ queues: [...] })`, or [add and remove them at runtime](/recipes/manage-queues-at-runtime).
 - Lock the dashboard with [read-only mode](/recipes/read-only-mode).
 - Scope queues per tenant with a [visibility guard](/recipes/visibility-guard).
 - Change title, logo, polling via [UIConfig](/configuration/ui-config).

--- a/website/docs/queue-adapters/bull.md
+++ b/website/docs/queue-adapters/bull.md
@@ -38,11 +38,16 @@ All options are optional.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `readOnlyMode` | `boolean` | `false` | Hides all queue and job actions. |
-| `allowRetries` | `boolean` | `true` | Shows or hides the retry buttons. Ignored when `readOnlyMode` is `true`. |
+| `allowRetries` | `boolean` | `true` | Shows or hides the retry buttons on **failed** jobs. Forced to `false` when `readOnlyMode` is `true`. |
 | `description` | `string` | `''` | Queue description text displayed in the UI. |
 | `displayName` | `string` | `''` | Overrides the queue name shown in the UI. |
 | `prefix` | `string` | `''` | Prepended to job names in the UI. |
 | `delimiter` | `string` | `''` | Delimiter between the prefix and the job name. |
+| `externalJobUrl` | `(job) => { href, displayText? }` | none | Links each job card to a page in your own app. See [External job URLs](/recipes/external-job-url). |
+
+::: tip
+`allowCompletedRetries` (available on [`BullMQAdapter`](/queue-adapters/bullmq)) has no effect here. Bull can't retry completed jobs, so it's always off.
+:::
 
 ## Instance methods
 

--- a/website/docs/queue-adapters/bullmq.md
+++ b/website/docs/queue-adapters/bullmq.md
@@ -38,11 +38,13 @@ All options are optional.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `readOnlyMode` | `boolean` | `false` | Hides all queue and job actions. |
-| `allowRetries` | `boolean` | `true` | Shows or hides the retry buttons. Ignored when `readOnlyMode` is `true`. |
+| `allowRetries` | `boolean` | `true` | Shows or hides the retry buttons on **failed** jobs. Forced to `false` when `readOnlyMode` is `true`. |
+| `allowCompletedRetries` | `boolean` | `true` | Shows or hides the retry button on **completed** jobs. Only takes effect when `allowRetries` is `true`. |
 | `description` | `string` | `''` | Queue description text displayed in the UI. |
 | `displayName` | `string` | `''` | Overrides the queue name shown in the UI. |
 | `prefix` | `string` | `''` | Prepended to job names in the UI. |
 | `delimiter` | `string` | `''` | Delimiter between the prefix and the job name. |
+| `externalJobUrl` | `(job) => { href, displayText? }` | none | Links each job card to a page in your own app. See [External job URLs](/recipes/external-job-url). |
 
 ## Instance methods
 
@@ -60,18 +62,12 @@ adapter.setVisibilityGuard((request) => {
 
 ## Flow tree
 
-The flow tree tab on the job detail page works with `BullMQAdapter` queues. Enable it by passing a flow producer to `createBullBoard`:
+The flow tree tab on the job detail page works with `BullMQAdapter` queues automatically. There's nothing to configure. When you open a job that belongs to a [BullMQ flow](https://docs.bullmq.io/guide/flows), bull-board reads the parent/child graph and renders it.
 
-```ts
-import { FlowProducer } from 'bullmq';
-import { createBullBoard } from '@bull-board/api';
+It builds a `FlowProducer` from the Redis connection of a registered `BullMQAdapter` (cached per connection), then walks the job's parent chain across queues to find the flow root. So it works as long as every queue in the flow is registered on the board.
 
-createBullBoard({
-  queues: [new BullMQAdapter(myQueue)],
-  serverAdapter,
-  options: {
-    uiConfig: { /* ... */ },
-  },
-  flowProducer: new FlowProducer({ connection: { host: 'localhost', port: 6379 } }),
-});
-```
+::: tip
+The flow tree only spans queues bull-board knows about. If a parent job lives in a queue you didn't pass to `createBullBoard`, the tree stops at the boundary. Register every queue that participates in the flow.
+:::
+
+Bull (the legacy library) has no flows, so the tab is BullMQ-only.

--- a/website/docs/queue-adapters/index.md
+++ b/website/docs/queue-adapters/index.md
@@ -19,11 +19,13 @@ All adapters accept the same optional options:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `readOnlyMode` | `boolean` | `false` | Hides all queue and job actions. |
-| `allowRetries` | `boolean` | `true` | Shows or hides the retry buttons. Ignored when `readOnlyMode` is `true`. |
+| `allowRetries` | `boolean` | `true` | Shows or hides the retry buttons on **failed** jobs. Forced to `false` when `readOnlyMode` is `true`. |
+| `allowCompletedRetries` | `boolean` | `true` | Shows or hides the retry button on **completed** jobs. Only takes effect when `allowRetries` is `true`. Always `false` on `BullAdapter` (Bull can't retry completed jobs). |
 | `description` | `string` | `''` | Queue description text displayed in the UI. |
 | `displayName` | `string` | `''` | Overrides the queue name shown in the UI. |
 | `prefix` | `string` | `''` | Prepended to job names in the UI. |
 | `delimiter` | `string` | `''` | Delimiter between the prefix and the job name. |
+| `externalJobUrl` | `(job) => { href, displayText? }` | none | Links each job card to a page in your own app. See [External job URLs](/recipes/external-job-url). |
 
 ## Instance methods
 

--- a/website/docs/recipes/alerting.md
+++ b/website/docs/recipes/alerting.md
@@ -1,0 +1,91 @@
+# Alerting on failed jobs
+
+> Applies to: all adapters.
+
+bull-board is a viewer, not a monitor. It shows the state of your queues while you have the tab open. It doesn't watch them for you and it sends nothing anywhere, so "how do I get alerted when a job fails?" isn't a question the dashboard answers. That part is on you, and it belongs in your worker code, not the board.
+
+BullMQ already emits the events you need. Wire your alerting to those, and use bull-board to investigate once an alert fires.
+
+## Alert from the worker (same process)
+
+If the alert lives in the same process as the worker, listen to its `failed` event. In most cases you only want to page once a job has spent all its retries, not on every intermediate attempt:
+
+```ts
+import { Worker } from 'bullmq';
+
+const worker = new Worker('emails', processor, { connection });
+
+worker.on('failed', (job, err) => {
+  // `failed` fires on every attempt. Only alert once retries are exhausted.
+  const exhausted = !job || job.attemptsMade >= (job.opts.attempts ?? 1);
+  if (exhausted) {
+    notifyOnCall(`Job ${job?.id} on "emails" failed for good: ${err.message}`);
+  }
+});
+```
+
+Attach an `error` listener too. Without one, an error inside the worker can bubble up as an unhandled exception and take the process down:
+
+```ts
+worker.on('error', (err) => {
+  logger.error({ err }, 'bullmq worker error');
+});
+```
+
+## Alert from anywhere (cross-process)
+
+Worker events only fire in the process running the worker. If your alerting service runs in a separate process (an API pod, a small dedicated watcher), use `QueueEvents`, which reads the events straight from Redis:
+
+```ts
+import { QueueEvents } from 'bullmq';
+
+const events = new QueueEvents('emails', { connection });
+
+events.on('failed', ({ jobId, failedReason }) => {
+  notifyOnCall(`Job ${jobId} on "emails" failed: ${failedReason}`);
+});
+
+events.on('stalled', ({ jobId }) => {
+  // A worker picked the job up and then went silent (crash, OOM, event-loop block).
+  notifyOnCall(`Job ${jobId} on "emails" stalled`);
+});
+```
+
+`QueueEvents` gives you `jobId` and `failedReason`, but not the `Job` instance, so the "retries exhausted?" check from the worker version isn't available here. If you only want the final failure, either keep that logic in the worker, or fetch the job (`queue.getJob(jobId)`) and inspect `attemptsMade` yourself.
+
+## Route permanently-failed jobs to a dead-letter queue
+
+A common pattern: once a job is truly dead, push it onto a separate "dead-letter" queue, then register that queue on the board. Now permanently-failed work has its own inbox you can inspect and replay from the dashboard, instead of hunting through the failed tab of a busy queue.
+
+```ts
+const deadLetters = new Queue('emails-dead-letter', { connection });
+
+worker.on('failed', async (job, err) => {
+  if (job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
+    await deadLetters.add('dead', { original: job.data, reason: err.message });
+  }
+});
+
+// Register both on the board so the DLQ is one click away.
+createBullBoard({
+  queues: [new BullMQAdapter(emailsQueue), new BullMQAdapter(deadLetters)],
+  serverAdapter,
+});
+```
+
+Mark the dead-letter queue [read-only](/recipes/read-only-mode) if it's only there to be read.
+
+## What the dashboard does give you
+
+Not alerts, but two things worth knowing:
+
+- **Throughput chart.** Set `showMetrics: true` in [UIConfig](/configuration/ui-config) for a completed/failed-per-minute chart per queue. It needs [BullMQ metrics](https://docs.bullmq.io/guide/metrics) enabled on your workers. Good for spotting a spike after the fact, not for waking anyone up.
+- **Job logs.** Lines your worker writes with `job.log()` show up under each job. When an alert points you at a failed job, that's where the "what happened" usually is. See [Job logs and flows](/recipes/job-logs-and-flows).
+
+## Going deeper
+
+Alerting well (deduping, escalation, telling a stalled worker apart from a genuinely failing job) is a BullMQ and ops concern, not a bull-board one. The BullMQ docs are the source for the event semantics:
+
+- [Events](https://docs.bullmq.io/guide/events): the full `QueueEvents` list.
+- [Workers](https://docs.bullmq.io/guide/workers): worker-level listeners and the `error` event.
+- [Retrying failing jobs](https://docs.bullmq.io/guide/retrying-failing-jobs): attempts, backoff, and what "failed for good" means.

--- a/website/docs/recipes/index.md
+++ b/website/docs/recipes/index.md
@@ -11,11 +11,14 @@ Short, code-first walkthroughs for common setups. Each recipe is a page; each pa
 | Protect the dashboard with basic auth | [Add basic auth](/recipes/basic-auth) | Express, Fastify, Hapi, NestJS |
 | Defend against CSRF on destructive actions | [CSRF protection](/recipes/csrf-protection) | Express |
 | Run several dashboards in one app | [Multiple dashboards](/recipes/multiple-dashboards) | Express |
+| Add or remove queues after startup | [Manage queues at runtime](/recipes/manage-queues-at-runtime) | All |
 | Show only a tenant's queues per request | [Per-tenant visibility](/recipes/per-tenant-visibility) | Fastify |
 | Surface worker logs and job flows in the UI | [Job logs and flows](/recipes/job-logs-and-flows) | All |
+| Get notified when jobs fail | [Alerting on failed jobs](/recipes/alerting) | All |
 | Change or force the polling interval | [Polling interval](/recipes/change-polling-interval) | All |
 | Link jobs to your own admin pages | [External job URLs](/recipes/external-job-url) | All |
 | Set global concurrency from the UI | [Global concurrency](/recipes/global-concurrency) | All |
 | Deploy the dashboard on Next.js / Vercel | [Next.js & Vercel](/recipes/nextjs) | Hono, Express |
+| Diagnose a dashboard that won't load | [Troubleshooting](/recipes/troubleshooting) | All |
 
 Missing something? Open an issue. felixmosh is responsive, and good recipes become features.

--- a/website/docs/recipes/manage-queues-at-runtime.md
+++ b/website/docs/recipes/manage-queues-at-runtime.md
@@ -1,0 +1,65 @@
+# Add and remove queues at runtime
+
+> Applies to: all adapters.
+
+`createBullBoard` isn't a one-shot call. It also returns four functions that change which queues the board shows while it's running, with no rebuild or restart:
+
+```ts
+const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
+  queues: [new BullMQAdapter(emailQueue)],
+  serverAdapter,
+});
+```
+
+Use them when queues aren't all known at startup: per-tenant queues created on demand, queues discovered from a registry, or a dashboard that follows queues as workers spin them up and down.
+
+## The four functions
+
+| Function | Signature | Effect |
+| --- | --- | --- |
+| `addQueue` | `(queue: BaseAdapter) => void` | Adds one queue. Overwrites if a queue with the same name is already registered. |
+| `removeQueue` | `(queueOrName: string \| BaseAdapter) => void` | Removes one queue, by adapter or by name. No-op if it isn't registered. |
+| `setQueues` | `(queues: BaseAdapter[]) => void` | Adds or overwrites a batch, and **leaves other registered queues in place**. |
+| `replaceQueues` | `(queues: BaseAdapter[]) => void` | Same as `setQueues`, but also **removes any queue not in the list**. A full sync. |
+
+Queues are keyed by name (`queue.getName()`, which includes any `prefix` you set). Registering two adapters that resolve to the same name means the second wins.
+
+## Add a queue on demand
+
+```ts
+const board = createBullBoard({ queues: [], serverAdapter });
+
+function onTenantCreated(tenantId: string) {
+  const queue = new Queue(`emails-${tenantId}`, { connection });
+  board.addQueue(new BullMQAdapter(queue));
+}
+
+function onTenantDeleted(tenantId: string) {
+  board.removeQueue(`emails-${tenantId}`);
+}
+```
+
+The dashboard picks up the change on its next poll, with no reload or remount.
+
+## Sync the board to a known set
+
+`setQueues` vs `replaceQueues` differ only in what happens to queues you _don't_ pass:
+
+```ts
+// Board currently shows: A, B, C
+
+board.setQueues([b, d]);      // → A, B, C, D  (adds D, updates B, keeps A and C)
+board.replaceQueues([b, d]);  // → B, D        (drops A and C)
+```
+
+Reach for `replaceQueues` when you have the authoritative full list and want the board to mirror it exactly. Reach for `setQueues` when you're merging in a batch and don't want to disturb queues registered elsewhere.
+
+## Notes
+
+- Changes take effect on the next request. The functions write to the same `Map` the board reads each time, so there's no cache to bust.
+- Removing a queue only detaches it from the dashboard. It doesn't close the Bull/BullMQ connection or touch Redis, so clean those up yourself if the queue is really gone.
+- On [NestJS](/server-adapters/nestjs) you don't hold the return value of `createBullBoard` directly. The module already calls `addQueue` when you register feature queues, and it exposes the same board instance for manual changes via `@InjectBullBoard() board: BullBoardInstance`. See [`examples/with-nestjs-module`](https://github.com/felixmosh/bull-board/tree/master/examples/with-nestjs-module).
+
+## Source of truth
+
+The four functions are built in [`packages/api/src/queuesApi.ts`](https://github.com/felixmosh/bull-board/blob/master/packages/api/src/queuesApi.ts) and returned from `createBullBoard` in [`packages/api/src/index.ts`](https://github.com/felixmosh/bull-board/blob/master/packages/api/src/index.ts).

--- a/website/docs/recipes/read-only-mode.md
+++ b/website/docs/recipes/read-only-mode.md
@@ -51,6 +51,14 @@ new BullMQAdapter(emailQueue, { allowRetries: false });
 
 Defaults to `true` on writable queues. When `readOnlyMode: true`, `allowRetries` is forced to `false`, the option is ignored since retries are themselves a destructive action.
 
+To keep failed-job retries but hide the retry button on **completed** jobs, use `allowCompletedRetries: false` (BullMQ only):
+
+```ts
+new BullMQAdapter(emailQueue, { allowCompletedRetries: false });
+```
+
+It only takes effect while `allowRetries` is `true`. On `BullAdapter` it's always off, because Bull can't retry completed jobs.
+
 ::: warning
 `allowRetries: false` only hides the retry buttons — it doesn't block the retry API endpoint. Anyone who knows the URL can still trigger a retry. Use `readOnlyMode: true` for real enforcement.
 :::

--- a/website/docs/recipes/troubleshooting.md
+++ b/website/docs/recipes/troubleshooting.md
@@ -1,0 +1,48 @@
+# Troubleshooting
+
+> Applies to: all adapters.
+
+The failure modes below account for most "it won't load" reports. Nearly all of them come down to one thing: the path bull-board thinks it's mounted at doesn't match the path the browser actually requests.
+
+## The page loads but assets and API calls 404
+
+You see the HTML, but the styles are missing and the network tab is full of 404s for `/static/...` and `/api/...`.
+
+`setBasePath` and the path you mount the router at have to be the same string. bull-board bakes the base path into the HTML it serves, and the browser builds every asset and API URL from it. If they disagree, every follow-up request misses.
+
+```ts
+serverAdapter.setBasePath('/admin/queues');   // ← these two
+app.use('/admin/queues', serverAdapter.getRouter());  // ← must match
+```
+
+Change one, change the other.
+
+## Same 404s, but only behind a reverse proxy
+
+Works on `localhost`, breaks once it's behind nginx / a load balancer / an ingress at a subpath.
+
+The base path has to be the path the **browser** sees, not the internal one. If the proxy exposes the dashboard at `https://example.com/tools/queues` but forwards to your app at `/`, then `setBasePath('/tools/queues')`, the public path, and let the proxy route it. The rule is the same as above; the "mount path" is just whatever the outside world requests.
+
+If the proxy strips the prefix before forwarding, either stop stripping it or set the base path to the stripped value, whichever keeps the browser's URL and the base path in agreement.
+
+## `Cannot find module '@bull-board/ui/package.json'`
+
+Thrown at startup, almost always under a bundler (Next.js/Vercel, esbuild, `ncc`, a Docker build that prunes `node_modules`).
+
+bull-board locates the compiled UI with `eval(require.resolve('@bull-board/ui/package.json'))`. The `eval` is deliberate: it hides the require from bundlers so they don't try to inline the whole UI, but it also means bundlers don't know to ship those files. Two fixes: point bull-board at the UI directly with `options.uiBasePath`, and/or tell the bundler to include the files. The [Next.js & Vercel recipe](/recipes/nextjs) walks through both.
+
+## Blank page, or a 500 on the dashboard root
+
+If the response is a 500 rather than a 404, it's usually the missing-UI case above (the view can't render). A genuinely blank page with no failed requests is more often a strict **Content-Security-Policy** on the parent app blocking the dashboard's scripts or styles. Check the browser console for CSP violations and allow bull-board's `/static` origin if so.
+
+## Buttons do nothing, or actions error after an upgrade
+
+If retry/clean/pause started failing after you bumped a dependency, suspect a Bull / BullMQ version mismatch between your workers and the version bull-board resolves. Pin the same version across both. See [version pinning](/configuration/production-checklist#version-pinning).
+
+## A destructive action returns 405
+
+That's [read-only mode](/recipes/read-only-mode) doing its job. The queue was registered with `readOnlyMode: true` (or the action is gated by `allowRetries`). Intended, not a bug.
+
+## Still stuck
+
+Open an issue on [felixmosh/bull-board](https://github.com/felixmosh/bull-board/issues) with your adapter, versions, and the mount/base-path setup. Most reports resolve to one of the above once the exact paths are on the table.

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
             { text: "Introduction", link: "/guide/introduction" },
             { text: "Installation", link: "/guide/getting-started" },
             { text: "Your first dashboard", link: "/guide/your-first-dashboard" },
+            { text: "Set up with an AI agent", link: "/guide/ai-agent-setup" },
           ],
         },
         {
@@ -96,12 +97,15 @@ export default defineConfig({
             { text: "Visibility guard", link: "/recipes/visibility-guard" },
             { text: "Formatters", link: "/recipes/formatters" },
             { text: "Multiple dashboards", link: "/recipes/multiple-dashboards" },
+            { text: "Manage queues at runtime", link: "/recipes/manage-queues-at-runtime" },
             { text: "Per-tenant visibility", link: "/recipes/per-tenant-visibility" },
             { text: "Job logs and flows", link: "/recipes/job-logs-and-flows" },
+            { text: "Alerting on failed jobs", link: "/recipes/alerting" },
             { text: "Polling interval", link: "/recipes/change-polling-interval" },
             { text: "External job URLs", link: "/recipes/external-job-url" },
             { text: "Global concurrency", link: "/recipes/global-concurrency" },
             { text: "Next.js & Vercel", link: "/recipes/nextjs" },
+            { text: "Troubleshooting", link: "/recipes/troubleshooting" },
           ],
         },
         {


### PR DESCRIPTION
Docs-only hardening pass. Everything is under `website/docs`, no library code changes. Closes some gaps against the actual API and covers the questions that keep coming up in issues.

Four new pages:

- Manage queues at runtime. Documents the `addQueue`, `removeQueue`, `setQueues` and `replaceQueues` functions that `createBullBoard` returns. Only `addQueue` had a passing mention before, and the difference between `setQueues` (upsert) and `replaceQueues` (full sync) wasn't written down anywhere.
- Alerting on failed jobs. bull-board is a viewer, not a monitor, so "how do I get alerted when a job fails?" comes up a lot. Shows the BullMQ `worker.on('failed')` retries-exhausted pattern, `QueueEvents` for cross-process alerting, and the dead-letter-queue approach, with pointers to the BullMQ docs for the event details.
- Troubleshooting. Collects the most common failure, asset and API 404s from a `basePath` that doesn't match the mount path, including behind a reverse proxy. Also the bundler `uiBasePath` case (links the Next.js recipe) and version mismatch.
- Set up with an AI agent. A copy-paste prompt for coding agents that bakes in the base-path gotcha and the "add auth before exposing" reminder, and points agents at the generated `llms.txt` / `llms-full.txt` so they work from the current API instead of stale memory.

A few corrections to existing pages:

- `allowCompletedRetries` was a real queue-adapter option missing from every options table. Added it (BullMQ, Bull, shared), noting Bull forces it off, plus a line in the read-only recipe.
- `externalJobUrl` now appears in the options tables. It had a recipe but wasn't listed as an option.
- The BullMQ flow-tree section showed passing `flowProducer` to `createBullBoard`, which the current signature ignores. Rewrote it: the flow tree is wired automatically from a registered BullMQ adapter's Redis connection, and only spans registered queues.
- Added an ioredis note to Installation about `maxRetriesPerRequest: null` for shared connections, a frequent setup snag.

New pages are linked from the sidebar, the recipes index and the production checklist. Built locally with `yarn docs:build`; the dead-link check passes.
