### PR TITLE
fix(api): pass queue prefix to FlowProducer in flow provider

### DIFF
--- a/packages/api/src/providers/flow.ts
+++ b/packages/api/src/providers/flow.ts
@@ -23,7 +23,8 @@ async function getFlowProducer(queues: BullBoardQueues): Promise<FlowProducer | 
   const cached = flowProducerCache.get(client);
   if (cached) return cached;
 
-  const producer = new FlowProducer({ connection: client });
+  const prefix = adapter.getQueuePrefix();
+  const producer = new FlowProducer({ connection: client, ...(prefix ? { prefix } : {}) });
   flowProducerCache.set(client, producer);
   return producer;
 }

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -264,6 +264,10 @@ export class BullMQAdapter extends BaseAdapter {
     return this.queue.client;
   }
 
+  public getQueuePrefix(): string | undefined {
+    return this.queue.opts?.prefix;
+  }
+
   /**
    * Fully prefixed Redis key for one of the queue's sets, for example `bull:MyQueue:completed`.
    * Exposed for @bull-board/metrics, which scans the completed and failed sorted sets

--- a/packages/api/tests/api/job-flow.spec.ts
+++ b/packages/api/tests/api/job-flow.spec.ts
@@ -81,6 +81,40 @@ describe('Job flow', () => {
     expect(res.body.flowRoot.children[0].name).toBe('leaf');
   });
 
+  it('resolves the flow tree when queues use a custom prefix', async () => {
+    const customPrefix = 'custom-prefix';
+    await parentQueue.close();
+    await childQueue.close();
+
+    parentQueue = new Queue('FlowParent', { connection, prefix: customPrefix });
+    childQueue = new Queue('FlowChild', { connection, prefix: customPrefix });
+    await parentQueue.obliterate({ force: true }).catch(() => {});
+    await childQueue.obliterate({ force: true }).catch(() => {});
+
+    flowProducer = new FlowProducer({ connection, prefix: customPrefix });
+
+    const tree = await flowProducer.add({
+      name: 'root',
+      queueName: parentQueue.name,
+      children: [{ name: 'leaf', queueName: childQueue.name, data: {} }],
+    });
+
+    createBullBoard({
+      queues: [new BullMQAdapter(parentQueue), new BullMQAdapter(childQueue)],
+      serverAdapter,
+    });
+    const agent = request(serverAdapter.getRouter());
+
+    const res = await agent
+      .get(`/api/queues/${childQueue.name}/${tree.children![0].job.id}/flow`)
+      .expect(200);
+
+    expect(res.body.isFlowNode).toBe(true);
+    expect(res.body.flowRoot.id).toBe(tree.job.id);
+    expect(res.body.flowRoot.children).toHaveLength(1);
+    expect(res.body.flowRoot.children[0].name).toBe('leaf');
+  });
+
   it('returns a non-flow response for a standalone job', async () => {
     const job = await parentQueue.add('solo', { foo: 'bar' });
 


### PR DESCRIPTION
The Job Flow tree never renders when queues use a custom Redis prefix.

`getFlowProducer()` in `packages/api/src/providers/flow.ts` creates `new FlowProducer({ connection: client })` without forwarding the queue's prefix. BullMQ queues registered with a custom prefix (e.g. `queue-local` via NestJS `BullModule.forRootAsync`) store job data under `<prefix>:<queue>:<jobId>`, but the FlowProducer defaults to `bull:` and looks there instead. `getFlow()` finds nothing and returns null, so the "Job Flow" section is absent for every flow job.

The fix reads the prefix from the adapter's underlying BullMQ queue (`adapter.queue.opts.prefix`) via a new `getQueuePrefix()` on `BullMQAdapter`, and passes it to `new FlowProducer({ connection: client, prefix })`. When no custom prefix is set, BullMQ fills in its own default, so existing behaviour is unchanged.

**To reproduce**: register two BullMQ queues with a non-default prefix, create a flow with a matching `FlowProducer`, open a child job in bull-board — the flow section is missing. After this change it renders the full parent-child tree.

## Tests

Added a test case in `job-flow.spec.ts` that creates queues and a `FlowProducer` with `prefix: 'custom-prefix'`, adds a flow, and asserts that `getFlowTree` resolves the full tree through the API. The three existing default-prefix tests continue to pass.