### PR TITLE
refactor(ui): share the queue test fixture across specs

### DIFF
--- a/packages/ui/src/utils/actionToast.ts
+++ b/packages/ui/src/utils/actionToast.ts
@@ -8,10 +8,6 @@ function hasError(result: unknown): boolean {
   return !!result && typeof result === 'object' && 'error' in result;
 }
 
-/**
- * Runs a queue action behind a pending toast so a long request never looks like a no-op,
- * then swaps that toast for a success message once it settles.
- */
 export async function runWithToast<T>(
   action: () => Promise<T>,
   messages: { pending: string; success: string }
@@ -21,8 +17,7 @@ export async function runWithToast<T>(
   try {
     const result = await action();
 
-    // `Api` resolves failed requests with `{ error }` after raising its own error toast,
-    // so a failure here only needs the pending toast cleared.
+    // `Api` resolves failed requests with `{ error }` and toasts them itself.
     if (hasError(result)) {
       toast.dismiss(toastId);
     } else {

--- a/packages/ui/src/utils/failedRetries.ts
+++ b/packages/ui/src/utils/failedRetries.ts
@@ -1,7 +1,7 @@
 import type { AppQueue } from '@bull-board/api/typings/app';
 
 export function canRetryFailedJobs(queue: AppQueue): boolean {
-  return !queue.readOnlyMode && queue.allowRetries && (queue.counts?.failed || 0) > 0;
+  return !queue.readOnlyMode && queue.allowRetries && queue.counts.failed > 0;
 }
 
 export interface RetriableFailedJobs {

--- a/packages/ui/tests/components/QueueMetrics.spec.tsx
+++ b/packages/ui/tests/components/QueueMetrics.spec.tsx
@@ -1,4 +1,3 @@
-import type { AppQueue } from '@bull-board/api/typings/app';
 import type {
   GetMetricsHistoryResponse,
   GetQueueMetricsResponse,
@@ -6,7 +5,7 @@ import type {
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { QueueMetrics } from '../../src/components/QueueMetrics/QueueMetrics';
 import { useSettingsStore } from '../../src/hooks/useSettings';
-import { createWrapper, deferred, render } from '../testUtils';
+import { createWrapper, deferred, makeQueue, render } from '../testUtils';
 
 beforeEach(() => {
   useSettingsStore.setState({
@@ -16,33 +15,6 @@ beforeEach(() => {
     collapseMetrics: false,
   });
 });
-
-function makeQueue(name: string): AppQueue {
-  return {
-    delimiter: '.',
-    name,
-    counts: {
-      active: 0,
-      completed: 0,
-      delayed: 0,
-      failed: 0,
-      paused: 0,
-      prioritized: 0,
-      waiting: 0,
-      'waiting-children': 0,
-      latest: 0,
-    },
-    jobs: [],
-    statuses: ['waiting', 'completed', 'failed'],
-    pagination: { pageCount: 1, range: { start: 0, end: 9 } },
-    readOnlyMode: false,
-    allowRetries: true,
-    allowCompletedRetries: true,
-    isPaused: false,
-    type: 'bullmq',
-    globalConcurrency: null,
-  };
-}
 
 const withMetrics = (): GetQueueMetricsResponse => ({
   completed: { meta: { count: 10, prevTS: Date.now(), prevCount: 8 }, data: [1, 2, 3], count: 10 },

--- a/packages/ui/tests/components/RetryFailedActions.spec.tsx
+++ b/packages/ui/tests/components/RetryFailedActions.spec.tsx
@@ -5,7 +5,7 @@ import { OverviewActions } from '../../src/components/OverviewDropDownActions/Ov
 import { QueueDropdownActions } from '../../src/components/QueueDropdownActions/QueueDropdownActions';
 import { useSettingsStore } from '../../src/hooks/useSettings';
 import type { QueueActions } from '../../typings/app';
-import { createWrapper, render } from '../testUtils';
+import { createWrapper, makeQueueWithFailed as makeQueue, render } from '../testUtils';
 
 beforeEach(() => {
   useSettingsStore.setState({
@@ -15,38 +15,7 @@ beforeEach(() => {
   });
 });
 
-function makeQueue(name: string, failed: number, overrides: Partial<AppQueue> = {}): AppQueue {
-  return {
-    delimiter: '.',
-    name,
-    displayName: name,
-    counts: {
-      active: 0,
-      completed: 0,
-      delayed: 0,
-      failed,
-      paused: 0,
-      prioritized: 0,
-      waiting: 0,
-      'waiting-children': 0,
-      latest: 0,
-    },
-    jobs: [],
-    statuses: ['waiting', 'completed', 'failed'],
-    pagination: { pageCount: 1, range: { start: 0, end: 9 } },
-    readOnlyMode: false,
-    allowRetries: true,
-    allowCompletedRetries: true,
-    isPaused: false,
-    type: 'bullmq',
-    globalConcurrency: null,
-    ...overrides,
-  };
-}
-
-// The action creators are curried: the component calls them while rendering and only
-// invokes the returned handler on click. Keeping the handlers separate lets the specs
-// tell "the menu item was wired up" apart from "the menu item was actually clicked".
+// Action creators are curried, so the separate handlers let a spec tell "wired up" from "clicked".
 function stubActions() {
   const noop = () => () => Promise.resolve();
   const retryAllHandler = jest.fn(() => Promise.resolve());

--- a/packages/ui/tests/hooks/useQueues.spec.tsx
+++ b/packages/ui/tests/hooks/useQueues.spec.tsx
@@ -1,38 +1,9 @@
-import type { AppQueue } from '@bull-board/api/typings/app';
 import type { GetQueuesResponse } from '@bull-board/api/typings/responses';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { useQueues } from '../../src/hooks/useQueues';
 import { useSettingsStore } from '../../src/hooks/useSettings';
-import { createWrapper, deferred, Deferred } from '../testUtils';
-
-function makeQueue(name: string, overrides: Partial<AppQueue> = {}): AppQueue {
-  return {
-    delimiter: '.',
-    name,
-    counts: {
-      active: 0,
-      completed: 0,
-      delayed: 0,
-      failed: 0,
-      paused: 0,
-      prioritized: 0,
-      waiting: 0,
-      'waiting-children': 0,
-      latest: 0,
-    },
-    jobs: [],
-    statuses: ['waiting', 'completed', 'failed'],
-    pagination: { pageCount: 1, range: { start: 0, end: 9 } },
-    readOnlyMode: false,
-    allowRetries: true,
-    allowCompletedRetries: true,
-    isPaused: false,
-    type: 'bullmq',
-    globalConcurrency: null,
-    ...overrides,
-  };
-}
+import { createWrapper, deferred, Deferred, makeQueue } from '../testUtils';
 
 beforeEach(() => {
   useSettingsStore.setState({

--- a/packages/ui/tests/pages/MetricsHistoryPage.spec.tsx
+++ b/packages/ui/tests/pages/MetricsHistoryPage.spec.tsx
@@ -1,4 +1,3 @@
-import type { AppQueue } from '@bull-board/api/typings/app';
 import type {
   GetMetricsHistoryResponse,
   GetQueuesResponse,
@@ -6,7 +5,7 @@ import type {
 import { act, screen, waitFor, within } from '@testing-library/react';
 import { useSettingsStore } from '../../src/hooks/useSettings';
 import { MetricsHistoryPage } from '../../src/pages/MetricsHistoryPage/MetricsHistoryPage';
-import { createWrapper, deferred, render } from '../testUtils';
+import { createWrapper, deferred, makeQueue, render } from '../testUtils';
 
 beforeEach(() => {
   useSettingsStore.setState({
@@ -15,33 +14,6 @@ beforeEach(() => {
     confirmQueueActions: false,
   });
 });
-
-function makeQueue(name: string): AppQueue {
-  return {
-    delimiter: '.',
-    name,
-    counts: {
-      active: 0,
-      completed: 0,
-      delayed: 0,
-      failed: 0,
-      paused: 0,
-      prioritized: 0,
-      waiting: 0,
-      'waiting-children': 0,
-      latest: 0,
-    },
-    jobs: [],
-    statuses: ['waiting', 'completed', 'failed'],
-    pagination: { pageCount: 1, range: { start: 0, end: 9 } },
-    readOnlyMode: false,
-    allowRetries: true,
-    allowCompletedRetries: true,
-    isPaused: false,
-    type: 'bullmq',
-    globalConcurrency: null,
-  };
-}
 
 function renderPage(
   getHistoryMetrics: jest.Mock,

--- a/packages/ui/tests/testUtils.tsx
+++ b/packages/ui/tests/testUtils.tsx
@@ -1,4 +1,4 @@
-import type { UIConfig } from '@bull-board/api/typings/app';
+import type { AppQueue, UIConfig } from '@bull-board/api/typings/app';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { createMemoryHistory, MemoryHistory } from 'history';
@@ -7,6 +7,43 @@ import { Router } from 'react-router-dom';
 import { ApiContext } from '../src/hooks/useApi';
 import { UIConfigContext } from '../src/hooks/useUIConfig';
 import type { Api } from '../src/services/Api';
+
+export function makeQueue(name: string, overrides: Partial<AppQueue> = {}): AppQueue {
+  return {
+    delimiter: '.',
+    name,
+    counts: {
+      active: 0,
+      completed: 0,
+      delayed: 0,
+      failed: 0,
+      paused: 0,
+      prioritized: 0,
+      waiting: 0,
+      'waiting-children': 0,
+      latest: 0,
+    },
+    jobs: [],
+    statuses: ['waiting', 'completed', 'failed'],
+    pagination: { pageCount: 1, range: { start: 0, end: 9 } },
+    readOnlyMode: false,
+    allowRetries: true,
+    allowCompletedRetries: true,
+    isPaused: false,
+    type: 'bullmq',
+    globalConcurrency: null,
+    ...overrides,
+  };
+}
+
+export function makeQueueWithFailed(
+  name: string,
+  failed: number,
+  overrides: Partial<AppQueue> = {}
+): AppQueue {
+  const queue = makeQueue(name, overrides);
+  return { ...queue, counts: { ...queue.counts, failed } };
+}
 
 export interface Deferred<T> {
   promise: Promise<T>;

--- a/packages/ui/tests/utils/failedRetries.spec.ts
+++ b/packages/ui/tests/utils/failedRetries.spec.ts
@@ -1,36 +1,5 @@
-import type { AppQueue } from '@bull-board/api/typings/app';
 import { canRetryFailedJobs, retriableFailedJobs } from '../../src/utils/failedRetries';
-
-function makeQueue(name: string, overrides: Partial<AppQueue> = {}): AppQueue {
-  return {
-    delimiter: '.',
-    name,
-    counts: {
-      active: 0,
-      completed: 0,
-      delayed: 0,
-      failed: 0,
-      paused: 0,
-      prioritized: 0,
-      waiting: 0,
-      'waiting-children': 0,
-      latest: 0,
-    },
-    jobs: [],
-    statuses: ['waiting', 'completed', 'failed'],
-    pagination: { pageCount: 1, range: { start: 0, end: 9 } },
-    readOnlyMode: false,
-    allowRetries: true,
-    allowCompletedRetries: true,
-    isPaused: false,
-    type: 'bullmq',
-    globalConcurrency: null,
-    ...overrides,
-  };
-}
-
-const withFailed = (name: string, failed: number, overrides: Partial<AppQueue> = {}) =>
-  makeQueue(name, { ...overrides, counts: { ...makeQueue(name).counts, failed } });
+import { makeQueueWithFailed as withFailed } from '../testUtils';
 
 it('allows retrying a writable queue that has failed jobs', () => {
   expect(canRetryFailedJobs(withFailed('Q1', 3))).toBe(true);


### PR DESCRIPTION
Self-review follow-up to #1278, no behaviour change.

`makeQueue` had been copy-pasted into five specs, byte for byte the same each time, and #1278 added two more copies of it. It now lives in `tests/testUtils` alongside a `makeQueueWithFailed` variant for the specs that care about the failed count, which takes about 160 lines out of the suite.

Also drops two comments that only restated the code underneath them, and a defensive `queue.counts?.failed` in `canRetryFailedJobs` where `counts` is required on `AppQueue` and the function next to it already reads it directly.

The dead `toastify.css` rules and the toast dark mode colours are deliberately left out of this one, since #1281 replaces that layer wholesale.
