### PR TITLE
fix(api): drop status-set ids that no longer resolve, and report them

### DIFF
--- a/packages/api/src/handlers/retryAll.ts
+++ b/packages/api/src/handlers/retryAll.ts
@@ -1,4 +1,5 @@
 import { BullBoardRequest, ControllerHandlerReturnType, JobRetryStatus } from '../../typings/app';
+import { RetryAllResponse } from '../../typings/responses';
 import { errorResponse } from '../errors';
 import { queueProvider } from '../providers/queue';
 import { BaseAdapter } from '../queueAdapters/base';
@@ -20,10 +21,17 @@ async function retryAll(
     });
   }
 
+  // Counted first so a job finishing mid-request understates the gap rather than inventing one.
+  const counts = await queue.getJobCounts();
   const jobs = await queue.getJobs([queueStatus]);
   await Promise.all(jobs.map((job) => job.retry(queueStatus)));
 
-  return { status: 200, body: {} };
+  const response: RetryAllResponse = {
+    retried: jobs.length,
+    skipped: Math.max(0, (counts[queueStatus] ?? 0) - jobs.length),
+  };
+
+  return { status: 200, body: response };
 }
 
 export const retryAllHandler = queueProvider(retryAll);

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -91,11 +91,7 @@ export abstract class BaseAdapter {
 
   public abstract getJobCounts(): Promise<JobCounts>;
 
-  /**
-   * The jobs held under the given statuses. A status set can outlive the jobs it points at, so
-   * implementations drop the ids that no longer resolve: every element here is a real job, and
-   * callers may use one without checking.
-   */
+  /** A status set can outlive the jobs it points at, so implementations drop ids that no longer resolve. */
   public abstract getJobs(
     jobStatuses: JobStatus[],
     start?: number,

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -91,6 +91,11 @@ export abstract class BaseAdapter {
 
   public abstract getJobCounts(): Promise<JobCounts>;
 
+  /**
+   * The jobs held under the given statuses. A status set can outlive the jobs it points at, so
+   * implementations drop the ids that no longer resolve: every element here is a real job, and
+   * callers may use one without checking.
+   */
   public abstract getJobs(
     jobStatuses: JobStatus[],
     start?: number,

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -60,8 +60,8 @@ export class BullAdapter extends BaseAdapter {
     start?: number,
     end?: number
   ): Promise<Job[]> {
-    const jobs = await this.queue.getJobs(jobStatuses, start, end);
-    return jobs.map(this.alignJobData);
+    const jobs = (await this.queue.getJobs(jobStatuses, start, end)) as (Job | undefined)[];
+    return jobs.filter((job): job is Job => !!job).map(this.alignJobData);
   }
 
   public getJobCounts(): Promise<JobCounts> {

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -128,9 +128,6 @@ export class BullMQAdapter extends BaseAdapter {
   }
 
   public async getJobs(jobStatuses: JobStatus[], start?: number, end?: number): Promise<Job[]> {
-    // BullMQ resolves the status set to ids and then each id to a job, so an id whose hash is
-    // gone — evicted under a maxmemory-policy other than `noeviction`, or removed by hand —
-    // comes back as `undefined` despite the `Job[]` return type.
     const jobs = (await this.queue.getJobs(jobStatuses, start, end)) as (Job | undefined)[];
     return jobs.filter((job): job is Job => !!job);
   }

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -127,8 +127,12 @@ export class BullMQAdapter extends BaseAdapter {
     return this.queue.getJob(id);
   }
 
-  public getJobs(jobStatuses: JobStatus[], start?: number, end?: number): Promise<Job[]> {
-    return this.queue.getJobs(jobStatuses, start, end);
+  public async getJobs(jobStatuses: JobStatus[], start?: number, end?: number): Promise<Job[]> {
+    // BullMQ resolves the status set to ids and then each id to a job, so an id whose hash is
+    // gone — evicted under a maxmemory-policy other than `noeviction`, or removed by hand —
+    // comes back as `undefined` despite the `Job[]` return type.
+    const jobs = (await this.queue.getJobs(jobStatuses, start, end)) as (Job | undefined)[];
+    return jobs.filter((job): job is Job => !!job);
   }
 
   public getJobCounts(): Promise<JobCounts> {

--- a/packages/api/tests/api/bull-adapter.spec.ts
+++ b/packages/api/tests/api/bull-adapter.spec.ts
@@ -130,6 +130,26 @@ describe('BullAdapter (legacy Bull)', () => {
       expect(await queue.getDelayedCount()).toBe(0);
     });
 
+    it('promotes the surviving delayed jobs when one has lost its data', async () => {
+      const kept = await queue.add('kept', {}, { delay: 60_000 });
+      const lost = await queue.add('lost', {}, { delay: 60_000 });
+      await queue.client.del(queue.toKey(lost.id as string));
+
+      await adapter.promoteAll();
+
+      expect(await (await queue.getJob(kept.id as string))!.getState()).toBe('waiting');
+    });
+
+    it('omits ids whose job data is gone', async () => {
+      const kept = await queue.add('kept', {});
+      const lost = await queue.add('lost', {});
+      await queue.client.del(queue.toKey(lost.id as string));
+
+      const jobs = await adapter.getJobs(['waiting']);
+
+      expect(jobs.map((job) => job?.id)).toEqual([kept.id]);
+    });
+
     it('reports no global concurrency support', async () => {
       expect(await adapter.getGlobalConcurrency()).toBeNull();
       await expect(adapter.setGlobalConcurrency(5)).resolves.toBeUndefined();

--- a/packages/api/tests/api/retry-all.spec.ts
+++ b/packages/api/tests/api/retry-all.spec.ts
@@ -75,6 +75,25 @@ describe('Retry All', () => {
     }
   });
 
+  it('should retry the surviving jobs when an id in the set has lost its data', async () => {
+    const jobIds = await failMultipleJobs(3);
+    await worker.close();
+    // A job hash can disappear while its id stays in the failed set — any maxmemory-policy
+    // other than `noeviction` will do it — and that id then resolves to no job at all.
+    const [orphanId, ...survivorIds] = jobIds;
+    const client = await testQueue.client;
+    await client.del(testQueue.toKey(orphanId));
+
+    const agent = setupBoard();
+
+    await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(200);
+
+    for (const jobId of survivorIds) {
+      const job = await testQueue.getJob(jobId);
+      expect(await job!.getState()).toBe('waiting');
+    }
+  });
+
   it('should return 400 for non-retriable status', async () => {
     const agent = setupBoard();
 

--- a/packages/api/tests/api/retry-all.spec.ts
+++ b/packages/api/tests/api/retry-all.spec.ts
@@ -67,8 +67,9 @@ describe('Retry All', () => {
     await worker.close();
     const agent = setupBoard();
 
-    await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(200);
+    const res = await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(200);
 
+    expect(res.body).toEqual({ retried: 3, skipped: 0 });
     for (const jobId of jobIds) {
       const job = await testQueue.getJob(jobId);
       expect(await job!.getState()).toBe('waiting');
@@ -84,8 +85,9 @@ describe('Retry All', () => {
 
     const agent = setupBoard();
 
-    await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(200);
+    const res = await agent.put(`/api/queues/${testQueue.name}/retry/failed`).expect(200);
 
+    expect(res.body).toEqual({ retried: 2, skipped: 1 });
     for (const jobId of survivorIds) {
       const job = await testQueue.getJob(jobId);
       expect(await job!.getState()).toBe('waiting');

--- a/packages/api/tests/api/retry-all.spec.ts
+++ b/packages/api/tests/api/retry-all.spec.ts
@@ -78,8 +78,6 @@ describe('Retry All', () => {
   it('should retry the surviving jobs when an id in the set has lost its data', async () => {
     const jobIds = await failMultipleJobs(3);
     await worker.close();
-    // A job hash can disappear while its id stays in the failed set — any maxmemory-policy
-    // other than `noeviction` will do it — and that id then resolves to no job at all.
     const [orphanId, ...survivorIds] = jobIds;
     const client = await testQueue.client;
     await client.del(testQueue.toKey(orphanId));

--- a/packages/api/tests/queueAdapters/bullMQ.spec.ts
+++ b/packages/api/tests/queueAdapters/bullMQ.spec.ts
@@ -42,8 +42,6 @@ describe('BullMQAdapter.getJobs', () => {
     await queue.close();
   });
 
-  // BullMQ resolves a status set to ids and then each id to a job, so an id left behind by a
-  // deleted job hash comes back as `undefined`. Callers are typed for jobs, not holes.
   it('omits ids whose job data is gone', async () => {
     const kept = await queue.add('kept', {});
     const lost = await queue.add('lost', {});

--- a/packages/api/tests/queueAdapters/bullMQ.spec.ts
+++ b/packages/api/tests/queueAdapters/bullMQ.spec.ts
@@ -24,3 +24,34 @@ describe('BullMQAdapter.getQueueKey', () => {
     expect(adapter.getQueueKey('completed')).toBe('custom:KeyQueue:completed');
   });
 });
+
+describe('BullMQAdapter.getJobs', () => {
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+  let queue: Queue;
+
+  beforeEach(async () => {
+    queue = new Queue('HoleQueue', { connection });
+    await queue.obliterate({ force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await queue.obliterate({ force: true }).catch(() => {});
+    await queue.close();
+  });
+
+  // BullMQ resolves a status set to ids and then each id to a job, so an id left behind by a
+  // deleted job hash comes back as `undefined`. Callers are typed for jobs, not holes.
+  it('omits ids whose job data is gone', async () => {
+    const kept = await queue.add('kept', {});
+    const lost = await queue.add('lost', {});
+    const client = await queue.client;
+    await client.del(queue.toKey(lost.id as string));
+
+    const jobs = await new BullMQAdapter(queue).getJobs(['waiting']);
+
+    expect(jobs.map((job) => job?.id)).toEqual([kept.id]);
+  });
+});

--- a/packages/api/typings/responses.d.ts
+++ b/packages/api/typings/responses.d.ts
@@ -45,6 +45,12 @@ export interface JobBelongsToJobSchedulerResponse {
 
 export type CleanJobResponse = JobBelongsToJobSchedulerResponse | undefined;
 
+/** `skipped` counts ids that were in the set with no job behind them, so a partial retry is visible. */
+export interface RetryAllResponse {
+  retried: number;
+  skipped: number;
+}
+
 export interface GetJobSchedulersResponse {
   schedulers: AppJobScheduler[];
 }

--- a/packages/ui/src/hooks/useQueues.ts
+++ b/packages/ui/src/hooks/useQueues.ts
@@ -58,12 +58,18 @@ export function useQueues(): QueuesState & { actions: QueueActions } {
 
   const withConfirmAndUpdate = getConfirmFor(invalidateQueues, openConfirm);
 
+  const skippedDescription = (skipped: number | undefined) =>
+    skipped ? t('QUEUE.ACTIONS.TOAST.RETRY_SKIPPED', { count: skipped }) : undefined;
+
   const retryAll = (queueName: string, status: JobRetryStatus) =>
     withConfirmAndUpdate(
       () =>
         runWithToast(() => api.retryAll(queueName, status), {
           pending: t('QUEUE.ACTIONS.TOAST.RETRY_PENDING', { status }),
-          success: t('QUEUE.ACTIONS.TOAST.RETRY_DONE', { status }),
+          success: (result) => ({
+            title: t('QUEUE.ACTIONS.TOAST.RETRY_DONE', { status }),
+            description: skippedDescription(result?.skipped),
+          }),
         }),
       t('QUEUE.ACTIONS.CONFIRM.RETRY_ALL', { status }),
       confirmQueueActions
@@ -79,9 +85,14 @@ export function useQueues(): QueuesState & { actions: QueueActions } {
               jobs: jobCount,
               count: queueNames.length,
             }),
-            success: t('QUEUE.ACTIONS.TOAST.RETRY_QUEUES_DONE', {
-              jobs: jobCount,
-              count: queueNames.length,
+            success: (results) => ({
+              title: t('QUEUE.ACTIONS.TOAST.RETRY_QUEUES_DONE', {
+                jobs: jobCount,
+                count: queueNames.length,
+              }),
+              description: skippedDescription(
+                results.reduce((total, result) => total + (result?.skipped ?? 0), 0)
+              ),
             }),
           }
         ),

--- a/packages/ui/src/services/Api.ts
+++ b/packages/ui/src/services/Api.ts
@@ -25,6 +25,7 @@ import {
   GetQueueMetricsResponse,
   GetQueuesResponse,
   GetQueueWorkersResponse,
+  RetryAllResponse,
 } from '@bull-board/api/typings/responses';
 import Axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { translateMessage } from '../utils/translateMessage';
@@ -62,7 +63,7 @@ export class Api {
     return this.axios.get(`/queues/${encodeURIComponent(queueName)}/workers`);
   }
 
-  public retryAll(queueName: string, status: JobRetryStatus): Promise<void> {
+  public retryAll(queueName: string, status: JobRetryStatus): Promise<RetryAllResponse> {
     return this.axios.put(
       `/queues/${encodeURIComponent(queueName)}/retry/${encodeURIComponent(status)}`
     );

--- a/packages/ui/src/static/locales/da-DK/messages.json
+++ b/packages/ui/src/static/locales/da-DK/messages.json
@@ -122,6 +122,7 @@
       "TOAST": {
         "RETRY_PENDING": "Prøver alle {{status}} jobs igen...",
         "RETRY_DONE": "Alle {{status}} jobs blev sendt tilbage i køen",
+        "RETRY_SKIPPED": "Sprang {{count}} id'er over, som ikke havde jobdata bag sig. Jobdata går som regel tabt på grund af en anden Redis-eviction-politik end noeviction.",
         "RETRY_QUEUES_PENDING": "Prøver {{jobs}} fejlede jobs i {{count}} køer igen...",
         "RETRY_QUEUES_DONE": "{{jobs}} fejlede jobs i {{count}} køer blev sendt tilbage i deres køer"
       },

--- a/packages/ui/src/static/locales/de-DE/messages.json
+++ b/packages/ui/src/static/locales/de-DE/messages.json
@@ -122,6 +122,7 @@
       "TOAST": {
         "RETRY_PENDING": "Alle {{status}} Jobs werden wiederholt...",
         "RETRY_DONE": "Alle {{status}} Jobs wurden zurück in die Warteschlange gestellt",
+        "RETRY_SKIPPED": "{{count}} IDs ohne zugehörige Jobdaten übersprungen. Die Jobdaten gehen meist durch eine andere Redis-Eviction-Policy als noeviction verloren.",
         "RETRY_QUEUES_PENDING": "{{jobs}} fehlgeschlagene Jobs in {{count}} Warteschlangen werden wiederholt...",
         "RETRY_QUEUES_DONE": "{{jobs}} fehlgeschlagene Jobs in {{count}} Warteschlangen wurden zurückgestellt"
       },

--- a/packages/ui/src/static/locales/en-GB/messages.json
+++ b/packages/ui/src/static/locales/en-GB/messages.json
@@ -122,6 +122,7 @@
       "TOAST": {
         "RETRY_PENDING": "Retrying all {{status}} jobs...",
         "RETRY_DONE": "All {{status}} jobs were sent back to the queue",
+        "RETRY_SKIPPED": "Skipped {{count}} ids with no job data behind them. The job data is usually lost to a Redis eviction policy other than noeviction.",
         "RETRY_QUEUES_PENDING": "Retrying {{jobs}} failed jobs in {{count}} queues...",
         "RETRY_QUEUES_DONE": "{{jobs}} failed jobs in {{count}} queues were sent back to their queues"
       },

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -121,6 +121,7 @@
       "TOAST": {
         "RETRY_PENDING": "Retrying all {{status}} jobs...",
         "RETRY_DONE": "All {{status}} jobs were sent back to the queue",
+        "RETRY_SKIPPED": "Skipped {{count}} ids with no job data behind them. The job data is usually lost to a Redis eviction policy other than noeviction.",
         "RETRY_QUEUES_PENDING": "Retrying {{jobs}} failed jobs in {{count}} queues...",
         "RETRY_QUEUES_DONE": "{{jobs}} failed jobs in {{count}} queues were sent back to their queues"
       },

--- a/packages/ui/src/static/locales/es-ES/messages.json
+++ b/packages/ui/src/static/locales/es-ES/messages.json
@@ -123,6 +123,7 @@
       "TOAST": {
         "RETRY_PENDING": "Reintentando todas las tareas {{status}}...",
         "RETRY_DONE": "Todas las tareas {{status}} volvieron a la cola",
+        "RETRY_SKIPPED": "Se omitieron {{count}} ids sin datos de tarea detrás. Los datos suelen perderse por una política de expulsión de Redis distinta de noeviction.",
         "RETRY_QUEUES_PENDING": "Reintentando {{jobs}} tareas fallidas de {{count}} colas...",
         "RETRY_QUEUES_DONE": "{{jobs}} tareas fallidas de {{count}} colas volvieron a sus colas"
       },

--- a/packages/ui/src/static/locales/fr-FR/messages.json
+++ b/packages/ui/src/static/locales/fr-FR/messages.json
@@ -123,6 +123,7 @@
       "TOAST": {
         "RETRY_PENDING": "Nouvelle tentative de toutes les tâches {{status}}...",
         "RETRY_DONE": "Toutes les tâches {{status}} ont été renvoyées dans la file",
+        "RETRY_SKIPPED": "{{count}} ids ignorés, sans données de tâche associées. Ces données sont généralement perdues à cause d'une politique d'éviction Redis autre que noeviction.",
         "RETRY_QUEUES_PENDING": "Nouvelle tentative de {{jobs}} tâches échouées dans {{count}} files...",
         "RETRY_QUEUES_DONE": "{{jobs}} tâches échouées de {{count}} files ont été renvoyées dans leurs files"
       },

--- a/packages/ui/src/static/locales/ja-JP/messages.json
+++ b/packages/ui/src/static/locales/ja-JP/messages.json
@@ -121,6 +121,7 @@
       "TOAST": {
         "RETRY_PENDING": "すべての{{status}}ジョブを再試行しています...",
         "RETRY_DONE": "すべての{{status}}ジョブをキューに戻しました",
+        "RETRY_SKIPPED": "ジョブデータが存在しない ID を {{count}} 件スキップしました。通常、noeviction 以外の Redis の破棄ポリシーによってジョブデータが失われます。",
         "RETRY_QUEUES_PENDING": "{{count}}個のキューの{{jobs}}件の失敗したジョブを再試行しています...",
         "RETRY_QUEUES_DONE": "{{count}}個のキューの{{jobs}}件の失敗したジョブをキューに戻しました"
       },

--- a/packages/ui/src/static/locales/ko-KR/messages.json
+++ b/packages/ui/src/static/locales/ko-KR/messages.json
@@ -120,6 +120,7 @@
       "TOAST": {
         "RETRY_PENDING": "모든 {{status}} 작업을 재시도하는 중...",
         "RETRY_DONE": "모든 {{status}} 작업을 큐로 되돌렸습니다",
+        "RETRY_SKIPPED": "작업 데이터가 없는 ID {{count}}개를 건너뛰었습니다. 작업 데이터는 보통 noeviction이 아닌 Redis 제거 정책 때문에 사라집니다.",
         "RETRY_QUEUES_PENDING": "{{count}}개 큐의 실패한 작업 {{jobs}}건을 재시도하는 중...",
         "RETRY_QUEUES_DONE": "{{count}}개 큐의 실패한 작업 {{jobs}}건을 각 큐로 되돌렸습니다"
       },

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -123,6 +123,7 @@
       "TOAST": {
         "RETRY_PENDING": "Tentando novamente todos os trabalhos {{status}}...",
         "RETRY_DONE": "Todos os trabalhos {{status}} voltaram para a fila",
+        "RETRY_SKIPPED": "{{count}} ids ignorados por não terem dados de trabalho. Os dados costumam se perder por uma política de remoção do Redis diferente de noeviction.",
         "RETRY_QUEUES_PENDING": "Tentando novamente {{jobs}} trabalhos com falha em {{count}} filas...",
         "RETRY_QUEUES_DONE": "{{jobs}} trabalhos com falha de {{count}} filas voltaram para suas filas"
       },

--- a/packages/ui/src/static/locales/tr-TR/messages.json
+++ b/packages/ui/src/static/locales/tr-TR/messages.json
@@ -122,6 +122,7 @@
       "TOAST": {
         "RETRY_PENDING": "“{{status}}” durumundaki tüm işler yeniden deneniyor...",
         "RETRY_DONE": "“{{status}}” durumundaki tüm işler kuyruğa geri gönderildi",
+        "RETRY_SKIPPED": "İş verisi bulunmayan {{count}} kimlik atlandı. İş verileri genellikle noeviction dışındaki bir Redis tahliye politikası yüzünden kaybolur.",
         "RETRY_QUEUES_PENDING": "{{count}} kuyruktaki {{jobs}} başarısız iş yeniden deneniyor...",
         "RETRY_QUEUES_DONE": "{{count}} kuyruktaki {{jobs}} başarısız iş kendi kuyruklarına geri gönderildi"
       },

--- a/packages/ui/src/static/locales/zh-CN/messages.json
+++ b/packages/ui/src/static/locales/zh-CN/messages.json
@@ -120,6 +120,7 @@
       "TOAST": {
         "RETRY_PENDING": "正在重试所有{{status}}作业...",
         "RETRY_DONE": "所有{{status}}作业已重新入队",
+        "RETRY_SKIPPED": "已跳过 {{count}} 个没有作业数据的 ID。作业数据通常因 Redis 使用了 noeviction 以外的淘汰策略而丢失。",
         "RETRY_QUEUES_PENDING": "正在重试 {{count}} 个队列中的 {{jobs}} 个失败作业...",
         "RETRY_QUEUES_DONE": "{{count}} 个队列中的 {{jobs}} 个失败作业已重新入队"
       },

--- a/packages/ui/src/utils/actionToast.ts
+++ b/packages/ui/src/utils/actionToast.ts
@@ -8,9 +8,19 @@ function hasError(result: unknown): boolean {
   return !!result && typeof result === 'object' && 'error' in result;
 }
 
+type SuccessToast = string | { title: string; description?: string };
+
+function resolveSuccess<T>(
+  success: SuccessToast | ((result: T) => SuccessToast),
+  result: T
+): { title: string; description?: string } {
+  const resolved = typeof success === 'function' ? success(result) : success;
+  return typeof resolved === 'string' ? { title: resolved } : resolved;
+}
+
 export async function runWithToast<T>(
   action: () => Promise<T>,
-  messages: { pending: string; success: string }
+  messages: { pending: string; success: SuccessToast | ((result: T) => SuccessToast) }
 ): Promise<T> {
   const toastId = toastManager.add({
     type: 'loading',
@@ -27,7 +37,7 @@ export async function runWithToast<T>(
     } else {
       toastManager.update(toastId, {
         type: 'success',
-        title: messages.success,
+        ...resolveSuccess(messages.success, result),
         timeout: TOAST_TIMEOUT,
       });
     }

--- a/packages/ui/tests/utils/actionToast.spec.ts
+++ b/packages/ui/tests/utils/actionToast.spec.ts
@@ -67,6 +67,18 @@ it('reports success for a batch where every request succeeded', async () => {
   );
 });
 
+it('builds the success toast from the result when success is a function', async () => {
+  await runWithToast(() => Promise.resolve({ skipped: 2 }), {
+    pending: 'pending',
+    success: (result) => ({ title: 'success', description: `skipped ${result.skipped}` }),
+  });
+
+  expect(toastManager.update).toHaveBeenCalledWith(
+    'toast-id',
+    expect.objectContaining({ title: 'success', description: 'skipped 2' })
+  );
+});
+
 it('drops the pending toast and rethrows when the action throws', async () => {
   const boom = new Error('boom');
 

--- a/website/docs/recipes/troubleshooting.md
+++ b/website/docs/recipes/troubleshooting.md
@@ -47,6 +47,14 @@ Working as intended. BullMQ v6 removed the paused job state, so a paused queue k
 
 That's [read-only mode](/recipes/read-only-mode) doing its job. The queue was registered with `readOnlyMode: true` (or the action is gated by `allowRetries`). Intended, not a bug.
 
+## "Retry all" says it skipped some ids, or a count is higher than the list
+
+The status set holds ids whose job data is gone, so the dashboard has an id and nothing to show for it. Counts come from the set (a `ZCARD`), which is why the badge can read higher than the rows beneath it, and why retrying leaves it stuck above zero.
+
+Redis is almost always the cause. BullMQ and Bull both require `maxmemory-policy noeviction`; under `allkeys-lru` or any other policy Redis evicts individual job hashes once memory fills, while the sets that point at them survive. Check with `redis-cli config get maxmemory-policy`, raise the instance's memory before switching the policy, or the writes that used to evict will start failing outright.
+
+The leftover ids are not removed for you, since deleting datastore entries is more than a dashboard should do behind your back. They age out of `completed` as new jobs push them past `removeOnComplete`, and **Clean** removes them from any set — along with the real jobs in it.
+
 ## Still stuck
 
 Open an issue on [felixmosh/bull-board](https://github.com/felixmosh/bull-board/issues) with your adapter, versions, and the mount/base-path setup. Most reports resolve to one of the above once the exact paths are on the table.


### PR DESCRIPTION
"Retry all failed" answers `500 ERRORS.INTERNAL_SERVER_ERROR` with `Cannot read properties of undefined (reading 'retry')` whenever the status set holds an id with no job behind it.

`getJobs()` is typed `Promise<QueueJob[]>` and does not deliver it. BullMQ reads ids out of the set and maps them through `Job.fromId`, which answers `undefined` for an empty hash (Bull answers `null`), so `retryAll` calls `.retry()` on nothing. `handlers/queues.ts` is the only caller that already guarded itself with `filter(Boolean)`; both `promoteAll` implementations carry the same latent crash.

Ids outliving their jobs is ordinary rather than exotic: any `maxmemory-policy` other than `noeviction` evicts job hashes while the hot status sets survive. On a 1 GB Memorystore instance running `allkeys-lru` I found holes in 18 of 26 queues, up to 690 of 1000 ids in one `completed` set.

It is also unrecoverable from the dashboard. `Promise.all(jobs.map(...))` throws mid-iteration, so the retries already dispatched keep running while the request fails; each click retries the jobs ahead of the first hole until the set is nothing but holes and the button stops doing anything at all.

## The fix

Filter in `BullMQAdapter.getJobs` and `BullAdapter.getJobs` so the declared type becomes true, and say so on `BaseAdapter.getJobs`. That covers `retryAll`, both `promoteAll`s and `BullMQProAdapter` without touching any of them. The `filter(Boolean)` already in `handlers/queues.ts` stays as insurance for adapters outside this repo.

## Saying so out loud

Filtering alone trades a crash for a quieter lie. `getJobCounts()` is a `ZCARD`, so the badge still counts the holes: the list renders two jobs under a three, and retry-all now succeeds while leaving that three stuck forever with no clue why.

Deleting the leftover ids is not a dashboard's call, so `retryAll` explains itself instead of acting. It returns `{ retried, skipped }`, and the success toast fills its description slot with what happened and the reason it usually happens:

> Skipped 2 ids with no job data behind them. The job data is usually lost to a Redis eviction policy other than noeviction.

`skipped` is the gap between the count and the jobs that resolved, read before the retries so a job finishing mid-request understates it rather than inventing one. Retrying failed jobs across several queues sums the gaps into one description. Translated in all ten non-English locales, and `troubleshooting.md` gains an entry for people who meet the mismatched count before they meet the toast.

`runWithToast` grew a `success` that can be a function of the result, or `{ title, description }`, since it only ever took a fixed string before.

## Tests

Four for the crash, each producing the hole the way production does — `client.del(queue.toKey(id))`, leaving the id in the set. Without the fix retry-all returns 500, Bull's `promoteAll` throws, and both adapters' `getJobs` return `[undefined, "1"]`. The retry-all specs also pin the new body (`{ retried: 2, skipped: 1 }` with a hole, `{ retried: 3, skipped: 0 }` without), and `actionToast.spec.ts` covers the result-driven toast.

Green across all three jest projects including the v5/v6 matrix, every adapter package, and `test:ui`; `typecheck:bullmq` passes both majors.

Worth knowing while reviewing: the `tests/api` specs import the built package, so stashing the source change is not enough to watch them fail — `dist` has to be rebuilt in between.
