### PR TITLE
feat(demo): show historical metrics in the demo, document @bull-board/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,23 @@ That's it! Now you can access the `/admin/queues` route, and you will be able to
 
 See the [docs](https://felixmosh.github.io/bull-board/) for queue adapter options (read-only, retries, formatters, visibility guard), BullMQ Pro setup, board UI config, and more.
 
+## Historical metrics
+
+BullMQ keeps only a short ring buffer of per-minute metrics, so the throughput chart can't look back further than an hour or so. The optional `@bull-board/metrics` package (beta) snapshots those metrics into long-retention Redis buckets and feeds them back to the board, which adds a Metrics history page and 7/30/90 day ranges on every queue chart. It is entirely opt-in: without it the core stays stateless and writes nothing.
+
+```sh
+npm install @bull-board/metrics
+```
+
+See the [historical metrics recipe](https://felixmosh.github.io/bull-board/recipes/historical-metrics) for the recorder setup and storage sizing, or try it on the [live demo](https://felixmosh.github.io/bull-board/demo/).
+
 ## Packages
 
 | Name                                                                     | Version                                                  | Downloads                                                                         |
 | ------------------------------------------------------------------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | [@bull-board/api](https://www.npmjs.com/package/@bull-board/api)         | ![npm](https://img.shields.io/npm/v/@bull-board/api)     | <img alt="npm downloads" src="https://img.shields.io/npm/dw/@bull-board/api">     |
 | [@bull-board/ui](https://www.npmjs.com/package/@bull-board/ui)           | ![npm](https://img.shields.io/npm/v/@bull-board/ui)      | <img alt="npm downloads" src="https://img.shields.io/npm/dw/@bull-board/ui">      |
+| [@bull-board/metrics](https://www.npmjs.com/package/@bull-board/metrics) | ![npm](https://img.shields.io/npm/v/@bull-board/metrics) | <img alt="npm downloads" src="https://img.shields.io/npm/dw/@bull-board/metrics"> |
 | [@bull-board/express](https://www.npmjs.com/package/@bull-board/express) | ![npm](https://img.shields.io/npm/v/@bull-board/express) | <img alt="npm downloads" src="https://img.shields.io/npm/dw/@bull-board/express"> |
 | [@bull-board/fastify](https://www.npmjs.com/package/@bull-board/fastify) | ![npm](https://img.shields.io/npm/v/@bull-board/fastify) | <img alt="npm downloads" src="https://img.shields.io/npm/dw/@bull-board/fastify"> |
 | [@bull-board/koa](https://www.npmjs.com/package/@bull-board/koa)         | ![npm](https://img.shields.io/npm/v/@bull-board/koa)     | <img alt="npm downloads" src="https://img.shields.io/npm/dw/@bull-board/koa">     |

--- a/website/demo/rsbuild.config.ts
+++ b/website/demo/rsbuild.config.ts
@@ -22,6 +22,12 @@ export default defineConfig({
         sortQueues: true,
         miscLinks: [],
         hideDocsLink: false,
+        // Served statically here rather than by the entry route, so the flags
+        // `createBullBoard` derives from the history provider have to be repeated. They
+        // must match the provider wired up in src/mocks/handlers.ts.
+        hasHistoryProvider: true,
+        hasHistoryUsage: true,
+        canPurgeHistory: true,
       }),
     },
   },

--- a/website/demo/src/mocks/MSWServerAdapter.ts
+++ b/website/demo/src/mocks/MSWServerAdapter.ts
@@ -13,6 +13,7 @@ export class MSWServerAdapter implements IServerAdapter {
   private errorHandler: ((error: Error) => ControllerHandlerReturnType) | undefined;
   private uiConfig: UIConfig = {};
   private _handlers: HttpHandler[] = [];
+  private routes: AppControllerRoute[] = [];
   private basePath = '';
 
   setBasePath(path: string): this {
@@ -43,6 +44,7 @@ export class MSWServerAdapter implements IServerAdapter {
   }
 
   setApiRoutes(routes: AppControllerRoute[]): this {
+    this.routes = routes;
     this._handlers = routes.flatMap((route) => {
       const methods = Array.isArray(route.method) ? route.method : [route.method];
       const pathPatterns = Array.isArray(route.route) ? route.route : [route.route];
@@ -54,6 +56,14 @@ export class MSWServerAdapter implements IServerAdapter {
       );
     });
     return this;
+  }
+
+  /**
+   * Rewrites routes that `createBullBoard` already registered, keeping the ones it added
+   * conditionally (the metrics history endpoints) instead of replacing the whole set.
+   */
+  mapApiRoutes(map: (route: AppControllerRoute) => AppControllerRoute): this {
+    return this.setApiRoutes(this.routes.map(map));
   }
 
   setUIConfig(config: UIConfig): this {

--- a/website/demo/src/mocks/MockAdapter.ts
+++ b/website/demo/src/mocks/MockAdapter.ts
@@ -10,6 +10,7 @@ import type {
   Status,
 } from '@bull-board/api/typings/app';
 import { MockQueueJob } from './MockQueueJob';
+import { hashStr, mulberry32 } from './prng';
 import type { DemoJob, DemoQueue } from './state';
 import { countByStatus, nextJobId, state } from './state';
 
@@ -25,28 +26,6 @@ const ALL_JOB_STATES: JobStatus[] = [
 ];
 
 const METRICS_WINDOW = 60;
-
-// Deterministic per-queue noise so the metrics chart is stable across reloads
-// (a flickering demo would make for a jittery screenshot).
-function hashStr(input: string): number {
-  let h = 2166136261;
-  for (let i = 0; i < input.length; i++) {
-    h ^= input.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  return h >>> 0;
-}
-
-function mulberry32(seed: number): () => number {
-  let a = seed;
-  return () => {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
 
 export class MockAdapter extends BaseAdapter {
   constructor(protected mockQueue: DemoQueue) {

--- a/website/demo/src/mocks/MockMetricsHistoryProvider.ts
+++ b/website/demo/src/mocks/MockMetricsHistoryProvider.ts
@@ -1,0 +1,329 @@
+import type {
+  MetricsHistoryPoint,
+  MetricsHistoryProvider,
+  MetricsHistoryPurgeOptions,
+  MetricsHistoryPurgeResult,
+  MetricsHistoryQuery,
+  MetricsHistoryQueueUsage,
+  MetricsHistoryTierUsage,
+  MetricsHistoryUsage,
+  MetricsType,
+} from '@bull-board/api/typings/app';
+import { hashStr, mulberry32 } from './prng';
+import { state } from './state';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const TAU = Math.PI * 2;
+
+/** Matches @bull-board/metrics defaults: hour/day tiers keep 90 days, minutes keep 7. */
+const RETENTION_DAYS = 90;
+const MINUTE_RETENTION_DAYS = 7;
+
+/** Same sentinel the real provider uses for the cross-queue rollup. */
+const GLOBAL_QUEUE = '__global__';
+const METRICS: MetricsType[] = ['completed', 'failed'];
+
+// Byte costs per recorded bucket, taken from the storage table in the
+// @bull-board/metrics README so the demo's storage panel shows realistic numbers.
+const BYTES_PER_MINUTE_BUCKET = 50;
+const BYTES_PER_HOUR_BUCKET = 13;
+const BYTES_PER_DAY_FIELD = 15;
+
+/** Hour bucket start (epoch ms, UTC-aligned) -> value. */
+type Series = Map<number, number>;
+type QueueSeries = Record<MetricsType, Series>;
+
+const alignHour = (ms: number) => Math.floor(ms / HOUR_MS) * HOUR_MS;
+const alignDay = (ms: number) => Math.floor(ms / DAY_MS) * DAY_MS;
+const toIsoDay = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+
+/**
+ * A queue's baseline throughput per hour, derived from how many jobs it holds so the
+ * history table ranks queues the same way the dashboard does.
+ */
+function hourlyBaseline(jobCount: number): number {
+  return Math.max(4, Math.round(jobCount / 2.5));
+}
+
+/**
+ * Synthesises 90 days of hourly throughput for one queue: a daily curve peaking in the
+ * afternoon, quieter weekends, a mild upward trend towards today, and rare hours where
+ * failures spike the way a real incident would.
+ */
+function buildQueueSeries(queueName: string, baseline: number, endHour: number): QueueSeries {
+  const completed: Series = new Map();
+  const failed: Series = new Map();
+  const totalHours = RETENTION_DAYS * 24;
+  const nowFraction = (Date.now() - endHour) / HOUR_MS;
+
+  for (let i = 0; i < totalHours; i++) {
+    const hourStart = endHour - i * HOUR_MS;
+    const rand = mulberry32(hashStr(`${queueName}:${hourStart}`));
+    const date = new Date(hourStart);
+
+    const diurnal = 0.55 + 0.45 * Math.sin(((date.getUTCHours() - 8) / 24) * TAU);
+    const dayOfWeek = date.getUTCDay();
+    const weekly = dayOfWeek === 0 || dayOfWeek === 6 ? 0.55 : 1;
+    const trend = 1 + 0.3 * (1 - i / totalHours);
+    const noise = 0.75 + rand() * 0.5;
+    // The newest bucket is the hour we're in, so it is only partially filled.
+    const elapsed = i === 0 ? Math.max(0.05, nowFraction) : 1;
+
+    const completedValue = Math.round(baseline * diurnal * weekly * trend * noise * elapsed);
+    if (completedValue <= 0) {
+      continue;
+    }
+    completed.set(hourStart, completedValue);
+
+    const isIncident = rand() > 0.985;
+    const failureRate = isIncident ? 0.18 + rand() * 0.2 : 0.005 + rand() * 0.02;
+    const failedValue = Math.round(completedValue * failureRate);
+    if (failedValue > 0) {
+      failed.set(hourStart, failedValue);
+    }
+  }
+
+  return { completed, failed };
+}
+
+function emptyTiers(): Record<'minute' | 'hour' | 'day', MetricsHistoryTierUsage> {
+  return {
+    minute: { keys: 0, bytes: 0 },
+    hour: { keys: 0, bytes: 0 },
+    day: { keys: 0, bytes: 0 },
+  };
+}
+
+function addTiers(
+  target: Record<'minute' | 'hour' | 'day', MetricsHistoryTierUsage>,
+  source: Record<'minute' | 'hour' | 'day', MetricsHistoryTierUsage>
+): void {
+  for (const tier of ['minute', 'hour', 'day'] as const) {
+    target[tier].keys += source[tier].keys;
+    target[tier].bytes += source[tier].bytes;
+  }
+}
+
+/**
+ * In-memory stand-in for `RedisMetricsHistoryProvider` from @bull-board/metrics.
+ *
+ * The demo has no Redis and no recorder, so the history the real package would have
+ * collected over 90 days is generated once at startup and then served, purged and
+ * measured like stored data. Everything lives in the page, so a reload brings it back.
+ */
+export class MockMetricsHistoryProvider implements MetricsHistoryProvider {
+  private readonly store = new Map<string, QueueSeries>();
+
+  constructor() {
+    const endHour = alignHour(Date.now());
+    const global: QueueSeries = { completed: new Map(), failed: new Map() };
+
+    for (const queue of state.queues) {
+      const series = buildQueueSeries(queue.name, hourlyBaseline(queue.jobs.length), endHour);
+      this.store.set(queue.name, series);
+
+      for (const metric of METRICS) {
+        for (const [hourStart, value] of series[metric]) {
+          global[metric].set(hourStart, (global[metric].get(hourStart) ?? 0) + value);
+        }
+      }
+    }
+
+    this.store.set(GLOBAL_QUEUE, global);
+  }
+
+  async getHistory({
+    queue,
+    metric,
+    from,
+    to,
+    granularity,
+  }: MetricsHistoryQuery): Promise<MetricsHistoryPoint[]> {
+    const series = this.store.get(queue ?? GLOBAL_QUEUE)?.[metric];
+    if (!series) {
+      return [];
+    }
+
+    // The real provider reads whole buckets, so a range starting mid-day still returns
+    // that day in full rather than a clipped first point.
+    const start = granularity === 'hour' ? alignHour(from) : alignDay(from);
+    const buckets = new Map<number, number>();
+
+    for (const [hourStart, value] of series) {
+      const bucket = granularity === 'hour' ? hourStart : alignDay(hourStart);
+      if (bucket < start || bucket > to) {
+        continue;
+      }
+      buckets.set(bucket, (buckets.get(bucket) ?? 0) + value);
+    }
+
+    return [...buckets.entries()]
+      .filter(([, value]) => value > 0)
+      .map(([ts, value]) => ({ ts, value }))
+      .sort((a, b) => a.ts - b.ts);
+  }
+
+  async getUsage(): Promise<MetricsHistoryUsage> {
+    const minuteCutoff = Date.now() - MINUTE_RETENTION_DAYS * DAY_MS;
+    const totals = emptyTiers();
+    const queues: MetricsHistoryQueueUsage[] = [];
+    let keys = 0;
+    let bytes = 0;
+    let minutes = 0;
+    const dayBounds: string[] = [];
+
+    for (const [queueName, series] of this.store) {
+      const tiers = emptyTiers();
+      const days = new Set<string>();
+      let queueMinutes = 0;
+
+      for (const metric of METRICS) {
+        const measured = measureSeries(series[metric], minuteCutoff);
+        addTiers(tiers, measured.tiers);
+        queueMinutes += measured.minutes;
+        for (const day of measured.days) {
+          days.add(day);
+        }
+      }
+
+      const queueKeys = tiers.minute.keys + tiers.hour.keys + tiers.day.keys;
+      const queueBytes = tiers.minute.bytes + tiers.hour.bytes + tiers.day.bytes;
+      const sortedDays = [...days].sort();
+
+      queues.push({
+        queue: queueName,
+        keys: queueKeys,
+        bytes: queueBytes,
+        minutes: queueMinutes,
+        days: sortedDays,
+        tiers,
+      });
+
+      addTiers(totals, tiers);
+      keys += queueKeys;
+      bytes += queueBytes;
+      minutes += queueMinutes;
+
+      if (sortedDays.length > 0) {
+        dayBounds.push(sortedDays[0], sortedDays[sortedDays.length - 1]);
+      }
+    }
+
+    queues.sort((a, b) => b.bytes - a.bytes);
+    dayBounds.sort();
+
+    return {
+      keys,
+      bytes,
+      minutes,
+      oldestDay: dayBounds[0] ?? null,
+      newestDay: dayBounds[dayBounds.length - 1] ?? null,
+      tiers: totals,
+      queues,
+    };
+  }
+
+  async purge({ queue, before }: MetricsHistoryPurgeOptions): Promise<MetricsHistoryPurgeResult> {
+    const cutoff = before ? Date.parse(`${before}T00:00:00Z`) : Number.POSITIVE_INFINITY;
+    // The rollup is trimmed first, while the queue's own buckets are still there to
+    // subtract from it.
+    const targets = queue ? [GLOBAL_QUEUE, queue] : [...this.store.keys()];
+    let keysDeleted = 0;
+    let fieldsDeleted = 0;
+
+    for (const name of targets) {
+      const series = this.store.get(name);
+      if (!series) {
+        continue;
+      }
+      // Purging one queue subtracts it from the rollup instead of wiping it, mirroring
+      // what the real admin does to keep the global series consistent.
+      const subtractFrom = queue && name === GLOBAL_QUEUE ? this.store.get(queue) : undefined;
+      if (queue && name === GLOBAL_QUEUE && !subtractFrom) {
+        continue;
+      }
+
+      for (const metric of METRICS) {
+        const target = series[metric];
+        const daysBefore = countDays(target);
+
+        // Deleting the entry a Map iterator is sitting on is well defined, and `set` only
+        // ever overwrites a key that is already there, so this can mutate as it walks.
+        for (const [hourStart, value] of target) {
+          if (hourStart >= cutoff) {
+            continue;
+          }
+          if (subtractFrom) {
+            const remainder = value - (subtractFrom[metric].get(hourStart) ?? 0);
+            if (remainder > 0) {
+              target.set(hourStart, remainder);
+              continue;
+            }
+          }
+          target.delete(hourStart);
+        }
+
+        const daysRemoved = daysBefore - countDays(target);
+        // One minute hash plus one hour hash per day, and one field in the totals hash.
+        keysDeleted += daysRemoved * 2;
+        fieldsDeleted += daysRemoved;
+        if (daysBefore > 0 && target.size === 0) {
+          keysDeleted += 1; // the totals hash itself
+        }
+      }
+    }
+
+    return { keysDeleted, fieldsDeleted };
+  }
+}
+
+function countDays(series: Series): number {
+  const days = new Set<number>();
+  for (const hourStart of series.keys()) {
+    days.add(alignDay(hourStart));
+  }
+  return days.size;
+}
+
+/**
+ * Turns an hourly series into the three-tier footprint the recorder would have written:
+ * a minute hash and an hour hash per active day, plus one field per day in the totals
+ * hash. Minute buckets only survive their shorter retention window.
+ */
+function measureSeries(
+  series: Series,
+  minuteCutoff: number
+): {
+  tiers: Record<'minute' | 'hour' | 'day', MetricsHistoryTierUsage>;
+  days: string[];
+  minutes: number;
+} {
+  const tiers = emptyTiers();
+  const days = new Set<string>();
+  const minuteDays = new Set<string>();
+  let activeHours = 0;
+  let minutes = 0;
+
+  for (const [hourStart, value] of series) {
+    if (value <= 0) {
+      continue;
+    }
+    activeHours += 1;
+    const day = toIsoDay(hourStart);
+    days.add(day);
+
+    if (hourStart >= minuteCutoff) {
+      minuteDays.add(day);
+      // A minute bucket exists for every minute the queue processed something; assume a
+      // few jobs per active minute, capped at the 60 buckets an hour can hold.
+      minutes += Math.min(60, Math.max(1, Math.round(value / 3)));
+    }
+  }
+
+  tiers.minute = { keys: minuteDays.size, bytes: minutes * BYTES_PER_MINUTE_BUCKET };
+  tiers.hour = { keys: days.size, bytes: activeHours * BYTES_PER_HOUR_BUCKET };
+  tiers.day = { keys: days.size > 0 ? 1 : 0, bytes: days.size * BYTES_PER_DAY_FIELD };
+
+  return { tiers, days: [...days], minutes };
+}

--- a/website/demo/src/mocks/handlers.ts
+++ b/website/demo/src/mocks/handlers.ts
@@ -1,10 +1,10 @@
 import { createBullBoard } from '@bull-board/api';
-import { appRoutes } from '@bull-board/api/dist/routes';
 import type { BullBoardRequest, ControllerHandlerReturnType } from '@bull-board/api/typings/app';
 import { seedFixtures } from './fixtures';
 import { findJob, state } from './state';
 import type { DemoJob } from './state';
 import { MockAdapter } from './MockAdapter';
+import { MockMetricsHistoryProvider } from './MockMetricsHistoryProvider';
 import { MSWServerAdapter } from './MSWServerAdapter';
 
 seedFixtures(state);
@@ -94,6 +94,9 @@ createBullBoard({
   serverAdapter,
   options: {
     uiBasePath: '/bull-board/demo',
+    // Stands in for @bull-board/metrics, which needs Redis and a running recorder. It
+    // turns on the Metrics history page and the longer ranges on each queue's chart.
+    historyProvider: new MockMetricsHistoryProvider(),
     uiConfig: {
       boardTitle: 'bull-board demo',
       boardLogo: { path: '/bull-board/demo/logo.svg', width: 32, height: 32 },
@@ -108,12 +111,10 @@ createBullBoard({
 });
 
 // Replace the flow handler with the mock (real one needs bullmq which isn't browser-safe)
-serverAdapter.setApiRoutes(
-  appRoutes.api.map((route) =>
-    route.route === '/api/queues/:queueName/:jobId/flow'
-      ? { ...route, handler: mockJobFlowHandler }
-      : route
-  )
+serverAdapter.mapApiRoutes((route) =>
+  route.route === '/api/queues/:queueName/:jobId/flow'
+    ? { ...route, handler: mockJobFlowHandler }
+    : route
 );
 
 export const handlers = serverAdapter.getHandlers();

--- a/website/demo/src/mocks/prng.ts
+++ b/website/demo/src/mocks/prng.ts
@@ -1,0 +1,21 @@
+// Deterministic noise so the demo's generated series are stable across reloads
+// (a flickering demo would make for a jittery screenshot).
+export function hashStr(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}


### PR DESCRIPTION
The [live demo](https://felixmosh.github.io/bull-board/demo/) doesn't show the historical metrics feature at all, and `@bull-board/metrics` is missing from the readme, so someone landing on either has no way to discover it. This adds both.

Opening as a draft while I get a second opinion on how faithful the demo's fake data should be.

## Demo

The demo runs entirely in the browser on MSW, so there is no Redis and no recorder to snapshot anything. `MockMetricsHistoryProvider` stands in for `RedisMetricsHistoryProvider`: it synthesises 90 days of hourly throughput per queue at startup and then serves, purges and measures it like stored data. The series has a daily curve peaking in the afternoon, quieter weekends, a mild upward trend towards today, and rare hours where failures spike, all seeded off the queue name so the charts are stable across reloads. Queue baselines come from the job counts already in the fixtures, so the history table ranks queues the same way the dashboard does.

It implements the full `MetricsHistoryProvider` surface, including `getUsage` and `purge`, so the storage panel is real rather than decorative. Byte costs per bucket come from the storage table in the metrics readme, so the numbers land in the same ballpark a real recorder would produce. Purging mutates the in-memory series for real and a reload brings everything back.

Two smaller things came out of wiring it up:

- `handlers.ts` used to call `setApiRoutes(appRoutes.api.map(...))` after `createBullBoard` to swap in the browser-safe flow handler, which silently dropped any route `createBullBoard` had registered conditionally. Replaced with a `mapApiRoutes` shim on `MSWServerAdapter` that rewrites the routes already registered.
- The demo's uiConfig is injected statically by rsbuild rather than by the entry route, so `hasHistoryProvider`, `hasHistoryUsage` and `canPurgeHistory` have to be repeated there. Noted in a comment next to both copies.

`hashStr`/`mulberry32` moved out of `MockAdapter` into `prng.ts` since both files now need them.

### Metrics history page, 90d

![Metrics history page](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-demo-metrics/.pr-assets/metrics-history-90d.png)

### Storage panel

![Storage panel](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-demo-metrics/.pr-assets/metrics-history-storage.png)

### Longer ranges on a queue chart

![Queue chart at 90d](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-demo-metrics/.pr-assets/queue-chart-90d.png)

## Readme

Adds `@bull-board/metrics` to the packages table and a short section explaining what it is for, why BullMQ alone can't do it, and that it is opt-in, linking to the existing recipe and the demo.

## Verification

- `tsc --noEmit` and `oxlint` clean on the demo workspace
- `yarn build` in `website/demo` succeeds
- Walked the demo in a browser: history page at 7d/30d/90d, per-queue ranges, storage panel, and a trim purge (recorded range narrowed from 2026-04-24..2026-07-23 to 2026-07-16..2026-07-23, hourly tier dropped from 506 kB to 43.1 kB, trim button correctly disabled afterwards). No console errors.
