### PR TITLE
fix(api): declare bull queue libraries as optional peers

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -57,6 +57,16 @@
     "ts-jest": "^29.4.11"
   },
   "peerDependencies": {
-    "@bull-board/ui": "8.1.2"
+    "@bull-board/ui": "8.1.2",
+    "bull": "^4.16.5",
+    "bullmq": "^5.79.2"
+  },
+  "peerDependenciesMeta": {
+    "bull": {
+      "optional": true
+    },
+    "bullmq": {
+      "optional": true
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,13 @@ __metadata:
     ts-jest: "npm:^29.4.11"
   peerDependencies:
     "@bull-board/ui": 8.1.2
+    bull: ^4.16.5
+    bullmq: ^5.79.2
+  peerDependenciesMeta:
+    bull:
+      optional: true
+    bullmq:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes #1265.

`@bull-board/api` imports `bull` / `bullmq` from its queue adapters at runtime,
but currently only declares them as dev dependencies. Under package managers with
strict or isolated dependency layouts, this can fail with `Cannot find module`
when the consumer uses the Bull or BullMQ adapter.

This declares both queue libraries as optional peer dependencies, since consumers
normally use either Bull or BullMQ, not necessarily both.

The peer ranges match the versions currently used by this package's own
devDependencies/tests.

Checks:
- yarn lint:check
- yarn format:check
- yarn test