### PR TITLE
chore: support ioredis v6

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -51,7 +51,7 @@
     "@types/supertest": "^2.0.16",
     "bull": "^4.16.5",
     "bullmq": "^5.80.9",
-    "ioredis": "^5.11.1",
+    "ioredis": "^6.0.0",
     "jest": "^30.4.2",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.11"

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -39,6 +39,8 @@ recorder downtime, for example:
 
 On shutdown, call `recorder.stop()` and `provider.disconnect()`. Both only close the Redis connection if the recorder/provider opened it internally, so it's a safe no-op if you passed in your own `Redis` instance.
 
+`connection` may be ioredis options or a `Redis` instance you created. `ioredis` is a peer dependency (v5 or v6): resolve a single copy in your app, and if you reuse an existing client, pass one built from that same `ioredis` — a client from a different install (for example one created internally by a BullMQ pinned to a different ioredis major) is not recognized as a `Redis` instance and would be misread as options.
+
 Timestamps and buckets are UTC.
 
 ## Job latency

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -35,15 +35,18 @@
     "@bull-board/api": "8.5.0"
   },
   "peerDependencies": {
-    "ioredis": "^5.0.0"
+    "ioredis": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^22.20.0",
     "bullmq": "^5.80.9",
-    "ioredis": "^5.11.1",
+    "ioredis": "^6.0.0",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.11",
     "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/packages/metrics/src/HistoryAdmin.ts
+++ b/packages/metrics/src/HistoryAdmin.ts
@@ -154,7 +154,10 @@ export class MetricsHistoryAdmin {
       this.redis = opts.connection;
       this.ownsRedis = false;
     } else {
-      this.redis = new Redis(opts.connection);
+      // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
+      // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
+      // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
+      this.redis = new Redis({ protocol: 2, ...opts.connection });
       this.ownsRedis = true;
     }
   }

--- a/packages/metrics/src/LatencySampler.ts
+++ b/packages/metrics/src/LatencySampler.ts
@@ -284,8 +284,10 @@ export class LatencySampler {
       // The prioritized set is scored by priority, not by time, so neither end is guaranteed
       // to hold the oldest job. Both ends are an approximation, and a cheap one: the true
       // oldest would mean fetching the whole set every tick.
-      .zrange(adapter.getQueueKey('prioritized'), 0, 0)
-      .zrange(adapter.getQueueKey('prioritized'), -1, -1)
+      // String indices: ioredis v6 types `zrange`'s stop arg as string-only (Redis coerces
+      // either way), so numeric literals no longer typecheck. '0'/'-1' are the first/last members.
+      .zrange(adapter.getQueueKey('prioritized'), '0', '0')
+      .zrange(adapter.getQueueKey('prioritized'), '-1', '-1')
       .exec();
 
     // A pipeline reports failures per command: a Redis error arrives in the entry's error

--- a/packages/metrics/src/MetricsRecorder.ts
+++ b/packages/metrics/src/MetricsRecorder.ts
@@ -89,7 +89,10 @@ export class MetricsRecorder {
       this.redis = opts.connection;
       this.ownsRedis = false;
     } else {
-      this.redis = new Redis(opts.connection);
+      // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
+      // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
+      // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
+      this.redis = new Redis({ protocol: 2, ...opts.connection });
       this.ownsRedis = true;
     }
     this.store = new HistoryStore({ redis: this.redis, retention: resolveRetention(opts) });

--- a/packages/metrics/src/RedisMetricsHistoryProvider.ts
+++ b/packages/metrics/src/RedisMetricsHistoryProvider.ts
@@ -40,7 +40,10 @@ export class RedisMetricsHistoryProvider implements MetricsHistoryProvider {
       this.redis = opts.connection;
       this.ownsRedis = false;
     } else {
-      this.redis = new Redis(opts.connection);
+      // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
+      // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
+      // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
+      this.redis = new Redis({ protocol: 2, ...opts.connection });
       this.ownsRedis = true;
     }
     const retention = resolveRetention(opts);

--- a/packages/metrics/tests/protocolGuardrail.spec.ts
+++ b/packages/metrics/tests/protocolGuardrail.spec.ts
@@ -1,0 +1,56 @@
+import { Redis } from 'ioredis';
+import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
+import { MetricsRecorder } from '../src/MetricsRecorder';
+import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
+
+// ioredis v6 enables RESP3 (`protocol: 3`) by default. The three classes that can open their
+// own connection force `protocol: 2` on the options-construction path for exact v5 wire parity
+// and Redis < 6 support, while letting an explicit caller `protocol` win. These assertions read
+// the constructed client's negotiated option -- no server round-trip is needed, so they don't
+// depend on the Redis version under test.
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: +(process.env.REDIS_PORT || 6379),
+  db: +(process.env.REDIS_TEST_DB || 15),
+};
+
+// The `redis` field is private; the tests reach it to inspect the resolved options.
+const protocolOf = (owner: { redis: Redis }): number | undefined => owner.redis.options.protocol;
+
+describe('RESP2 guardrail on the options-construction path', () => {
+  describe('defaults an owned connection to protocol 2', () => {
+    it('RedisMetricsHistoryProvider', () => {
+      const provider = new RedisMetricsHistoryProvider({ connection });
+      expect(protocolOf(provider as unknown as { redis: Redis })).toBe(2);
+      provider.disconnect();
+    });
+
+    it('MetricsRecorder', () => {
+      const recorder = new MetricsRecorder({ queues: [], connection });
+      expect(protocolOf(recorder as unknown as { redis: Redis })).toBe(2);
+      recorder.stop();
+    });
+
+    it('MetricsHistoryAdmin', () => {
+      const admin = new MetricsHistoryAdmin({ connection });
+      expect(protocolOf(admin as unknown as { redis: Redis })).toBe(2);
+      admin.disconnect();
+    });
+  });
+
+  it('lets an explicit caller protocol win over the default', () => {
+    const provider = new RedisMetricsHistoryProvider({
+      connection: { ...connection, protocol: 3 },
+    });
+    expect(protocolOf(provider as unknown as { redis: Redis })).toBe(3);
+    provider.disconnect();
+  });
+
+  it('does not override the protocol of an injected Redis instance', () => {
+    const injected = new Redis({ ...connection, lazyConnect: true, protocol: 3 });
+    const provider = new RedisMetricsHistoryProvider({ connection: injected });
+    expect(protocolOf(provider as unknown as { redis: Redis })).toBe(3);
+    // ownsRedis is false for an injected client, so disconnect() is a no-op -- close it directly.
+    injected.disconnect();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,7 +473,7 @@ __metadata:
     "@types/supertest": "npm:^2.0.16"
     bull: "npm:^4.16.5"
     bullmq: "npm:^5.80.9"
-    ioredis: "npm:^5.11.1"
+    ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
     redis-info: "npm:^3.1.0"
     supertest: "npm:^7.2.2"
@@ -670,12 +670,12 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.20.0"
     bullmq: "npm:^5.80.9"
-    ioredis: "npm:^5.11.1"
+    ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
     ts-jest: "npm:^29.4.11"
     typescript: "npm:^5.9.3"
   peerDependencies:
-    ioredis: ^5.0.0
+    ioredis: ^5.0.0 || ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -1817,6 +1817,13 @@ __metadata:
   version: 1.10.0
   resolution: "@ioredis/commands@npm:1.10.0"
   checksum: 10c0/baf91e62d0e64ef2b5f7ca4413dc2456fe250e87483beac4a1c8ef1fe5ad0d2fcdeb9b89d4556d8ef6c7455c64a964359d729601fdb06b2f4c76c35dd59afa99
+  languageName: node
+  linkType: hard
+
+"@ioredis/commands@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@ioredis/commands@npm:2.0.0"
+  checksum: 10c0/2fb5edb9782790c24a375cc78bd69d45ac6c268d7d7ed8e534f2d4ecc28707bde9882a04eecd68be369ae784801bf93fa267b9a76f86418b252a08f341934e35
   languageName: node
   linkType: hard
 
@@ -9329,7 +9336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:5.11.1, ioredis@npm:^5.11.1, ioredis@npm:^5.3.2":
+"ioredis@npm:5.11.1, ioredis@npm:^5.3.2":
   version: 5.11.1
   resolution: "ioredis@npm:5.11.1"
   dependencies:
@@ -9341,6 +9348,20 @@ __metadata:
     redis-parser: "npm:3.0.0"
     standard-as-callback: "npm:2.1.0"
   checksum: 10c0/a8b27043cf2c045dfc93f40a32ce24cf9f8b57799a37f4234c4b925c365ccf131629590f94a512f546fda2ba8ed034009c94c4933ecd44c50bc166636d929fd6
+  languageName: node
+  linkType: hard
+
+"ioredis@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "ioredis@npm:6.0.0"
+  dependencies:
+    "@ioredis/commands": "npm:2.0.0"
+    cluster-key-slot: "npm:1.1.1"
+    debug: "npm:4.4.3"
+    denque: "npm:2.1.0"
+    redis-errors: "npm:1.2.0"
+    standard-as-callback: "npm:2.1.0"
+  checksum: 10c0/6f74e1d298440c0d814e6bf9b3acdb0991d4c1862d3fa64c3828668bcc306823f7845710abdc5eab7986a35d86ec8c86c4bb9c9c7d727636d385ecb2cd40abd7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Support ioredis v6

Widens the `ioredis` range to allow **v6** alongside v5. v6 has only two breaking changes: Node.js 20+ (already met by CI) and RESP3-by-default. RESP3 keeps `replyMappingMode: "legacy"`, so `hgetall` / `hmget` / `pipeline` / `multi` / `scan` return the same RESP2-compatible shapes as v5 — no reply-parsing changes needed. All direct ioredis usage lives in `packages/metrics`.

### Changes

- **Versions** — `@bull-board/metrics`: peer `^5.0.0` → `^5.0.0 || ^6.0.0`, devDep → `^6.0.0`, `engines.node >=20`. `@bull-board/api`: devDep → `^6.0.0` (tests only; no runtime import, so no `engines` floor on the published lib).
- **RESP2 guardrail** — the three metrics classes that open their own connection default the options path to `new Redis({ protocol: 2, ...opts.connection })`, for exact v5 wire parity and Redis < 6 support. Applied only when the caller passes options (never an injected `Redis`); an explicit caller `protocol` still wins.
- **v6 typing fix** — `LatencySampler` passes `zrange` range args as strings (`'0'`/`'-1'`); v6 types the `stop` arg as string-only. Redis coerces either way, behavior unchanged.
- **Tests / docs** — new `protocolGuardrail.spec.ts` (default, override, injected passthrough); README note that a shared client must come from the same `ioredis` install.

### Compatibility

Fully backward compatible: the metrics peer range still accepts ioredis v5, and the `protocol: 2` default preserves existing v5 wire behavior. Consumers pick a single ioredis major via the peer dependency.
