### PR TITLE
feat: per-queue job data schema for the add-job form

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -259,6 +259,25 @@ const run = async () => {
       new BullMQAdapter(resetPassword, {
         delimiter: ';',
         displayName: 'Reset Password',
+        description: 'Sends a password-reset email to the requesting user.',
+        jobDataSchema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['userId', 'email'],
+          properties: {
+            userId: { type: 'string', description: 'Internal id of the user requesting the reset.' },
+            email: {
+              type: 'string',
+              format: 'email',
+              description: 'Address the reset link is sent to.',
+            },
+            locale: {
+              type: 'string',
+              description: 'BCP-47 locale for the email template.',
+              default: 'en',
+            },
+          },
+        },
       }),
     ],
     serverAdapter,

--- a/packages/api/src/handlers/jobDataSchema.ts
+++ b/packages/api/src/handlers/jobDataSchema.ts
@@ -1,0 +1,17 @@
+import { BullBoardRequest, ControllerHandlerReturnType } from '../../typings/app';
+import { queueProvider } from '../providers/queue';
+import { BaseAdapter } from '../queueAdapters/base';
+
+async function getJobDataSchema(
+  _req: BullBoardRequest,
+  queue: BaseAdapter
+): Promise<ControllerHandlerReturnType> {
+  return {
+    status: 200,
+    body: queue.getJobDataSchema() || {},
+  };
+}
+
+export const jobDataSchemaHandler = queueProvider(getJobDataSchema, {
+  skipReadOnlyModeCheck: true,
+});

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -87,7 +87,6 @@ async function getAppQueues(
         name: queueName,
         displayName: queue.getDisplayName() || undefined,
         description: queue.getDescription() || undefined,
-        jobDataSchema: queue.getJobDataSchema(),
         statuses: queue.getStatuses(),
         counts: counts as Record<Status, number>,
         jobs: jobs.filter(Boolean).map((job) => formatJob(job, queue)),

--- a/packages/api/src/handlers/queues.ts
+++ b/packages/api/src/handlers/queues.ts
@@ -87,6 +87,7 @@ async function getAppQueues(
         name: queueName,
         displayName: queue.getDisplayName() || undefined,
         description: queue.getDescription() || undefined,
+        jobDataSchema: queue.getJobDataSchema(),
         statuses: queue.getStatuses(),
         counts: counts as Record<Status, number>,
         jobs: jobs.filter(Boolean).map((job) => formatJob(job, queue)),

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -22,6 +22,7 @@ export abstract class BaseAdapter {
   public readonly delimiter: string;
   public readonly description: string;
   public readonly displayName: string;
+  public readonly jobDataSchema: QueueAdapterOptions['jobDataSchema'] | undefined;
   public readonly type: QueueType;
   public readonly externalJobUrl: QueueAdapterOptions['externalJobUrl'];
   private formatters = new Map<FormatterField, (data: any) => any>();
@@ -38,6 +39,7 @@ export abstract class BaseAdapter {
     this.delimiter = options.delimiter || '';
     this.description = options.description || '';
     this.displayName = options.displayName || '';
+    this.jobDataSchema = options.jobDataSchema;
     this.type = type;
     this.externalJobUrl = options.externalJobUrl;
   }
@@ -48,6 +50,10 @@ export abstract class BaseAdapter {
 
   public getDisplayName(): string {
     return this.displayName;
+  }
+
+  public getJobDataSchema(): Record<string, any> | undefined {
+    return this.jobDataSchema;
   }
 
   public setFormatter<T extends FormatterField>(

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -6,6 +6,7 @@ import { defaultJobOptionsHandler } from './handlers/defaultJobOptions';
 import { emptyQueueHandler } from './handlers/emptyQueue';
 import { entryPoint } from './handlers/entryPoint';
 import { jobHandler } from './handlers/job';
+import { jobDataSchemaHandler } from './handlers/jobDataSchema';
 import { jobFlowHandler } from './handlers/jobFlow';
 import { jobLogsHandler } from './handlers/jobLogs';
 import { metricsHandler } from './handlers/metrics';
@@ -41,6 +42,11 @@ export const appRoutes: AppRouteDefs = {
       method: 'get',
       route: '/api/queues/:queueName/default-job-options',
       handler: defaultJobOptionsHandler,
+    },
+    {
+      method: 'get',
+      route: '/api/queues/:queueName/job-data-schema',
+      handler: jobDataSchemaHandler,
     },
     { method: 'put', route: '/api/queues/pause', handler: pauseAllHandler },
     { method: 'put', route: '/api/queues/resume', handler: resumeAllHandler },

--- a/packages/api/tests/api/job-data-schema.spec.ts
+++ b/packages/api/tests/api/job-data-schema.spec.ts
@@ -9,9 +9,11 @@ const connection = {
   port: +(process.env.REDIS_PORT || 6379),
 };
 
-async function fetchQueue(serverAdapter: ExpressAdapter, queueName: string) {
-  const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(200);
-  return JSON.parse(res.text).queues.find((queue: any) => queue.name === queueName);
+async function fetchJobDataSchema(serverAdapter: ExpressAdapter, queueName: string) {
+  const res = await request(serverAdapter.getRouter())
+    .get(`/api/queues/${encodeURIComponent(queueName)}/job-data-schema`)
+    .expect(200);
+  return JSON.parse(res.text);
 }
 
 describe('Job data schema', () => {
@@ -27,7 +29,7 @@ describe('Job data schema', () => {
     await queue.close();
   });
 
-  it('exposes the configured job data schema on the queue', async () => {
+  it('exposes the configured job data schema on a dedicated endpoint', async () => {
     const jobDataSchema = {
       type: 'object',
       properties: {
@@ -39,15 +41,23 @@ describe('Job data schema', () => {
     queue = new Queue('WithSchema', { connection });
     createBullBoard({ queues: [new BullMQAdapter(queue, { jobDataSchema })], serverAdapter });
 
-    const serialized = await fetchQueue(serverAdapter, 'WithSchema');
-    expect(serialized.jobDataSchema).toEqual(jobDataSchema);
+    expect(await fetchJobDataSchema(serverAdapter, 'WithSchema')).toEqual(jobDataSchema);
   });
 
-  it('omits the schema when the queue does not configure one', async () => {
+  it('returns an empty object when the queue does not configure a schema', async () => {
     queue = new Queue('NoSchema', { connection });
     createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
-    const serialized = await fetchQueue(serverAdapter, 'NoSchema');
+    expect(await fetchJobDataSchema(serverAdapter, 'NoSchema')).toEqual({});
+  });
+
+  it('keeps the schema out of the polled queues list', async () => {
+    const jobDataSchema = { type: 'object', properties: { make: { type: 'string' } } };
+    queue = new Queue('WithSchema', { connection });
+    createBullBoard({ queues: [new BullMQAdapter(queue, { jobDataSchema })], serverAdapter });
+
+    const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(200);
+    const serialized = JSON.parse(res.text).queues.find((q: any) => q.name === 'WithSchema');
     expect(serialized.jobDataSchema).toBeUndefined();
   });
 });

--- a/packages/api/tests/api/job-data-schema.spec.ts
+++ b/packages/api/tests/api/job-data-schema.spec.ts
@@ -1,0 +1,53 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { Queue } from 'bullmq';
+import request from 'supertest';
+
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: +(process.env.REDIS_PORT || 6379),
+};
+
+async function fetchQueue(serverAdapter: ExpressAdapter, queueName: string) {
+  const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(200);
+  return JSON.parse(res.text).queues.find((queue: any) => queue.name === queueName);
+}
+
+describe('Job data schema', () => {
+  let serverAdapter: ExpressAdapter;
+  let queue: Queue;
+
+  beforeEach(() => {
+    serverAdapter = new ExpressAdapter();
+  });
+
+  afterEach(async () => {
+    await queue.obliterate({ force: true }).catch(() => {});
+    await queue.close();
+  });
+
+  it('exposes the configured job data schema on the queue', async () => {
+    const jobDataSchema = {
+      type: 'object',
+      properties: {
+        make: { type: 'string' },
+        model: { type: 'string' },
+      },
+      required: ['make', 'model'],
+    };
+    queue = new Queue('WithSchema', { connection });
+    createBullBoard({ queues: [new BullMQAdapter(queue, { jobDataSchema })], serverAdapter });
+
+    const serialized = await fetchQueue(serverAdapter, 'WithSchema');
+    expect(serialized.jobDataSchema).toEqual(jobDataSchema);
+  });
+
+  it('omits the schema when the queue does not configure one', async () => {
+    queue = new Queue('NoSchema', { connection });
+    createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
+
+    const serialized = await fetchQueue(serverAdapter, 'NoSchema');
+    expect(serialized.jobDataSchema).toBeUndefined();
+  });
+});

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -49,7 +49,7 @@ export interface QueueAdapterOptions {
   displayName: string;
   delimiter: string;
   externalJobUrl?: (job: QueueJobJson) => ExternalJobUrl;
-  jobDataSchema: Record<string, any>;
+  jobDataSchema?: Record<string, any>;
 }
 
 export type BullBoardQueues = Map<string, BaseAdapter>;
@@ -177,7 +177,6 @@ export interface AppQueue {
   name: string;
   displayName?: string;
   description?: string;
-  jobDataSchema?: Record<string, any>;
   counts: Record<Status, number>;
   jobs: AppJob[];
   statuses: Status[];

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -49,6 +49,7 @@ export interface QueueAdapterOptions {
   displayName: string;
   delimiter: string;
   externalJobUrl?: (job: QueueJobJson) => ExternalJobUrl;
+  jobDataSchema: Record<string, any>;
 }
 
 export type BullBoardQueues = Map<string, BaseAdapter>;
@@ -176,6 +177,7 @@ export interface AppQueue {
   name: string;
   displayName?: string;
   description?: string;
+  jobDataSchema?: Record<string, any>;
   counts: Record<Status, number>;
   jobs: AppJob[];
   statuses: Status[];

--- a/packages/api/typings/responses.d.ts
+++ b/packages/api/typings/responses.d.ts
@@ -15,3 +15,5 @@ export interface GetQueueMetricsResponse {
 }
 
 export type GetQueueDefaultJobOptionsResponse = QueueDefaultJobOptions;
+
+export type GetQueueJobDataSchemaResponse = Record<string, any>;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,6 +74,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
+    "json-schema-library": "^9.3.5",
     "nanoid": "^6.0.0",
     "pretty-bytes": "^7.1.1",
     "react": "^19.2.7",

--- a/packages/ui/src/components/AddJobModal/AddJobModal.tsx
+++ b/packages/ui/src/components/AddJobModal/AddJobModal.tsx
@@ -5,6 +5,7 @@ import { useActiveQueue } from '../../hooks/useActiveQueue';
 import { useQueues } from '../../hooks/useQueues';
 import bullJobOptionsSchema from '../../schemas/bull/jobOptions.json';
 import bullMQJobOptionsSchema from '../../schemas/bullmq/jobOptions.json';
+import { jobDataFromSchema } from '../../utils/jobDataFromSchema';
 import { Button } from '../Button/Button';
 import { InputField } from '../Form/InputField/InputField';
 import { JsonField } from '../Form/JsonField/JsonField';
@@ -85,7 +86,14 @@ export const AddJobModal = ({ open, onClose, job, queue: queueProp }: AddJobModa
           defaultValue={job?.name}
           placeholder="__default__"
         />
-        <JsonField label={t('ADD_JOB.JOB_DATA')} id="job-data" name="jobData" value={job?.data} />
+        <JsonField
+          key={`job-data-${selectedQueue.name}`}
+          label={t('ADD_JOB.JOB_DATA')}
+          id="job-data"
+          name="jobData"
+          schema={selectedQueue.jobDataSchema}
+          value={job?.data ?? jobDataFromSchema(selectedQueue.jobDataSchema)}
+        />
         <JsonField
           label={t('ADD_JOB.JOB_OPTIONS')}
           id="job-options"

--- a/packages/ui/src/components/AddJobModal/AddJobModal.tsx
+++ b/packages/ui/src/components/AddJobModal/AddJobModal.tsx
@@ -2,6 +2,7 @@ import type { AppJob, AppQueue } from '@bull-board/api/typings/app';
 import { FormEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useActiveQueue } from '../../hooks/useActiveQueue';
+import { useQueueJobDataSchema } from '../../hooks/useQueueJobDataSchema';
 import { useQueues } from '../../hooks/useQueues';
 import bullJobOptionsSchema from '../../schemas/bull/jobOptions.json';
 import bullMQJobOptionsSchema from '../../schemas/bullmq/jobOptions.json';
@@ -29,6 +30,10 @@ export const AddJobModal = ({ open, onClose, job, queue: queueProp }: AddJobModa
   const effectiveQueue = queueProp || useActiveQueue();
   const [selectedQueue, setSelectedQueue] = useState<AppQueue | null>(effectiveQueue);
   const { t } = useTranslation();
+  const { jobDataSchema, loading: jobDataSchemaLoading } = useQueueJobDataSchema(
+    selectedQueue?.name ?? null,
+    open
+  );
 
   if (!queues || !effectiveQueue || !selectedQueue) {
     return null;
@@ -87,12 +92,12 @@ export const AddJobModal = ({ open, onClose, job, queue: queueProp }: AddJobModa
           placeholder="__default__"
         />
         <JsonField
-          key={`job-data-${selectedQueue.name}`}
+          key={`job-data-${selectedQueue.name}-${jobDataSchemaLoading ? 'loading' : 'ready'}`}
           label={t('ADD_JOB.JOB_DATA')}
           id="job-data"
           name="jobData"
-          schema={selectedQueue.jobDataSchema}
-          value={job?.data ?? jobDataFromSchema(selectedQueue.jobDataSchema)}
+          schema={jobDataSchema ?? undefined}
+          value={job?.data ?? jobDataFromSchema(jobDataSchema ?? undefined)}
         />
         <JsonField
           label={t('ADD_JOB.JOB_OPTIONS')}

--- a/packages/ui/src/components/JsonEditor/JsonEditor.tsx
+++ b/packages/ui/src/components/JsonEditor/JsonEditor.tsx
@@ -41,7 +41,6 @@ const customStyle = HighlightStyle.define([
 
 const theme = EditorView.theme({
   '&': {
-    height: '200px',
     backgroundColor: 'var(--input-bg)',
     border: '1px var(--input-border) solid',
     borderRadius: '0.375rem',
@@ -65,7 +64,9 @@ const theme = EditorView.theme({
     borderLeftColor: 'var(--json-edit-cursor-color)',
   },
   '.cm-activeLineGutter': { backgroundColor: 'var(--json-edit-gutter-active-bg)' },
-  '.cm-scroller': { overflow: 'auto' },
+  // Grow with content between a comfortable minimum and a cap, then scroll.
+  '.cm-scroller': { overflow: 'auto', maxHeight: '360px' },
+  '.cm-content': { minHeight: '120px' },
   '.cm-tooltip': {
     padding: '0.25rem 0.5rem',
     borderRadius: '0.275rem',

--- a/packages/ui/src/hooks/queryKeys.ts
+++ b/packages/ui/src/hooks/queryKeys.ts
@@ -15,5 +15,6 @@ export const queryKeys = {
   job: (queueName: string, jobId: string) => ['job', queueName, jobId] as const,
   jobFlow: (queueName: string, jobId: string) => ['jobFlow', queueName, jobId] as const,
   metrics: (queueName: string | null) => ['metrics', queueName] as const,
+  jobDataSchema: (queueName: string | null) => ['jobDataSchema', queueName] as const,
   redisStats: ['redisStats'] as const,
 };

--- a/packages/ui/src/hooks/queryKeys.ts
+++ b/packages/ui/src/hooks/queryKeys.ts
@@ -16,5 +16,6 @@ export const queryKeys = {
   jobFlow: (queueName: string, jobId: string) => ['jobFlow', queueName, jobId] as const,
   metrics: (queueName: string | null) => ['metrics', queueName] as const,
   jobDataSchema: (queueName: string | null) => ['jobDataSchema', queueName] as const,
+  defaultJobOptions: (queueName: string | null) => ['defaultJobOptions', queueName] as const,
   redisStats: ['redisStats'] as const,
 };

--- a/packages/ui/src/hooks/useQueueDefaultJobOptions.ts
+++ b/packages/ui/src/hooks/useQueueDefaultJobOptions.ts
@@ -1,35 +1,17 @@
-import { GetQueueDefaultJobOptionsResponse } from '@bull-board/api/typings/responses';
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from './queryKeys';
 import { useApi } from './useApi';
 
 export function useQueueDefaultJobOptions(queueName: string | null, enabled: boolean) {
   const api = useApi();
-  const [defaultJobOptions, setDefaultJobOptions] =
-    useState<GetQueueDefaultJobOptionsResponse | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (!enabled || !queueName) return;
+  const { data, isPending } = useQuery({
+    queryKey: queryKeys.defaultJobOptions(queueName),
+    queryFn: () => api.getQueueDefaultJobOptions(queueName as string),
+    enabled: enabled && !!queueName,
+    // Fixed at queue construction, it can't change while the dashboard is open.
+    staleTime: Infinity,
+  });
 
-    let cancelled = false;
-    setLoading(true);
-    api
-      .getQueueDefaultJobOptions(queueName)
-      .then((data) => {
-        if (!cancelled) setDefaultJobOptions(data);
-      })
-      .catch((error) => {
-        // eslint-disable-next-line no-console
-        console.error('Failed to fetch default job options', error);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [queueName, enabled]);
-
-  return { defaultJobOptions, loading };
+  return { defaultJobOptions: data ?? null, loading: isPending };
 }

--- a/packages/ui/src/hooks/useQueueJobDataSchema.ts
+++ b/packages/ui/src/hooks/useQueueJobDataSchema.ts
@@ -1,35 +1,17 @@
-import { GetQueueJobDataSchemaResponse } from '@bull-board/api/typings/responses';
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from './queryKeys';
 import { useApi } from './useApi';
 
 export function useQueueJobDataSchema(queueName: string | null, enabled: boolean) {
   const api = useApi();
-  const [jobDataSchema, setJobDataSchema] = useState<GetQueueJobDataSchemaResponse | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (!enabled || !queueName) return;
+  const { data, isPending } = useQuery({
+    queryKey: queryKeys.jobDataSchema(queueName),
+    queryFn: () => api.getQueueJobDataSchema(queueName as string),
+    enabled: enabled && !!queueName,
+    // Author-supplied config, it can't change while the dashboard is open.
+    staleTime: Infinity,
+  });
 
-    let cancelled = false;
-    setLoading(true);
-    setJobDataSchema(null);
-    api
-      .getQueueJobDataSchema(queueName)
-      .then((data) => {
-        if (!cancelled) setJobDataSchema(data);
-      })
-      .catch((error) => {
-        // eslint-disable-next-line no-console
-        console.error('Failed to fetch job data schema', error);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [queueName, enabled]);
-
-  return { jobDataSchema, loading };
+  return { jobDataSchema: data ?? null, loading: isPending };
 }

--- a/packages/ui/src/hooks/useQueueJobDataSchema.ts
+++ b/packages/ui/src/hooks/useQueueJobDataSchema.ts
@@ -1,0 +1,35 @@
+import { GetQueueJobDataSchemaResponse } from '@bull-board/api/typings/responses';
+import { useEffect, useState } from 'react';
+import { useApi } from './useApi';
+
+export function useQueueJobDataSchema(queueName: string | null, enabled: boolean) {
+  const api = useApi();
+  const [jobDataSchema, setJobDataSchema] = useState<GetQueueJobDataSchemaResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || !queueName) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setJobDataSchema(null);
+    api
+      .getQueueJobDataSchema(queueName)
+      .then((data) => {
+        if (!cancelled) setJobDataSchema(data);
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch job data schema', error);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [queueName, enabled]);
+
+  return { jobDataSchema, loading };
+}

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -9,6 +9,7 @@ import {
 import {
   GetJobResponse,
   GetQueueDefaultJobOptionsResponse,
+  GetQueueJobDataSchemaResponse,
   GetQueueMetricsResponse,
   GetQueuesResponse,
 } from '@bull-board/api/typings/responses';
@@ -151,6 +152,10 @@ export class Api {
 
   public getQueueDefaultJobOptions(queueName: string): Promise<GetQueueDefaultJobOptionsResponse> {
     return this.axios.get(`/queues/${encodeURIComponent(queueName)}/default-job-options`);
+  }
+
+  public getQueueJobDataSchema(queueName: string): Promise<GetQueueJobDataSchemaResponse> {
+    return this.axios.get(`/queues/${encodeURIComponent(queueName)}/job-data-schema`);
   }
 
   private handleResponse(response: AxiosResponse): any {

--- a/packages/ui/src/utils/jobDataFromSchema.ts
+++ b/packages/ui/src/utils/jobDataFromSchema.ts
@@ -42,7 +42,8 @@ export function jobDataFromSchema(schema?: JsonSchema): Record<string, any> | un
   if (properties && typeof properties === 'object') {
     return Object.entries(properties as Record<string, JsonSchema>).reduce(
       (acc, [key, prop]) => {
-        acc[key] = prop && prop.default !== undefined ? prop.default : placeholderForType(prop?.type);
+        acc[key] =
+          prop && prop.default !== undefined ? prop.default : placeholderForType(prop?.type);
         return acc;
       },
       {} as Record<string, any>

--- a/packages/ui/src/utils/jobDataFromSchema.ts
+++ b/packages/ui/src/utils/jobDataFromSchema.ts
@@ -1,0 +1,53 @@
+type JsonSchema = Record<string, any>;
+
+function placeholderForType(type: string | string[] | undefined): unknown {
+  const resolved = Array.isArray(type) ? type[0] : type;
+  switch (resolved) {
+    case 'string':
+      return '';
+    case 'number':
+    case 'integer':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'array':
+      return [];
+    case 'object':
+      return {};
+    default:
+      return null;
+  }
+}
+
+/**
+ * Derives a starting value for the "add job" data editor from a queue's JSON Schema.
+ * Priority: an explicit `default`, then the first `examples` entry, then a skeleton
+ * built from `properties` (each key seeded with its own `default` or a typed placeholder).
+ * Returns undefined when the schema carries nothing usable, so callers fall back to `{}`.
+ */
+export function jobDataFromSchema(schema?: JsonSchema): Record<string, any> | undefined {
+  if (!schema || typeof schema !== 'object') {
+    return undefined;
+  }
+
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+
+  if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+
+  const { properties } = schema;
+  if (properties && typeof properties === 'object') {
+    return Object.entries(properties as Record<string, JsonSchema>).reduce(
+      (acc, [key, prop]) => {
+        acc[key] = prop && prop.default !== undefined ? prop.default : placeholderForType(prop?.type);
+        return acc;
+      },
+      {} as Record<string, any>
+    );
+  }
+
+  return undefined;
+}

--- a/packages/ui/src/utils/jobDataFromSchema.ts
+++ b/packages/ui/src/utils/jobDataFromSchema.ts
@@ -1,32 +1,17 @@
-type JsonSchema = Record<string, any>;
+import { Draft07 } from 'json-schema-library';
 
-function placeholderForType(type: string | string[] | undefined): unknown {
-  const resolved = Array.isArray(type) ? type[0] : type;
-  switch (resolved) {
-    case 'string':
-      return '';
-    case 'number':
-    case 'integer':
-      return 0;
-    case 'boolean':
-      return false;
-    case 'array':
-      return [];
-    case 'object':
-      return {};
-    default:
-      return null;
-  }
-}
+type JsonSchema = Record<string, any>;
 
 /**
  * Derives a starting value for the "add job" data editor from a queue's JSON Schema.
- * Priority: an explicit `default`, then the first `examples` entry, then a skeleton
- * built from `properties` (each key seeded with its own `default` or a typed placeholder).
- * Returns undefined when the schema carries nothing usable, so callers fall back to `{}`.
+ * Priority: an explicit schema-level `default`, then the first `examples` entry, then a
+ * template generated from the schema. The template walks nested objects and arrays and
+ * seeds each leaf with its own `default` or a typed placeholder, which the hand-rolled
+ * version could not do. Returns undefined when the schema yields nothing, so callers fall
+ * back to `{}`.
  */
 export function jobDataFromSchema(schema?: JsonSchema): Record<string, any> | undefined {
-  if (!schema || typeof schema !== 'object') {
+  if (!schema || typeof schema !== 'object' || Object.keys(schema).length === 0) {
     return undefined;
   }
 
@@ -38,17 +23,11 @@ export function jobDataFromSchema(schema?: JsonSchema): Record<string, any> | un
     return schema.examples[0];
   }
 
-  const { properties } = schema;
-  if (properties && typeof properties === 'object') {
-    return Object.entries(properties as Record<string, JsonSchema>).reduce(
-      (acc, [key, prop]) => {
-        acc[key] =
-          prop && prop.default !== undefined ? prop.default : placeholderForType(prop?.type);
-        return acc;
-      },
-      {} as Record<string, any>
-    );
-  }
+  const template = new Draft07(schema).getTemplate(undefined, schema, {
+    addOptionalProps: true,
+  }) as Record<string, any> | undefined;
 
-  return undefined;
+  return template && typeof template === 'object' && Object.keys(template).length > 0
+    ? template
+    : undefined;
 }

--- a/packages/ui/tests/utils/jobDataFromSchema.spec.ts
+++ b/packages/ui/tests/utils/jobDataFromSchema.spec.ts
@@ -1,0 +1,57 @@
+import { jobDataFromSchema } from '../../src/utils/jobDataFromSchema';
+
+describe('jobDataFromSchema', () => {
+  it('returns undefined when there is no schema', () => {
+    expect(jobDataFromSchema(undefined)).toBeUndefined();
+    expect(jobDataFromSchema({})).toBeUndefined();
+  });
+
+  it('prefers an explicit schema-level default', () => {
+    const schema = {
+      type: 'object',
+      default: { make: 'Toyota', model: 'Corolla' },
+      properties: { make: { type: 'string' }, model: { type: 'string' } },
+    };
+    expect(jobDataFromSchema(schema)).toEqual({ make: 'Toyota', model: 'Corolla' });
+  });
+
+  it('falls back to the first examples entry', () => {
+    const schema = {
+      type: 'object',
+      examples: [{ make: 'Honda' }, { make: 'Ford' }],
+      properties: { make: { type: 'string' } },
+    };
+    expect(jobDataFromSchema(schema)).toEqual({ make: 'Honda' });
+  });
+
+  it('builds a typed skeleton from properties when no default is given', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        make: { type: 'string' },
+        year: { type: 'number' },
+        electric: { type: 'boolean' },
+        tags: { type: 'array' },
+        meta: { type: 'object' },
+      },
+    };
+    expect(jobDataFromSchema(schema)).toEqual({
+      make: '',
+      year: 0,
+      electric: false,
+      tags: [],
+      meta: {},
+    });
+  });
+
+  it('uses per-property defaults inside the skeleton', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        make: { type: 'string', default: 'Tesla' },
+        model: { type: 'string' },
+      },
+    };
+    expect(jobDataFromSchema(schema)).toEqual({ make: 'Tesla', model: '' });
+  });
+});

--- a/packages/ui/tests/utils/jobDataFromSchema.spec.ts
+++ b/packages/ui/tests/utils/jobDataFromSchema.spec.ts
@@ -54,4 +54,23 @@ describe('jobDataFromSchema', () => {
     };
     expect(jobDataFromSchema(schema)).toEqual({ make: 'Tesla', model: '' });
   });
+
+  it('recurses into nested objects and arrays', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        make: { type: 'string' },
+        owner: {
+          type: 'object',
+          properties: { name: { type: 'string' }, vip: { type: 'boolean' } },
+        },
+        tags: { type: 'array', items: { type: 'string' } },
+      },
+    };
+    expect(jobDataFromSchema(schema)).toEqual({
+      make: '',
+      owner: { name: '', vip: false },
+      tags: [],
+    });
+  });
 });

--- a/website/docs/queue-adapters/index.md
+++ b/website/docs/queue-adapters/index.md
@@ -26,6 +26,32 @@ All adapters accept the same optional options:
 | `prefix` | `string` | `''` | Prepended to job names in the UI. |
 | `delimiter` | `string` | `''` | Delimiter between the prefix and the job name. |
 | `externalJobUrl` | `(job) => { href, displayText? }` | none | Links each job card to a page in your own app. See [External job URLs](/recipes/external-job-url). |
+| `jobDataSchema` | `object` (JSON Schema) | none | Describes the shape of a job's `data`. Drives the **Add job** form: prefills the editor with a starting value and turns on schema-aware autocomplete and validation. See [Job data schema](#job-data-schema). |
+
+## Job data schema
+
+Pass a [JSON Schema](https://json-schema.org/) as `jobDataSchema` to teach the dashboard what a queue's job `data` looks like. The **Add job** form then does three things with it:
+
+- **Prefills** the job data editor with a starting value: the schema's `default`, otherwise its first `examples` entry, otherwise a skeleton built from `properties` (each key seeded with its own `default` or a typed placeholder).
+- **Autocompletes** the expected keys as you type, with any `description` shown on hover.
+- **Validates** the JSON against the schema inline, flagging missing required fields, wrong types, and unknown keys before you submit.
+
+```ts
+new BullMQAdapter(resetPassword, {
+  jobDataSchema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['userId', 'email'],
+    properties: {
+      userId: { type: 'string', description: 'Internal id of the user requesting the reset.' },
+      email: { type: 'string', format: 'email', description: 'Address the reset link is sent to.' },
+      locale: { type: 'string', description: 'BCP-47 locale for the email template.', default: 'en' },
+    },
+  },
+});
+```
+
+The schema is documentation for the dashboard only. It is not enforced by Bull or BullMQ, so keep it in step with what your worker actually expects.
 
 ## Instance methods
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,6 +761,7 @@ __metadata:
     identity-obj-proxy: "npm:^3.0.0"
     jest: "npm:^30.4.2"
     jest-environment-jsdom: "npm:^30.4.1"
+    json-schema-library: "npm:^9.3.5"
     nanoid: "npm:^6.0.0"
     pretty-bytes: "npm:^7.1.1"
     react: "npm:^19.2.7"


### PR DESCRIPTION
Closes #1263.

Queues can now declare an optional JSON Schema for their job `data`, and the add-job form puts it to work. The motivation is the one from the issue: when you manually enqueue a job on a queue you did not write, you should not have to go back to the code to remember what properties it needs.

A single `jobDataSchema` option on any queue adapter drives three things in the **Add job** form:

- **Prefill.** The job data editor opens with a starting value instead of an empty object. It uses the schema's `default`, otherwise its first `examples` entry, otherwise a template generated from the schema by `json-schema-library`, the same validator the editor already pulls in for linting. The template walks nested objects and arrays and seeds each leaf with its own `default` or a typed placeholder, so a schema that only lists `properties` still gives you a ready-to-fill template.
- **Autocomplete.** The editor already speaks JSON Schema for job options; wiring the schema into the job data field gives the same key autocomplete, with any `description` shown on hover.
- **Validation.** The JSON is linted against the schema inline, flagging missing required fields, wrong types and unknown keys before you submit.

The schema is author-supplied config on the adapter, exactly like `description` and `displayName`. It lives in the dashboard only and is never read from Redis, so it documents the contract for the person adding a job rather than enforcing anything at the worker. That tradeoff is called out in the docs.

The dashboard loads the schema from a dedicated `GET /api/queues/:queueName/job-data-schema` endpoint when the Add job modal opens, instead of attaching it to the queues list that the UI polls every 15 seconds. Schemas can get large, and that polled payload is already heavy, so the schema is only fetched when someone actually opens the form. This mirrors the existing `default-job-options` endpoint.

While wiring the schema into the data field, the `JsonEditor` was changed from a fixed 200px box to one that grows with its content between a min and a max height and then scrolls. Small payloads like an empty job-options object no longer sit in a large empty box, and a prefilled schema sizes naturally.

Everything is opt-in and additive. Queues without a `jobDataSchema` behave exactly as before.

### Testing

- `packages/api`: contract tests for the new `job-data-schema` endpoint (returns the configured schema, an empty object when none is set) plus a check that the schema stays out of the polled `GET /api/queues` payload.
- `packages/ui`: unit tests for the prefill derivation (`default` vs `examples` vs properties skeleton, per-property defaults).
- Full UI suite and the API queues suite pass.

The `with-express` example configures a schema on the Reset Password queue for manual verification.
