### PR TITLE
fix(ui): restore mobile header logo contrast in light mode

### DIFF
--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -89,6 +89,8 @@
     height: auto;
     line-height: inherit;
     background-color: transparent;
+    color: var(--text-color);
+    box-shadow: none;
     border: none;
     padding: 0.5rem;
   }


### PR DESCRIPTION
On a phone in light mode the "Bull Dashboard" wordmark is invisible.

The desktop `.logo` rule pairs `background-color: hsl(217, 22%, 24%)` with `color: #f5f8fa`, which reads fine because the logo sits over the dark sidebar column. The `max-width: 768px` block drops the dark background but keeps the near-white text, so on a phone it lands on `--header-bg`, which is `#fff` in light mode. Contrast comes out at 1.06:1. Dark mode was never affected, which is why it went unnoticed.

The desktop `box-shadow` survives the same way and draws a faint panel edge around the logo, which is the box you can see in the before shot.

Adding `color: var(--text-color)` and `box-shadow: none` to the mobile block takes light mode to 9.4:1 and leaves dark mode where it was at 8.05:1.

**Before**

![The mobile header in light mode, with the wordmark invisible against the white background](https://raw.githubusercontent.com/Stosiu/bull-board/assets/retry-all-failed-jobs/shots/v3-mobile-light.png)

**After**

| Light | Dark |
|---|---|
| ![](https://raw.githubusercontent.com/Stosiu/bull-board/assets/retry-all-failed-jobs/shots/header-light-after.png) | ![](https://raw.githubusercontent.com/Stosiu/bull-board/assets/retry-all-failed-jobs/shots/header-dark-after.png) |

Dates back to 2725a18b. Independent of #1280 and #1281, so it sits on its own branch off master.
