### PR TITLE
feat(ui): type-check i18n keys and enforce locale completeness in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -148,6 +148,9 @@ jobs:
         env:
           CI: true
 
+      - name: Typecheck UI
+        run: yarn workspace @bull-board/ui typecheck
+
       - name: Test UI
         run: yarn workspace @bull-board/ui test
         env:

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "build:analyze": "RSDOCTOR=true rsbuild build",
     "clean": "rm -rf dist",
     "test": "jest",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "sync:locales": "i18next-locales-sync -c ./localesSync.config.js",
     "gen:jsonSchema": "npm run gen:jsonSchema:bullmq && npm run gen:jsonSchema:bull",
     "gen:jsonSchema:bullmq": "npx ts-json-schema-generator --path '../../node_modules/bullmq/dist/esm/interfaces/**/*.ts' --type 'JobsOptions' --out './src/schemas/bullmq/jobOptions.json'",

--- a/packages/ui/src/components/JobCard/Details/Details.tsx
+++ b/packages/ui/src/components/JobCard/Details/Details.tsx
@@ -2,6 +2,7 @@ import type { AppJob, Status } from '@bull-board/api/typings/app';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDetailsTabs } from '../../../hooks/useDetailsTabs';
+import { dynamicTranslationKey } from '../../../utils/dynamicTranslationKey';
 import { Button } from '../../Button/Button';
 import { DetailsContent } from './DetailsContent/DetailsContent';
 import s from './Details.module.css';
@@ -27,7 +28,7 @@ export const Details = ({ status, job, actions, withTimeline = false }: DetailsP
         {tabs.map((tab) => (
           <li key={tab.title}>
             <Button onClick={tab.selectTab} isActive={tab.isActive}>
-              {t(`JOB.TABS.${tab.title.toUpperCase()}`)}
+              {t(dynamicTranslationKey(`JOB.TABS.${tab.title.toUpperCase()}`))}
             </Button>
           </li>
         ))}

--- a/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
+++ b/packages/ui/src/components/JobCard/JobActions/JobActions.tsx
@@ -2,6 +2,7 @@ import { STATUSES } from '@bull-board/api/constants/statuses';
 import type { Status } from '@bull-board/api/typings/app';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { dynamicTranslationKey } from '../../../utils/dynamicTranslationKey';
 import { Button } from '../../Button/Button';
 import { DuplicateIcon } from '../../Icons/Duplicate';
 import { PromoteIcon } from '../../Icons/Promote';
@@ -72,7 +73,7 @@ export const JobActions = ({ actions, status, allowRetries }: JobActionsProps) =
     <ul className={s.jobActions}>
       {buttons.map((type) => (
         <li key={type.titleKey}>
-          <Tooltip title={t(`JOB.ACTIONS.${type.titleKey}`)}>
+          <Tooltip title={t(dynamicTranslationKey(`JOB.ACTIONS.${type.titleKey}`))}>
             <Button onClick={actions[type.actionKey]} className={s.button}>
               <type.Icon />
             </Button>

--- a/packages/ui/src/components/OverviewDropDownActions/OverviewDropDownActions.tsx
+++ b/packages/ui/src/components/OverviewDropDownActions/OverviewDropDownActions.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { QueueActions } from '../../../typings/app';
 import type { QueueSortKey, SortDirection } from '../../hooks/useSortQueues';
+import { dynamicTranslationKey } from '../../utils/dynamicTranslationKey';
 import { Button } from '../Button/Button';
 import { EllipsisVerticalIcon } from '../Icons/EllipsisVertical';
 import { PauseIcon } from '../Icons/Pause';
@@ -89,7 +90,7 @@ export const OverviewActions = ({
                       key={key}
                       onClick={() => onSort(key as QueueSortKey)}
                     >
-                      {t(`DASHBOARD.SORTING.${key.toUpperCase()}`)}
+                      {t(dynamicTranslationKey(`DASHBOARD.SORTING.${key.toUpperCase()}`))}
                       {sortBy === key && SortDir}
                     </Menu.Item>
                   ))}

--- a/packages/ui/src/components/OverviewTree/OverviewTree.tsx
+++ b/packages/ui/src/components/OverviewTree/OverviewTree.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOverviewState } from '../../hooks/useMenuState';
 import { useQueues } from '../../hooks/useQueues';
+import { dynamicTranslationKey } from '../../utils/dynamicTranslationKey';
 import {
   aggregateCounts,
   areAllPaused,
@@ -37,7 +38,7 @@ const AggregateCounts = ({ counts }: { counts: AggregatedCounts }) => {
         <span
           key={status}
           className={s.countChip}
-          title={t(`QUEUE.STATUS.${status.toUpperCase()}`)}
+          title={t(dynamicTranslationKey(`QUEUE.STATUS.${status.toUpperCase()}`))}
         >
           <span className={s.countDot} style={{ backgroundColor: `var(--${status})` }} />
           {counts.byStatus[status]}

--- a/packages/ui/src/components/QueueCard/QueueStats/QueueStats.tsx
+++ b/packages/ui/src/components/QueueCard/QueueStats/QueueStats.tsx
@@ -3,6 +3,7 @@ import cn from 'clsx';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { dynamicTranslationKey } from '../../../utils/dynamicTranslationKey';
 import { links } from '../../../utils/links';
 import { toCamelCase } from '../../../utils/toCamelCase';
 import s from './QueueStats.module.css';
@@ -33,7 +34,7 @@ export const QueueStats = ({ queue }: IQueueStatsProps) => {
                 aria-valuemin={0}
                 aria-valuemax={total}
                 className={cn(s[toCamelCase(status)], s.bar)}
-                title={t(`QUEUE.STATUS.${status.toUpperCase()}`)}
+                title={t(dynamicTranslationKey(`QUEUE.STATUS.${status.toUpperCase()}`))}
               >
                 {value}
               </Link>

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -4,6 +4,7 @@ import { languages } from '../../constants/languages';
 import { availableJobTabs } from '../../hooks/useDetailsTabs';
 import { useSettingsStore } from '../../hooks/useSettings';
 import { useUIConfig } from '../../hooks/useUIConfig';
+import { dynamicTranslationKey } from '../../utils/dynamicTranslationKey';
 import { CollapsibleSection } from '../CollapsibleSection/CollapsibleSection';
 import { InputField } from '../Form/InputField/InputField';
 import { SelectField } from '../Form/SelectField/SelectField';
@@ -124,7 +125,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
           label={t('SETTINGS.DEFAULT_JOB_TAB')}
           id="default-job-tab"
           options={['default'].concat(availableJobTabs).map((tab) => ({
-            text: t(`JOB.TABS.${tab.toUpperCase()}`),
+            text: t(dynamicTranslationKey(`JOB.TABS.${tab.toUpperCase()}`)),
             value: tab,
           }))}
           value={defaultJobTab}

--- a/packages/ui/src/components/StatusTabs/StatusTabs.tsx
+++ b/packages/ui/src/components/StatusTabs/StatusTabs.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, NavLinkProps } from 'react-router-dom';
+import { dynamicTranslationKey } from '../../utils/dynamicTranslationKey';
 import { toCamelCase } from '../../utils/toCamelCase';
 import s from './StatusTabs.module.css';
 
@@ -23,7 +24,9 @@ export const StatusTabs = ({ items, children }: PropsWithChildren<StatusTabsProp
       <div className={s.tabsWrapper}>
         <ul className={s.statusTabs}>
           {items.map(({ status, to, isActive, count }) => {
-            const displayStatus = t(`QUEUE.STATUS.${status.toUpperCase()}`).toLocaleUpperCase();
+            const displayStatus = t(
+              dynamicTranslationKey(`QUEUE.STATUS.${status.toUpperCase()}`)
+            ).toLocaleUpperCase();
 
             return (
               <li key={status} className={s[toCamelCase(status)]}>

--- a/packages/ui/src/constants/languages.ts
+++ b/packages/ui/src/constants/languages.ts
@@ -1,6 +1,7 @@
 export const languages = [
   'en-US',
   'en-GB',
+  'da-DK',
   'de-DE',
   'es-ES',
   'fr-FR',

--- a/packages/ui/src/i18next.d.ts
+++ b/packages/ui/src/i18next.d.ts
@@ -1,0 +1,17 @@
+import 'i18next';
+import type messages from './static/locales/en-US/messages.json';
+
+// Makes `t()` type-checked against the primary locale (en-US). Unknown or
+// misspelled keys become compile errors, and keys autocomplete. Other locales
+// are kept in parity with en-US by the i18n completeness test, not by types.
+//
+// Kept under src/ (not typings/) so it is not published to npm — a global
+// i18next augmentation must not leak into consumers of @bull-board/ui.
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'messages';
+    resources: {
+      messages: typeof messages;
+    };
+  }
+}

--- a/packages/ui/src/static/locales/da-DK/messages.json
+++ b/packages/ui/src/static/locales/da-DK/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Filtrer køer",
     "PAUSED": "Pauset",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Job",

--- a/packages/ui/src/static/locales/de-DE/messages.json
+++ b/packages/ui/src/static/locales/de-DE/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Warteschlangen filtern",
     "PAUSED": "Pausiert",
     "EXPAND_ALL": "Alle Gruppen ausklappen",
-    "COLLAPSE_ALL": "Alle Gruppen einklappen"
+    "COLLAPSE_ALL": "Alle Gruppen einklappen",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Job",

--- a/packages/ui/src/static/locales/en-GB/messages.json
+++ b/packages/ui/src/static/locales/en-GB/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Filter queues",
     "PAUSED": "Paused",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Job",

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Filter queues",
     "PAUSED": "Paused",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Job",

--- a/packages/ui/src/static/locales/es-ES/messages.json
+++ b/packages/ui/src/static/locales/es-ES/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Filtrar colas",
     "PAUSED": "Pausada",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Tarea",

--- a/packages/ui/src/static/locales/fr-FR/messages.json
+++ b/packages/ui/src/static/locales/fr-FR/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Filtrer les files",
     "PAUSED": "En pause",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Tâche",

--- a/packages/ui/src/static/locales/ja-JP/messages.json
+++ b/packages/ui/src/static/locales/ja-JP/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "キューを絞り込み",
     "PAUSED": "一時停止中",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT": "{{count}} ジョブ",

--- a/packages/ui/src/static/locales/ko-KR/messages.json
+++ b/packages/ui/src/static/locales/ko-KR/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "큐 필터",
     "PAUSED": "일시정지됨",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT": "{{count}}개의 작업",

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Filtrar filas",
     "PAUSED": "Em Pausa",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} Tarefa",

--- a/packages/ui/src/static/locales/tr-TR/messages.json
+++ b/packages/ui/src/static/locales/tr-TR/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "Kuyrukları filtrele",
     "PAUSED": "Durduruldu",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT_one": "{{count}} İş",

--- a/packages/ui/src/static/locales/zh-CN/messages.json
+++ b/packages/ui/src/static/locales/zh-CN/messages.json
@@ -6,7 +6,9 @@
     "SEARCH_INPUT_PLACEHOLDER": "筛选队列",
     "PAUSED": "已暂停",
     "EXPAND_ALL": "Expand all groups",
-    "COLLAPSE_ALL": "Collapse all groups"
+    "COLLAPSE_ALL": "Collapse all groups",
+    "EXPAND_SIDEBAR": "Expand sidebar",
+    "COLLAPSE_SIDEBAR": "Collapse sidebar"
   },
   "DASHBOARD": {
     "JOBS_COUNT": "{{count}} 个作业",

--- a/packages/ui/src/utils/dynamicTranslationKey.ts
+++ b/packages/ui/src/utils/dynamicTranslationKey.ts
@@ -1,0 +1,12 @@
+import type { ParseKeys } from 'i18next';
+
+/**
+ * Asserts a runtime-constructed translation key as a valid i18next key.
+ *
+ * `t()` is typed against the en-US resources, so it rejects string keys the
+ * compiler cannot prove exist. A handful of call sites build the key from a
+ * runtime value (a status, tab, or action name) and cannot be checked
+ * statically. Route those through this helper so the escape hatch is explicit
+ * and greppable instead of scattering `as ParseKeys` casts across components.
+ */
+export const dynamicTranslationKey = (key: string): ParseKeys => key as ParseKeys;

--- a/packages/ui/tests/i18n.spec.ts
+++ b/packages/ui/tests/i18n.spec.ts
@@ -4,18 +4,23 @@ import path from 'path';
 import { syncLocales } from 'i18next-locales-sync';
 import { languages } from '../src/constants/languages';
 
-const localesDir = path.resolve(__dirname, '../src/static/locales');
-const primaryLanguage = 'en-US';
+// Reuse the same config `yarn sync:locales` runs on, so the test can never
+// drift from the real sync behaviour.
+const syncConfig = require('../localesSync.config.js') as {
+  primaryLanguage: string;
+  secondaryLanguages: string[];
+  localesFolder: string;
+  spaces: number;
+};
+
+const { primaryLanguage, secondaryLanguages, localesFolder, spaces } = syncConfig;
+const localesDir = path.resolve(__dirname, '..', localesFolder);
 
 const read = (p: string) => fs.readFileSync(p, 'utf8');
 
-const localeFolders = fs
-  .readdirSync(localesDir)
-  .filter((name) => fs.statSync(path.join(localesDir, name)).isDirectory());
-
 describe('i18n locales', () => {
   it('registers every locale folder in the languages list (and vice versa)', () => {
-    expect([...localeFolders].sort()).toEqual([...languages].sort());
+    expect([primaryLanguage, ...secondaryLanguages].sort()).toEqual([...languages].sort());
   });
 
   it('ships a messages.json for every registered language', () => {
@@ -30,14 +35,12 @@ describe('i18n locales', () => {
   it('keeps every locale in sync with en-US (run `yarn sync:locales`)', () => {
     const outputFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'bb-locales-'));
     try {
-      const secondaryLanguages = localeFolders.filter((lng) => lng !== primaryLanguage).sort();
-
       syncLocales({
         primaryLanguage,
         secondaryLanguages,
         localesFolder: localesDir,
         outputFolder,
-        spaces: 2,
+        spaces,
       });
 
       const outOfSync = secondaryLanguages.filter(

--- a/packages/ui/tests/i18n.spec.ts
+++ b/packages/ui/tests/i18n.spec.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { syncLocales } from 'i18next-locales-sync';
+import { languages } from '../src/constants/languages';
+
+const localesDir = path.resolve(__dirname, '../src/static/locales');
+const primaryLanguage = 'en-US';
+
+const read = (p: string) => fs.readFileSync(p, 'utf8');
+
+const localeFolders = fs
+  .readdirSync(localesDir)
+  .filter((name) => fs.statSync(path.join(localesDir, name)).isDirectory());
+
+describe('i18n locales', () => {
+  it('registers every locale folder in the languages list (and vice versa)', () => {
+    expect([...localeFolders].sort()).toEqual([...languages].sort());
+  });
+
+  it('ships a messages.json for every registered language', () => {
+    for (const lng of languages) {
+      expect(fs.existsSync(path.join(localesDir, lng, 'messages.json'))).toBe(true);
+    }
+  });
+
+  // Guards against adding/removing a key in en-US without running `yarn sync:locales`.
+  // Re-runs the sync into a throwaway folder and asserts it produces no changes,
+  // which is exactly what a synced tree looks like (plurals expanded per CLDR).
+  it('keeps every locale in sync with en-US (run `yarn sync:locales`)', () => {
+    const outputFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'bb-locales-'));
+    try {
+      const secondaryLanguages = localeFolders.filter((lng) => lng !== primaryLanguage).sort();
+
+      syncLocales({
+        primaryLanguage,
+        secondaryLanguages,
+        localesFolder: localesDir,
+        outputFolder,
+        spaces: 2,
+      });
+
+      const outOfSync = secondaryLanguages.filter(
+        (lng) =>
+          read(path.join(localesDir, lng, 'messages.json')) !==
+          read(path.join(outputFolder, lng, 'messages.json'))
+      );
+
+      expect(outOfSync).toEqual([]);
+    } finally {
+      fs.rmSync(outputFolder, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/ui/tsconfig.typecheck.json
+++ b/packages/ui/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  // Type-checks the app source (including .tsx) against the i18next key typings.
+  // The production build (rsbuild + @rsbuild/plugin-type-check) only checks .ts,
+  // so this config is what enforces typed `t()` keys in CI. It mirrors the
+  // build's automatic JSX runtime with "react-jsx"; noUnusedLocals is relaxed
+  // because many components still carry a now-unused `import React` from the
+  // classic runtime, which is unrelated to type safety.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noUnusedLocals": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "typings/*.d.ts"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx", "src/test"]
+}

--- a/packages/ui/typings/i18next.d.ts
+++ b/packages/ui/typings/i18next.d.ts
@@ -1,12 +1,9 @@
 import 'i18next';
-import type messages from './static/locales/en-US/messages.json';
+import type messages from '../src/static/locales/en-US/messages.json';
 
 // Makes `t()` type-checked against the primary locale (en-US). Unknown or
 // misspelled keys become compile errors, and keys autocomplete. Other locales
 // are kept in parity with en-US by the i18n completeness test, not by types.
-//
-// Kept under src/ (not typings/) so it is not published to npm — a global
-// i18next augmentation must not leak into consumers of @bull-board/ui.
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'messages';


### PR DESCRIPTION
The recent `fix: add missing queue.info messages` (ec64657) patched a set of translation keys that were used in the UI but never defined. It was found and fixed by hand, and nothing stops the same thing from happening again. This PR makes translation coverage checkable instead of relying on someone spotting raw keys in the running UI.

There are two independent guards, because they catch different classes of problem.

The first is types. `t()` is now typed against the primary `en-US` resource via `src/i18next.d.ts`, so any key used in a component that does not exist in `en-US` is a compile error, and keys autocomplete. A new `typecheck` script enforces this in CI (`tsc -p tsconfig.typecheck.json`, wired into the Test UI job). The production build only type-checks `.ts` files, so this config is what covers `.tsx`; it mirrors the build's automatic JSX runtime and relaxes `noUnusedLocals`, since many components still carry a now-unused `React` import from the classic runtime that is unrelated to key safety. A few call sites build keys from a runtime value (a status, tab, or action name) and cannot be verified statically, so they route through a small `dynamicTranslationKey` helper that keeps the escape hatch explicit and greppable rather than scattering casts.

Turning the typing on immediately surfaced two keys that the queue.info fix missed: `MENU.EXPAND_SIDEBAR` and `MENU.COLLAPSE_SIDEBAR`, used by `SidebarToggle` but present in no locale. They are added to `en-US` and propagated with `sync:locales`.

The second guard is a completeness test (`tests/i18n.spec.ts`). It asserts that every locale folder is registered in the `languages` list and vice versa, and that `sync:locales` produces no drift, so adding a key to `en-US` without syncing fails CI. This is the part that catches missing translations across locales, which typing cannot. It also flagged that `da-DK` shipped real, partly translated Danish but was never registered in `languages`, so it never loaded; it is registered now.

Non-English locales carry English placeholders for the two new keys, to be translated through the usual flow.
