### PR TITLE
fix(api): count grouped jobs, not groups, in BullMQProAdapter

### DIFF
--- a/packages/api/bullMQProAdapter.d.ts
+++ b/packages/api/bullMQProAdapter.d.ts
@@ -1,6 +1,5 @@
 export { BullMQProAdapter } from './dist/queueAdapters/bullMQPro';
 export type {
-  GroupJobCountsByStatus,
   GroupStatusName,
   GroupSummary,
   GroupSummaryWithCount,

--- a/packages/api/bullMQProAdapter.d.ts
+++ b/packages/api/bullMQProAdapter.d.ts
@@ -1,5 +1,6 @@
 export { BullMQProAdapter } from './dist/queueAdapters/bullMQPro';
 export type {
+  GroupJobCountsByStatus,
   GroupStatusName,
   GroupSummary,
   GroupSummaryWithCount,

--- a/packages/api/src/queueAdapters/bullMQPro.ts
+++ b/packages/api/src/queueAdapters/bullMQPro.ts
@@ -9,13 +9,16 @@ import {
 import { STATUSES } from '../constants/statuses';
 import { BullMQAdapter } from './bullMQ';
 import type {
-  GroupsCountByStatus,
+  GroupJobCountsByStatus,
   GroupStatusName,
+  GroupSummaryWithCount,
   JobProLike,
   QueueProLike,
 } from './bullMQProTypes';
 
-const GROUP_COUNTS_TTL_MS = 5_000;
+const GROUPS_TTL_MS = 5_000;
+
+const GROUP_STATUSES: GroupStatusName[] = ['waiting', 'limited', 'maxed', 'paused'];
 
 const BUCKET_TO_GROUP_STATUSES: Partial<Record<JobStatus, GroupStatusName[]>> = {
   [STATUSES.waiting]: ['waiting'],
@@ -23,15 +26,30 @@ const BUCKET_TO_GROUP_STATUSES: Partial<Record<JobStatus, GroupStatusName[]>> = 
   [STATUSES.paused]: ['paused'],
 };
 
-interface CachedGroupCounts {
+/**
+ * Jobs held by a single group.
+ *
+ * bullmq-pro only started returning `count` from `getGroupsByStatus()` in 7.46.3. On older
+ * versions it is missing, and counting the group as one job keeps the totals in the same
+ * ballpark -- a group is only listed while it holds jobs -- instead of yielding `NaN`.
+ */
+function groupJobCount(group: GroupSummaryWithCount): number {
+  return Number.isFinite(group.count) ? group.count : 1;
+}
+
+function sumGroupJobs(groups: GroupSummaryWithCount[]): number {
+  return groups.reduce((total, group) => total + groupJobCount(group), 0);
+}
+
+interface CachedGroups {
   fetchedAt: number;
-  value: GroupsCountByStatus;
+  value: GroupSummaryWithCount[];
 }
 
 export class BullMQProAdapter extends BullMQAdapter {
   public readonly isPro = true;
   private readonly proQueue: QueueProLike;
-  private groupCountsCache: CachedGroupCounts | null = null;
+  private readonly groupsCache = new Map<GroupStatusName, CachedGroups>();
 
   constructor(queue: QueueProLike, options: Partial<QueueAdapterOptions> = {}) {
     super(queue as unknown as Queue, options);
@@ -45,7 +63,7 @@ export class BullMQProAdapter extends BullMQAdapter {
   }
 
   public async getJobCounts(): Promise<JobCounts> {
-    const [base, groups] = await Promise.all([super.getJobCounts(), this.getGroupCounts()]);
+    const [base, groups] = await Promise.all([super.getJobCounts(), this.getGroupJobCounts()]);
     return {
       ...base,
       [STATUSES.waiting]: (base[STATUSES.waiting] ?? 0) + groups.waiting,
@@ -85,51 +103,77 @@ export class BullMQProAdapter extends BullMQAdapter {
   }
 
   public addJob(name: string, data: any, options: QueueJobOptions) {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.addJob(name, data, options);
   }
 
   public async clean(jobStatus: JobCleanStatus, graceTimeMs: number): Promise<void> {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.clean(jobStatus, graceTimeMs);
   }
 
   public async empty(): Promise<void> {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.empty();
   }
 
   public async obliterate(): Promise<void> {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.obliterate();
   }
 
   public async pause(): Promise<void> {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.pause();
   }
 
   public async resume(): Promise<void> {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.resume();
   }
 
   public async promoteAll(): Promise<void> {
-    this.invalidateGroupCounts();
+    this.invalidateGroupsCache();
     return super.promoteAll();
   }
 
-  private invalidateGroupCounts(): void {
-    this.groupCountsCache = null;
+  private invalidateGroupsCache(): void {
+    this.groupsCache.clear();
   }
 
-  private async getGroupCounts(): Promise<GroupsCountByStatus> {
+  /**
+   * Number of jobs sitting in the queue's groups, per group status.
+   *
+   * Note this deliberately does not use `getGroupsCountByStatus()`, which counts *groups*
+   * rather than the jobs inside them -- folding that into job counts reported one job per
+   * group (issue #1346). `getGroupsByStatus()` returns each group's job count next to its
+   * id, so a per-status job total is the sum of those.
+   *
+   * The four group statuses are disjoint in bullmq-pro (a group moves out of the waiting
+   * set when it becomes limited, maxed or paused), so no job is counted twice.
+   */
+  private async getGroupJobCounts(): Promise<GroupJobCountsByStatus> {
+    const entries = await Promise.all(
+      GROUP_STATUSES.map(
+        async (status) => [status, sumGroupJobs(await this.getCachedGroups(status))] as const
+      )
+    );
+    return Object.fromEntries(entries) as GroupJobCountsByStatus;
+  }
+
+  /**
+   * Groups of a given status, cached briefly. Counting jobs and listing them both need the
+   * same group listing, and serving them from one snapshot keeps a page of jobs consistent
+   * with the counts the pagination was computed from.
+   */
+  private async getCachedGroups(status: GroupStatusName): Promise<GroupSummaryWithCount[]> {
     const now = Date.now();
-    if (this.groupCountsCache && now - this.groupCountsCache.fetchedAt < GROUP_COUNTS_TTL_MS) {
-      return this.groupCountsCache.value;
+    const cached = this.groupsCache.get(status);
+    if (cached && now - cached.fetchedAt < GROUPS_TTL_MS) {
+      return cached.value;
     }
-    const value = await this.proQueue.getGroupsCountByStatus();
-    this.groupCountsCache = { fetchedAt: now, value };
+    const value = await this.proQueue.getGroupsByStatus(status);
+    this.groupsCache.set(status, { fetchedAt: now, value });
     return value;
   }
 
@@ -158,18 +202,20 @@ export class BullMQProAdapter extends BullMQAdapter {
     for (const groupStatus of groupStatuses) {
       if (remainingTake <= 0) break;
 
-      const groups = await this.proQueue.getGroupsByStatus(groupStatus);
+      const groups = await this.getCachedGroups(groupStatus);
 
       for (const group of groups) {
         if (remainingTake <= 0) break;
 
-        if (remainingSkip >= group.count) {
-          remainingSkip -= group.count;
+        const count = groupJobCount(group);
+
+        if (remainingSkip >= count) {
+          remainingSkip -= count;
           continue;
         }
 
         const groupStart = remainingSkip;
-        const groupEnd = Math.min(group.count - 1, groupStart + remainingTake - 1);
+        const groupEnd = Math.min(count - 1, groupStart + remainingTake - 1);
         const jobs = await this.proQueue.getGroupJobs(group.id, groupStart, groupEnd);
 
         collected.push(...jobs);

--- a/packages/api/src/queueAdapters/bullMQPro.ts
+++ b/packages/api/src/queueAdapters/bullMQPro.ts
@@ -9,16 +9,13 @@ import {
 import { STATUSES } from '../constants/statuses';
 import { BullMQAdapter } from './bullMQ';
 import type {
-  GroupJobCountsByStatus,
   GroupStatusName,
   GroupSummaryWithCount,
   JobProLike,
   QueueProLike,
 } from './bullMQProTypes';
 
-const GROUPS_TTL_MS = 5_000;
-
-const GROUP_STATUSES: GroupStatusName[] = ['waiting', 'limited', 'maxed', 'paused'];
+const SNAPSHOT_TTL_MS = 5_000;
 
 const BUCKET_TO_GROUP_STATUSES: Partial<Record<JobStatus, GroupStatusName[]>> = {
   [STATUSES.waiting]: ['waiting'],
@@ -26,30 +23,46 @@ const BUCKET_TO_GROUP_STATUSES: Partial<Record<JobStatus, GroupStatusName[]>> = 
   [STATUSES.paused]: ['paused'],
 };
 
+/** A group and the number of jobs it holds, once that number is known. */
+interface GroupWithJobCount {
+  id: string;
+  count: number;
+}
+
 /**
- * Jobs held by a single group.
+ * One reading of the queue: the counts BullMQ reports for the ungrouped jobs, and every group
+ * with the jobs it holds.
  *
- * bullmq-pro only started returning `count` from `getGroupsByStatus()` in 7.46.3. On older
- * versions it is missing, and counting the group as one job keeps the totals in the same
- * ballpark -- a group is only listed while it holds jobs -- instead of yielding `NaN`.
+ * Both halves are read together because pagination is worked out from the counts and then
+ * applied to the groups. The object literals building it are typed as
+ * `Record<GroupStatusName, ...>`, so a group status added to the union is a compile error here
+ * rather than a key that silently goes missing and totals up as `NaN`.
  */
-function groupJobCount(group: GroupSummaryWithCount): number {
-  return Number.isFinite(group.count) ? group.count : 1;
+interface QueueSnapshot {
+  counts: JobCounts;
+  groups: Record<GroupStatusName, GroupWithJobCount[]>;
 }
 
-function sumGroupJobs(groups: GroupSummaryWithCount[]): number {
-  return groups.reduce((total, group) => total + groupJobCount(group), 0);
+/**
+ * The job count bullmq-pro put next to a group, or `null` when there is none to be had.
+ *
+ * `getGroupsByStatus()` only returns `count` from 7.46.3 on, and values that come back out of a
+ * Lua script can arrive as strings, so it is coerced rather than trusted: `Number.isFinite()`
+ * alone would read `"15"` as no count at all.
+ */
+function reportedJobCount(group: GroupSummaryWithCount): number | null {
+  const count = Number(group.count);
+  return Number.isFinite(count) && count >= 0 ? count : null;
 }
 
-interface CachedGroups {
-  fetchedAt: number;
-  value: GroupSummaryWithCount[];
+function sumJobCounts(groups: GroupWithJobCount[]): number {
+  return groups.reduce((total, group) => total + group.count, 0);
 }
 
 export class BullMQProAdapter extends BullMQAdapter {
   public readonly isPro = true;
   private readonly proQueue: QueueProLike;
-  private readonly groupsCache = new Map<GroupStatusName, CachedGroups>();
+  private snapshotCache: { fetchedAt: number; value: Promise<QueueSnapshot> } | null = null;
 
   constructor(queue: QueueProLike, options: Partial<QueueAdapterOptions> = {}) {
     super(queue as unknown as Queue, options);
@@ -63,28 +76,33 @@ export class BullMQProAdapter extends BullMQAdapter {
   }
 
   public async getJobCounts(): Promise<JobCounts> {
-    const [base, groups] = await Promise.all([super.getJobCounts(), this.getGroupJobCounts()]);
+    const { counts, groups } = await this.getSnapshot();
     return {
-      ...base,
-      [STATUSES.waiting]: (base[STATUSES.waiting] ?? 0) + groups.waiting,
-      [STATUSES.delayed]: (base[STATUSES.delayed] ?? 0) + groups.limited + groups.maxed,
-      [STATUSES.paused]: (base[STATUSES.paused] ?? 0) + groups.paused,
+      ...counts,
+      [STATUSES.waiting]: (counts[STATUSES.waiting] ?? 0) + sumJobCounts(groups.waiting),
+      [STATUSES.delayed]:
+        (counts[STATUSES.delayed] ?? 0) + sumJobCounts(groups.limited) + sumJobCounts(groups.maxed),
+      [STATUSES.paused]: (counts[STATUSES.paused] ?? 0) + sumJobCounts(groups.paused),
     };
   }
 
   public async getJobs(jobStatuses: JobStatus[], start = 0, end = -1): Promise<Job[]> {
-    const requestedEnd = end;
-    const normalizedEnd = end === -1 ? Number.MAX_SAFE_INTEGER : end;
-    const pageSize = normalizedEnd - start + 1;
-
     const groupStatuses = this.getRelevantGroupStatuses(jobStatuses);
 
     if (groupStatuses.length === 0) {
-      return super.getJobs(jobStatuses, start, requestedEnd);
+      return super.getJobs(jobStatuses, start, end);
     }
 
-    const counts = await super.getJobCounts();
-    const regularCount = jobStatuses.reduce((sum, status) => sum + (counts[status] ?? 0), 0);
+    const normalizedEnd = end === -1 ? Number.MAX_SAFE_INTEGER : end;
+    const pageSize = normalizedEnd - start + 1;
+
+    // The same reading `getJobCounts()` served, so the ungrouped/grouped boundary this page is
+    // cut at is the one the caller's pagination was computed from.
+    const snapshot = await this.getSnapshot();
+    const regularCount = jobStatuses.reduce(
+      (sum, status) => sum + (snapshot.counts[status] ?? 0),
+      0
+    );
 
     const regularJobs: Job[] =
       start < regularCount
@@ -98,83 +116,135 @@ export class BullMQProAdapter extends BullMQAdapter {
       return regularJobs;
     }
 
-    const groupJobs = await this.fetchJobsFromGroups(groupStatuses, groupSkip, groupTake);
+    const groupJobs = await this.fetchJobsFromGroups(snapshot, groupStatuses, groupSkip, groupTake);
     return [...regularJobs, ...groupJobs];
   }
 
   public addJob(name: string, data: any, options: QueueJobOptions) {
-    this.invalidateGroupsCache();
-    return super.addJob(name, data, options);
+    return this.withSnapshotReset(() => super.addJob(name, data, options));
   }
 
   public async clean(jobStatus: JobCleanStatus, graceTimeMs: number): Promise<void> {
-    this.invalidateGroupsCache();
-    return super.clean(jobStatus, graceTimeMs);
+    return this.withSnapshotReset(() => super.clean(jobStatus, graceTimeMs));
   }
 
   public async empty(): Promise<void> {
-    this.invalidateGroupsCache();
-    return super.empty();
+    return this.withSnapshotReset(() => super.empty());
   }
 
   public async obliterate(): Promise<void> {
-    this.invalidateGroupsCache();
-    return super.obliterate();
+    return this.withSnapshotReset(() => super.obliterate());
   }
 
   public async pause(): Promise<void> {
-    this.invalidateGroupsCache();
-    return super.pause();
+    return this.withSnapshotReset(() => super.pause());
   }
 
   public async resume(): Promise<void> {
-    this.invalidateGroupsCache();
-    return super.resume();
+    return this.withSnapshotReset(() => super.resume());
   }
 
   public async promoteAll(): Promise<void> {
-    this.invalidateGroupsCache();
-    return super.promoteAll();
-  }
-
-  private invalidateGroupsCache(): void {
-    this.groupsCache.clear();
+    return this.withSnapshotReset(() => super.promoteAll());
   }
 
   /**
-   * Number of jobs sitting in the queue's groups, per group status.
-   *
-   * Note this deliberately does not use `getGroupsCountByStatus()`, which counts *groups*
-   * rather than the jobs inside them -- folding that into job counts reported one job per
-   * group (issue #1346). `getGroupsByStatus()` returns each group's job count next to its
-   * id, so a per-status job total is the sum of those.
-   *
-   * The four group statuses are disjoint in bullmq-pro (a group moves out of the waiting
-   * set when it becomes limited, maxed or paused), so no job is counted twice.
+   * Runs a mutation with the cached reading dropped on both sides of it. Dropping it beforehand
+   * is not enough on its own: a poll landing while the write is still in flight would cache the
+   * queue as it was and serve that for a whole TTL.
    */
-  private async getGroupJobCounts(): Promise<GroupJobCountsByStatus> {
-    const entries = await Promise.all(
-      GROUP_STATUSES.map(
-        async (status) => [status, sumGroupJobs(await this.getCachedGroups(status))] as const
-      )
-    );
-    return Object.fromEntries(entries) as GroupJobCountsByStatus;
+  private async withSnapshotReset<T>(mutation: () => Promise<T>): Promise<T> {
+    this.invalidateSnapshot();
+    try {
+      return await mutation();
+    } finally {
+      this.invalidateSnapshot();
+    }
+  }
+
+  private invalidateSnapshot(): void {
+    this.snapshotCache = null;
   }
 
   /**
-   * Groups of a given status, cached briefly. Counting jobs and listing them both need the
-   * same group listing, and serving them from one snapshot keeps a page of jobs consistent
-   * with the counts the pagination was computed from.
+   * The current reading of the queue, taken at most once every `SNAPSHOT_TTL_MS`.
+   *
+   * Counting jobs and listing them need the same group listing, and the counts decide where the
+   * listing is cut, so both come out of one reading -- otherwise a group that changes status
+   * between the two calls is counted twice, or a page skips jobs the count promised.
+   *
+   * It is the in-flight promise that is cached, so callers arriving together -- two browser tabs
+   * polling, say -- share one reading instead of racing to replace each other's.
    */
-  private async getCachedGroups(status: GroupStatusName): Promise<GroupSummaryWithCount[]> {
+  private getSnapshot(): Promise<QueueSnapshot> {
     const now = Date.now();
-    const cached = this.groupsCache.get(status);
-    if (cached && now - cached.fetchedAt < GROUPS_TTL_MS) {
+    const cached = this.snapshotCache;
+
+    if (cached && now - cached.fetchedAt < SNAPSHOT_TTL_MS) {
       return cached.value;
     }
-    const value = await this.proQueue.getGroupsByStatus(status);
-    this.groupsCache.set(status, { fetchedAt: now, value });
-    return value;
+
+    const entry = { fetchedAt: now, value: this.readQueue() };
+    this.snapshotCache = entry;
+
+    // A failed reading must not be handed out for the rest of the TTL.
+    entry.value.catch(() => {
+      if (this.snapshotCache === entry) {
+        this.invalidateSnapshot();
+      }
+    });
+
+    return entry.value;
+  }
+
+  private async readQueue(): Promise<QueueSnapshot> {
+    const [counts, waiting, limited, maxed, paused] = await Promise.all([
+      super.getJobCounts(),
+      this.listGroups('waiting'),
+      this.listGroups('limited'),
+      this.listGroups('maxed'),
+      this.listGroups('paused'),
+    ]);
+
+    return { counts, groups: { waiting, limited, maxed, paused } };
+  }
+
+  /**
+   * Every group of one status, with the number of jobs it holds.
+   *
+   * Note this deliberately does not use `getGroupsCountByStatus()`, which counts *groups*
+   * rather than the jobs inside them -- folding that into job counts reported one job per group
+   * (issue #1346). Only `getGroupsByStatus()` names the groups, so counting the jobs in them
+   * costs a listing of every group on every reading; that is what the snapshot TTL bounds.
+   *
+   * The range is passed explicitly rather than left to the getter's default: the totals are
+   * only right if every group is listed.
+   */
+  private async listGroups(status: GroupStatusName): Promise<GroupWithJobCount[]> {
+    const groups = await this.proQueue.getGroupsByStatus(status, 0, -1);
+
+    return Promise.all(
+      groups.map(async (group) => ({
+        id: group.id,
+        count: reportedJobCount(group) ?? (await this.countGroupJobs(group.id)),
+      }))
+    );
+  }
+
+  /**
+   * Jobs in one group, asked for outright. Needed on bullmq-pro < 7.46.3, where
+   * `getGroupsByStatus()` returns ids alone: assuming one job per group would understate the
+   * counts and, since those counts also decide what to read from each group, hide every job in
+   * the group but the first. Versions old enough to lack `getGroupJobsCount()` as well keep
+   * that one-job-per-group approximation.
+   */
+  private async countGroupJobs(groupId: string): Promise<number> {
+    if (typeof this.proQueue.getGroupJobsCount !== 'function') {
+      return 1;
+    }
+
+    const count = Number(await this.proQueue.getGroupJobsCount(groupId));
+    return Number.isFinite(count) && count >= 0 ? count : 1;
   }
 
   private getRelevantGroupStatuses(jobStatuses: JobStatus[]): GroupStatusName[] {
@@ -190,41 +260,50 @@ export class BullMQProAdapter extends BullMQAdapter {
     return [...result];
   }
 
+  /**
+   * A page of jobs taken from the groups, in the order the statuses were asked for.
+   *
+   * Which slice of which group to read follows from the counts already in the snapshot, so the
+   * ranges are all worked out first and the groups then read at once: a page spanning ten
+   * groups costs one round trip's latency rather than ten.
+   */
   private async fetchJobsFromGroups(
+    snapshot: QueueSnapshot,
     groupStatuses: GroupStatusName[],
     skip: number,
     take: number
   ): Promise<JobProLike[]> {
-    const collected: JobProLike[] = [];
+    const ranges: { id: string; start: number; end: number }[] = [];
     let remainingSkip = skip;
     let remainingTake = take;
 
     for (const groupStatus of groupStatuses) {
       if (remainingTake <= 0) break;
 
-      const groups = await this.getCachedGroups(groupStatus);
-
-      for (const group of groups) {
+      for (const group of snapshot.groups[groupStatus]) {
         if (remainingTake <= 0) break;
 
-        const count = groupJobCount(group);
-
-        if (remainingSkip >= count) {
-          remainingSkip -= count;
+        if (remainingSkip >= group.count) {
+          remainingSkip -= group.count;
           continue;
         }
 
-        const groupStart = remainingSkip;
-        const groupEnd = Math.min(count - 1, groupStart + remainingTake - 1);
-        const jobs = await this.proQueue.getGroupJobs(group.id, groupStart, groupEnd);
+        const start = remainingSkip;
+        const end = Math.min(group.count - 1, start + remainingTake - 1);
 
-        collected.push(...jobs);
+        ranges.push({ id: group.id, start, end });
         remainingSkip = 0;
-        remainingTake -= jobs.length;
+        remainingTake -= end - start + 1;
       }
     }
 
-    return collected;
+    const pages = await Promise.all(
+      ranges.map(({ id, start, end }) => this.proQueue.getGroupJobs(id, start, end))
+    );
+
+    // A group can hold fewer jobs than the snapshot said, so the page is trimmed rather than
+    // assumed to be exactly `take` long.
+    return pages.flat().slice(0, take);
   }
 }
 

--- a/packages/api/src/queueAdapters/bullMQProTypes.ts
+++ b/packages/api/src/queueAdapters/bullMQProTypes.ts
@@ -10,10 +10,11 @@ export interface GroupSummary {
 export interface GroupSummaryWithCount {
   id: string;
   /**
-   * Number of jobs held by this group. Only returned by bullmq-pro >= 7.46.3; older
-   * versions return the id alone.
+   * Number of jobs held by this group. Only returned by bullmq-pro >= 7.46.3; older versions
+   * return the id alone, hence optional -- the adapter asks `getGroupJobsCount()` for the
+   * groups that arrive without one.
    */
-  count: number;
+  count?: number;
 }
 
 /** Number of *groups* in each group status, as reported by `getGroupsCountByStatus()`. */
@@ -24,18 +25,21 @@ export interface GroupsCountByStatus {
   paused: number;
 }
 
-/** Number of *jobs* held by the groups of each group status. */
-export type GroupJobCountsByStatus = Record<GroupStatusName, number>;
-
+/**
+ * The part of `QueuePro` the adapter calls, and only that part, so that a wrapper or a test
+ * double has nothing dead to implement.
+ *
+ * `GroupSummary` and `GroupsCountByStatus` above describe `getGroups()` and
+ * `getGroupsCountByStatus()`, which the adapter deliberately does not use (see
+ * `listGroups()` in bullMQPro.ts); they stay exported because they are part of the published
+ * types.
+ */
 export interface QueueProLike extends Queue {
-  getGroups(start?: number, end?: number): Promise<GroupSummary[]>;
   getGroupsByStatus(
     status: GroupStatusName,
     start?: number,
     end?: number
   ): Promise<GroupSummaryWithCount[]>;
-  getGroupsCount(): Promise<number>;
-  getGroupsCountByStatus(): Promise<GroupsCountByStatus>;
   getGroupJobs(groupId: string | number, start?: number, end?: number): Promise<JobProLike[]>;
   getGroupJobsCount(groupId: string | number): Promise<number>;
 }

--- a/packages/api/src/queueAdapters/bullMQProTypes.ts
+++ b/packages/api/src/queueAdapters/bullMQProTypes.ts
@@ -9,15 +9,23 @@ export interface GroupSummary {
 
 export interface GroupSummaryWithCount {
   id: string;
+  /**
+   * Number of jobs held by this group. Only returned by bullmq-pro >= 7.46.3; older
+   * versions return the id alone.
+   */
   count: number;
 }
 
+/** Number of *groups* in each group status, as reported by `getGroupsCountByStatus()`. */
 export interface GroupsCountByStatus {
   waiting: number;
   limited: number;
   maxed: number;
   paused: number;
 }
+
+/** Number of *jobs* held by the groups of each group status. */
+export type GroupJobCountsByStatus = Record<GroupStatusName, number>;
 
 export interface QueueProLike extends Queue {
   getGroups(start?: number, end?: number): Promise<GroupSummary[]>;

--- a/packages/api/tests/api/bullmq-pro-adapter.spec.ts
+++ b/packages/api/tests/api/bullmq-pro-adapter.spec.ts
@@ -1,6 +1,5 @@
 import { BullMQProAdapter } from '@bull-board/api/bullMQProAdapter';
 import type {
-  GroupsCountByStatus,
   GroupStatusName,
   GroupSummaryWithCount,
   JobProLike,
@@ -33,32 +32,62 @@ const makeFakeJob = (props: Partial<any> = {}): JobProLike => {
   } as unknown as JobProLike;
 };
 
+/** `count` jobs whose ids are `<prefix>0`, `<prefix>1`, ... */
+const makeFakeJobs = (prefix: string, count: number): JobProLike[] =>
+  Array.from({ length: count }, (_, index) => makeFakeJob({ id: `${prefix}${index}` }));
+
+const jobIds = (jobs: { id?: string }[]) => jobs.map((job) => job.id);
+
 interface MockOverrides {
   jobCounts?: Record<string, number>;
-  groupCounts?: GroupsCountByStatus;
   jobsByStatus?: Record<string, JobProLike[]>;
   groupsByStatus?: Partial<Record<GroupStatusName, GroupSummaryWithCount[]>>;
   groupJobs?: Record<string, JobProLike[]>;
 }
 
 /** A group as bullmq-pro < 7.46.3 returns it: an id, with no job count. */
-const groupWithoutCount = (id: string): GroupSummaryWithCount =>
-  ({ id }) as unknown as GroupSummaryWithCount;
+const groupWithoutCount = (id: string): GroupSummaryWithCount => ({ id });
 
-const makeMockQueue = (
-  overrides: MockOverrides = {}
-): QueueProLike & { calls: Record<string, number> } => {
+/** A group whose count came back out of Redis as a string rather than a number. */
+const groupWithStringCount = (id: string, count: number): GroupSummaryWithCount =>
+  ({ id, count: String(count) }) as unknown as GroupSummaryWithCount;
+
+type MockQueue = QueueProLike & {
+  calls: Record<string, number>;
+  /** `getGroupsByStatus()` calls per group status. */
+  groupListings: Record<string, number>;
+  /** Every `(status, start, end)` `getGroupsByStatus()` was asked for. */
+  groupRanges: [GroupStatusName, number | undefined, number | undefined][];
+  /** How many `getGroupJobs()` calls were ever in flight at the same time. */
+  maxConcurrentGroupJobs: number;
+};
+
+/**
+ * How many times the adapter has read the groups. A single read asks `getGroupsByStatus()`
+ * once per group status, so counting the most-read status says how many reads happened without
+ * hard-coding how many group statuses there are.
+ */
+const groupReads = (queue: MockQueue): number => Math.max(0, ...Object.values(queue.groupListings));
+
+const makeMockQueue = (overrides: MockOverrides = {}): MockQueue => {
   const calls: Record<string, number> = {
     getJobCounts: 0,
     getGroupsCountByStatus: 0,
     getGroupsByStatus: 0,
     getGroupJobs: 0,
+    getGroupJobsCount: 0,
   };
+
+  let inFlightGroupJobs = 0;
 
   const fake: any = {
     name: 'pro-queue',
     metaValues: { version: 'bullmq-pro-7.0.0' },
     client: Promise.resolve({ info: async () => 'redis_version:7\n' }),
+    calls,
+    groupListings: {} as Record<string, number>,
+    groupRanges: [] as [GroupStatusName, number | undefined, number | undefined][],
+    maxConcurrentGroupJobs: 0,
     async getJobCounts() {
       calls.getJobCounts++;
       return (
@@ -81,31 +110,36 @@ const makeMockQueue = (
       }
       return out;
     },
+    // The adapter must never fall back to counting groups instead of the jobs in them (#1346),
+    // so this stays on the double purely as a trap.
     async getGroupsCountByStatus() {
       calls.getGroupsCountByStatus++;
-      return overrides.groupCounts ?? { waiting: 0, limited: 0, maxed: 0, paused: 0 };
+      return { waiting: 0, limited: 0, maxed: 0, paused: 0 };
     },
-    async getGroupsByStatus(status: GroupStatusName, _start?: number, _end?: number) {
+    async getGroupsByStatus(status: GroupStatusName, start?: number, end?: number) {
       calls.getGroupsByStatus++;
+      fake.groupListings[status] = (fake.groupListings[status] ?? 0) + 1;
+      fake.groupRanges.push([status, start, end]);
       return overrides.groupsByStatus?.[status] ?? [];
     },
-    async getGroupJobs(groupId: string | number, _start = 0, _end = -1) {
+    async getGroupJobs(groupId: string | number, start = 0, end = -1) {
       calls.getGroupJobs++;
-      return overrides.groupJobs?.[String(groupId)] ?? [];
+      inFlightGroupJobs++;
+      fake.maxConcurrentGroupJobs = Math.max(fake.maxConcurrentGroupJobs, inFlightGroupJobs);
+      // Yield, so calls issued together overlap and calls awaited one by one do not.
+      await Promise.resolve();
+      inFlightGroupJobs--;
+
+      const jobs = overrides.groupJobs?.[String(groupId)] ?? [];
+      return jobs.slice(start, end === -1 ? undefined : end + 1);
     },
-    async getGroups() {
-      return [];
+    async getGroupJobsCount(groupId: string | number) {
+      calls.getGroupJobsCount++;
+      return overrides.groupJobs?.[String(groupId)]?.length ?? 0;
     },
-    async getGroupsCount() {
-      return 0;
-    },
-    async getGroupJobsCount() {
-      return 0;
-    },
-    calls,
   };
 
-  return fake as QueueProLike & { calls: Record<string, number> };
+  return fake as MockQueue;
 };
 
 describe('BullMQProAdapter', () => {
@@ -167,13 +201,59 @@ describe('BullMQProAdapter', () => {
       expect(queue.calls.getGroupsCountByStatus).toBe(0);
     });
 
+    // The totals are only right if every group is listed, so the range is never left to the
+    // getter's default.
+    it('asks for the whole range of groups', async () => {
+      const queue = makeMockQueue();
+      const adapter = new BullMQProAdapter(queue);
+
+      await adapter.getJobCounts();
+
+      expect(queue.groupRanges).toEqual([
+        ['waiting', 0, -1],
+        ['limited', 0, -1],
+        ['maxed', 0, -1],
+        ['paused', 0, -1],
+      ]);
+    });
+
+    // ioredis surfaces numbers coming out of a Lua script as strings often enough that a count
+    // of "15" must not degrade to the no-count fallback.
+    it('reads a count that arrives as a string', async () => {
+      const queue = makeMockQueue({
+        groupsByStatus: {
+          waiting: [groupWithStringCount('a', 15), groupWithStringCount('b', 30)],
+        },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const counts = await adapter.getJobCounts();
+
+      expect(counts.waiting).toBe(45);
+      expect(queue.calls.getGroupJobsCount).toBe(0);
+    });
+
     // bullmq-pro < 7.46.3 does not return a count alongside the group id.
-    it('falls back to one job per group when the pro version reports no count', async () => {
+    it('asks the queue to count the groups that arrive without a count', async () => {
+      const queue = makeMockQueue({
+        groupsByStatus: { waiting: [groupWithoutCount('a'), groupWithoutCount('b')] },
+        groupJobs: { a: makeFakeJobs('a', 15), b: makeFakeJobs('b', 30) },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const counts = await adapter.getJobCounts();
+
+      expect(counts.waiting).toBe(45);
+      expect(queue.calls.getGroupJobsCount).toBe(2);
+    });
+
+    it('counts a group as one job when the queue cannot count it either', async () => {
       const queue = makeMockQueue({
         groupsByStatus: {
           waiting: [groupWithoutCount('a'), groupWithoutCount('b'), groupWithoutCount('c')],
         },
       });
+      delete (queue as any).getGroupJobsCount;
       const adapter = new BullMQProAdapter(queue);
 
       const counts = await adapter.getJobCounts();
@@ -181,32 +261,48 @@ describe('BullMQProAdapter', () => {
       expect(counts.waiting).toBe(3);
     });
 
-    it('caches group counts within TTL', async () => {
+    it('reads the queue once within the TTL', async () => {
       const queue = makeMockQueue();
       const adapter = new BullMQProAdapter(queue);
 
       await adapter.getJobCounts();
       await adapter.getJobCounts();
 
-      // One call per group status, served from cache the second time around.
-      expect(queue.calls.getGroupsByStatus).toBe(4);
+      expect(groupReads(queue)).toBe(1);
+      expect(queue.calls.getJobCounts).toBe(1);
     });
 
-    it('serves a listing from the snapshot the counts were taken from', async () => {
-      const queue = makeMockQueue({
-        jobCounts: { waiting: 0 } as any,
-        groupsByStatus: { waiting: [{ id: 'g1', count: 1 }] },
-        groupJobs: { g1: [makeFakeJob({ id: 'g1-a' })] },
-      });
+    it('shares one reading between callers arriving together', async () => {
+      const queue = makeMockQueue();
       const adapter = new BullMQProAdapter(queue);
 
-      await adapter.getJobCounts();
-      await adapter.getJobs(['waiting' as any], 0, 9);
+      await Promise.all([adapter.getJobCounts(), adapter.getJobCounts()]);
 
-      expect(queue.calls.getGroupsByStatus).toBe(4);
+      expect(groupReads(queue)).toBe(1);
+      expect(queue.calls.getJobCounts).toBe(1);
     });
 
-    it('invalidates cache after addJob', async () => {
+    it('does not serve a failed reading for the rest of the TTL', async () => {
+      const queue = makeMockQueue();
+      let failNext = true;
+      const groups = queue.getGroupsByStatus.bind(queue);
+      (queue as any).getGroupsByStatus = async (...args: any[]) => {
+        if (failNext) {
+          failNext = false;
+          throw new Error('redis is down');
+        }
+        return (groups as any)(...args);
+      };
+      const adapter = new BullMQProAdapter(queue);
+
+      await expect(adapter.getJobCounts()).rejects.toThrow('redis is down');
+
+      await expect(adapter.getJobCounts()).resolves.toEqual(
+        expect.objectContaining({ waiting: 0 })
+      );
+    });
+
+    it('invalidates the reading after addJob', async () => {
       const queue = makeMockQueue();
       // Provide an add method on the underlying queue so super.addJob can call through.
       (queue as any).add = async (_name: string, _data: any, _opts: any) => makeFakeJob();
@@ -216,10 +312,10 @@ describe('BullMQProAdapter', () => {
       await adapter.addJob('any', {}, {});
       await adapter.getJobCounts();
 
-      expect(queue.calls.getGroupsByStatus).toBe(8);
+      expect(groupReads(queue)).toBe(2);
     });
 
-    it('invalidates cache after pause', async () => {
+    it('invalidates the reading after pause', async () => {
       const queue = makeMockQueue();
       (queue as any).pause = async () => undefined;
       const adapter = new BullMQProAdapter(queue);
@@ -228,7 +324,27 @@ describe('BullMQProAdapter', () => {
       await adapter.pause();
       await adapter.getJobCounts();
 
-      expect(queue.calls.getGroupsByStatus).toBe(8);
+      expect(groupReads(queue)).toBe(2);
+    });
+
+    // Clearing only before the write would let a poll landing mid-write cache the queue as it
+    // was and serve that for a whole TTL.
+    it('drops a reading taken while a mutation was still in flight', async () => {
+      const queue = makeMockQueue();
+      let finishAdd: () => void = () => undefined;
+      (queue as any).add = () =>
+        new Promise((resolve) => {
+          finishAdd = () => resolve(makeFakeJob());
+        });
+      const adapter = new BullMQProAdapter(queue);
+
+      const added = adapter.addJob('any', {}, {});
+      await adapter.getJobCounts();
+      finishAdd();
+      await added;
+      await adapter.getJobCounts();
+
+      expect(groupReads(queue)).toBe(2);
     });
   });
 
@@ -241,36 +357,111 @@ describe('BullMQProAdapter', () => {
 
       const jobs = await adapter.getJobs(['completed' as any], 0, 9);
 
-      expect(jobs.map((j: any) => j.id)).toEqual(['1', '2']);
-      expect(queue.calls.getGroupsByStatus).toBe(0);
+      expect(jobIds(jobs as any)).toEqual(['1', '2']);
+      expect(groupReads(queue)).toBe(0);
+      expect(queue.calls.getJobCounts).toBe(0);
     });
 
     it('falls through to groups when regular jobs do not fill page', async () => {
       const queue = makeMockQueue({
-        jobCounts: { waiting: 1 } as any,
+        jobCounts: { waiting: 1 },
         jobsByStatus: { waiting: [makeFakeJob({ id: 'r1' })] },
-        groupsByStatus: { waiting: [{ id: 'g1', count: 3 }] },
-        groupJobs: { g1: [makeFakeJob({ id: 'g1-a' }), makeFakeJob({ id: 'g1-b' })] },
+        groupsByStatus: { waiting: [{ id: 'g1', count: 2 }] },
+        groupJobs: { g1: makeFakeJobs('g1-', 2) },
       });
       const adapter = new BullMQProAdapter(queue);
 
       const jobs = await adapter.getJobs(['waiting' as any], 0, 2);
 
-      expect(jobs.map((j: any) => j.id)).toEqual(['r1', 'g1-a', 'g1-b']);
+      expect(jobIds(jobs as any)).toEqual(['r1', 'g1-0', 'g1-1']);
     });
 
     it('skips into groups when start exceeds regular count', async () => {
       const queue = makeMockQueue({
-        jobCounts: { waiting: 2 } as any,
+        jobCounts: { waiting: 2 },
         jobsByStatus: { waiting: [] },
         groupsByStatus: { waiting: [{ id: 'g1', count: 5 }] },
-        groupJobs: { g1: [makeFakeJob({ id: 'g1-x' }), makeFakeJob({ id: 'g1-y' })] },
+        groupJobs: { g1: makeFakeJobs('g1-', 5) },
       });
       const adapter = new BullMQProAdapter(queue);
 
       const jobs = await adapter.getJobs(['waiting' as any], 3, 4);
 
-      expect(jobs.map((j: any) => j.id)).toEqual(['g1-x', 'g1-y']);
+      expect(jobIds(jobs as any)).toEqual(['g1-1', 'g1-2']);
+    });
+
+    it('pages across group boundaries', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 0 },
+        groupsByStatus: {
+          waiting: [
+            { id: 'a', count: 2 },
+            { id: 'b', count: 2 },
+          ],
+        },
+        groupJobs: { a: makeFakeJobs('a', 2), b: makeFakeJobs('b', 2) },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const jobs = await adapter.getJobs(['waiting' as any], 1, 2);
+
+      expect(jobIds(jobs as any)).toEqual(['a1', 'b0']);
+    });
+
+    // Without a real per-group count, pagination would read `[0, 0]` from every group and hide
+    // every job in it but the first.
+    it('lists every job of a group the pro version reported no count for', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 0 },
+        groupsByStatus: { waiting: [groupWithoutCount('a'), groupWithoutCount('b')] },
+        groupJobs: { a: makeFakeJobs('a', 3), b: makeFakeJobs('b', 3) },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const firstPage = await adapter.getJobs(['waiting' as any], 0, 3);
+      const secondPage = await adapter.getJobs(['waiting' as any], 4, 5);
+
+      expect(jobIds(firstPage as any)).toEqual(['a0', 'a1', 'a2', 'b0']);
+      expect(jobIds(secondPage as any)).toEqual(['b1', 'b2']);
+    });
+
+    it('reads the groups of a page at once rather than one by one', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 0 },
+        groupsByStatus: {
+          waiting: [
+            { id: 'a', count: 1 },
+            { id: 'b', count: 1 },
+            { id: 'c', count: 1 },
+          ],
+        },
+        groupJobs: { a: makeFakeJobs('a', 1), b: makeFakeJobs('b', 1), c: makeFakeJobs('c', 1) },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const jobs = await adapter.getJobs(['waiting' as any], 0, 2);
+
+      expect(jobIds(jobs as any)).toEqual(['a0', 'b0', 'c0']);
+      expect(queue.maxConcurrentGroupJobs).toBe(3);
+    });
+
+    it('serves a listing from the same reading the counts were taken from', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 1 },
+        jobsByStatus: { waiting: [makeFakeJob({ id: 'r1' })] },
+        groupsByStatus: { waiting: [{ id: 'g1', count: 2 }] },
+        groupJobs: { g1: makeFakeJobs('g1-', 2) },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const counts = await adapter.getJobCounts();
+      const jobs = await adapter.getJobs(['waiting' as any], 0, 9);
+
+      expect(counts.waiting).toBe(3);
+      expect(jobIds(jobs as any)).toEqual(['r1', 'g1-0', 'g1-1']);
+      // Counts and listing came out of one reading: neither half was fetched twice.
+      expect(groupReads(queue)).toBe(1);
+      expect(queue.calls.getJobCounts).toBe(1);
     });
   });
 

--- a/packages/api/tests/api/bullmq-pro-adapter.spec.ts
+++ b/packages/api/tests/api/bullmq-pro-adapter.spec.ts
@@ -41,6 +41,10 @@ interface MockOverrides {
   groupJobs?: Record<string, JobProLike[]>;
 }
 
+/** A group as bullmq-pro < 7.46.3 returns it: an id, with no job count. */
+const groupWithoutCount = (id: string): GroupSummaryWithCount =>
+  ({ id }) as unknown as GroupSummaryWithCount;
+
 const makeMockQueue = (
   overrides: MockOverrides = {}
 ): QueueProLike & { calls: Record<string, number> } => {
@@ -106,7 +110,7 @@ const makeMockQueue = (
 
 describe('BullMQProAdapter', () => {
   describe('getJobCounts', () => {
-    it('merges parent counts with group counts', async () => {
+    it('merges parent counts with the jobs held by groups', async () => {
       const queue = makeMockQueue({
         jobCounts: {
           active: 1,
@@ -118,7 +122,18 @@ describe('BullMQProAdapter', () => {
           prioritized: 0,
           'waiting-children': 0,
         },
-        groupCounts: { waiting: 10, limited: 20, maxed: 30, paused: 40 },
+        groupsByStatus: {
+          waiting: [
+            { id: 'w1', count: 4 },
+            { id: 'w2', count: 6 },
+          ],
+          limited: [{ id: 'l1', count: 20 }],
+          maxed: [
+            { id: 'm1', count: 12 },
+            { id: 'm2', count: 18 },
+          ],
+          paused: [{ id: 'p1', count: 40 }],
+        },
       });
       const adapter = new BullMQProAdapter(queue);
 
@@ -132,6 +147,40 @@ describe('BullMQProAdapter', () => {
       expect(counts.failed).toBe(6);
     });
 
+    // Issue #1346: group counts used to be folded in as-is, so 45 jobs spread over 3 groups
+    // were reported as 3 waiting.
+    it('counts the jobs inside groups, not the groups themselves', async () => {
+      const queue = makeMockQueue({
+        groupsByStatus: {
+          waiting: [
+            { id: 'a', count: 15 },
+            { id: 'b', count: 15 },
+            { id: 'c', count: 15 },
+          ],
+        },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const counts = await adapter.getJobCounts();
+
+      expect(counts.waiting).toBe(45);
+      expect(queue.calls.getGroupsCountByStatus).toBe(0);
+    });
+
+    // bullmq-pro < 7.46.3 does not return a count alongside the group id.
+    it('falls back to one job per group when the pro version reports no count', async () => {
+      const queue = makeMockQueue({
+        groupsByStatus: {
+          waiting: [groupWithoutCount('a'), groupWithoutCount('b'), groupWithoutCount('c')],
+        },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      const counts = await adapter.getJobCounts();
+
+      expect(counts.waiting).toBe(3);
+    });
+
     it('caches group counts within TTL', async () => {
       const queue = makeMockQueue();
       const adapter = new BullMQProAdapter(queue);
@@ -139,7 +188,22 @@ describe('BullMQProAdapter', () => {
       await adapter.getJobCounts();
       await adapter.getJobCounts();
 
-      expect(queue.calls.getGroupsCountByStatus).toBe(1);
+      // One call per group status, served from cache the second time around.
+      expect(queue.calls.getGroupsByStatus).toBe(4);
+    });
+
+    it('serves a listing from the snapshot the counts were taken from', async () => {
+      const queue = makeMockQueue({
+        jobCounts: { waiting: 0 } as any,
+        groupsByStatus: { waiting: [{ id: 'g1', count: 1 }] },
+        groupJobs: { g1: [makeFakeJob({ id: 'g1-a' })] },
+      });
+      const adapter = new BullMQProAdapter(queue);
+
+      await adapter.getJobCounts();
+      await adapter.getJobs(['waiting' as any], 0, 9);
+
+      expect(queue.calls.getGroupsByStatus).toBe(4);
     });
 
     it('invalidates cache after addJob', async () => {
@@ -152,7 +216,7 @@ describe('BullMQProAdapter', () => {
       await adapter.addJob('any', {}, {});
       await adapter.getJobCounts();
 
-      expect(queue.calls.getGroupsCountByStatus).toBe(2);
+      expect(queue.calls.getGroupsByStatus).toBe(8);
     });
 
     it('invalidates cache after pause', async () => {
@@ -164,7 +228,7 @@ describe('BullMQProAdapter', () => {
       await adapter.pause();
       await adapter.getJobCounts();
 
-      expect(queue.calls.getGroupsCountByStatus).toBe(2);
+      expect(queue.calls.getGroupsByStatus).toBe(8);
     });
   });
 

--- a/website/docs/queue-adapters/bullmq-pro.md
+++ b/website/docs/queue-adapters/bullmq-pro.md
@@ -1,6 +1,6 @@
 # BullMQ Pro
 
-For the [BullMQ Pro](https://docs.bullmq.io/bullmq-pro/introduction) queue library. Import `BullMQProAdapter` instead of `BullMQAdapter` to get awareness of Pro groups: group counts are folded into the `waiting`/`delayed`/`paused` job counts, jobs from `waiting`/`limited`/`maxed`/`paused` groups are listed alongside regular jobs in those tabs, and the group id is shown next to the job name in the UI.
+For the [BullMQ Pro](https://docs.bullmq.io/bullmq-pro/introduction) queue library. Import `BullMQProAdapter` instead of `BullMQAdapter` to get awareness of Pro groups: the jobs held by `waiting`/`limited`/`maxed`/`paused` groups are folded into the `waiting`/`delayed`/`paused` job counts, those jobs are listed alongside regular jobs in the same tabs, and the group id is shown next to the job name in the UI.
 
 ## Install
 
@@ -27,3 +27,18 @@ createBullBoard({
 ```
 
 All `BullMQAdapter` options (`readOnlyMode`, `allowRetries`, `description`, `prefix`, `setFormatter`, `setVisibilityGuard`) work the same way on `BullMQProAdapter`.
+
+## Group job counts
+
+Counting the jobs inside groups needs the per-group count that `getGroupsByStatus()` returns,
+which `@taskforcesh/bullmq-pro` added in **7.46.3**. On older versions the count is missing and
+the board falls back to counting each group as a single job, which is what it reported before
+7.46.3 was available.
+
+Two further caveats come from bullmq-pro itself:
+
+- Jobs added to a group with a `priority` live in a separate sorted set that the count returned
+  by `getGroupsByStatus()` does not include, so they are missing from the counts (and from the
+  tail of the listing) even on 7.46.3.
+- Group listings are read once per queue refresh and reused for both the counts and the page of
+  jobs, so a busy queue's numbers can be up to five seconds stale.

--- a/website/docs/queue-adapters/bullmq-pro.md
+++ b/website/docs/queue-adapters/bullmq-pro.md
@@ -30,15 +30,19 @@ All `BullMQAdapter` options (`readOnlyMode`, `allowRetries`, `description`, `pre
 
 ## Group job counts
 
-Counting the jobs inside groups needs the per-group count that `getGroupsByStatus()` returns,
-which `@taskforcesh/bullmq-pro` added in **7.46.3**. On older versions the count is missing and
-the board falls back to counting each group as a single job, which is what it reported before
-7.46.3 was available.
+The jobs inside groups are counted from the per-group count that `getGroupsByStatus()` returns,
+which `@taskforcesh/bullmq-pro` added in **7.46.3**. Groups that come back without one — every
+group on an older version — are counted with `getGroupJobsCount()` instead, one call per such
+group. Only a version that has neither falls back to counting a group as a single job.
 
-Two further caveats come from bullmq-pro itself:
+Three things follow from how bullmq-pro reports groups:
 
+- Counting grouped jobs means listing every group on every refresh: no call totals them. On a
+  queue with a very large number of groups, that listing is the expensive part of a refresh.
+- The board takes one reading of the queue — job counts and group listings together — and serves
+  both the numbers and the page of jobs from it for up to five seconds. A page therefore always
+  matches the counts its pagination was worked out from, at the cost of numbers that can be that
+  stale. Anything done from the board (adding, pausing, cleaning, ...) drops the reading at once.
 - Jobs added to a group with a `priority` live in a separate sorted set that the count returned
   by `getGroupsByStatus()` does not include, so they are missing from the counts (and from the
   tail of the listing) even on 7.46.3.
-- Group listings are read once per queue refresh and reused for both the counts and the page of
-  jobs, so a busy queue's numbers can be up to five seconds stale.


### PR DESCRIPTION
getGroupsCountByStatus() reports how many *groups* sit in each group status, so folding it into the job counts reported one job per group: a queue with 45 jobs spread over 3 groups showed "Waiting: 3". The counts also drive getPagination(), so the listing was capped at a single page.

getGroupsByStatus() returns each group's job count next to its id, so the per-status job total is the sum of those. The four group statuses are disjoint in bullmq-pro (a group is removed from the waiting set when it becomes limited, maxed or paused), so nothing is counted twice.

Counting and listing now share one briefly cached group snapshot instead of each making its own Redis round trip, which keeps a page of jobs consistent with the counts its pagination was computed from.

bullmq-pro only started returning `count` in 7.46.3; older versions fall back to counting a group as a single job rather than yielding NaN.

Fixes #1346