### PR TITLE
feat(ui): move SelectField onto Base UI Select

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "@tanstack/react-query": "^5.101.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/identity-obj-proxy": "^3.0.2",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.2.17",

--- a/packages/ui/src/components/AddJobModal/AddJobModal.tsx
+++ b/packages/ui/src/components/AddJobModal/AddJobModal.tsx
@@ -82,7 +82,7 @@ export const AddJobModal = ({ open, onClose, job, queue: queueProp }: AddJobModa
           }))}
           name="queueName"
           value={selectedQueue.name || ''}
-          onChange={(event) => setSelectedQueue(queues.find((q) => q.name === event.target.value)!)}
+          onChange={(value) => setSelectedQueue(queues.find((q) => q.name === value)!)}
         />
         <InputField
           label={t('ADD_JOB.JOB_NAME')}

--- a/packages/ui/src/components/Form/Field/Field.module.css
+++ b/packages/ui/src/components/Form/Field/Field.module.css
@@ -8,8 +8,7 @@
   margin-top: 1rem;
 }
 
-.field > input,
-.field > select {
+.field > input {
   font-size: 0.875rem !important;
   line-height: 1.25rem !important;
   display: block;

--- a/packages/ui/src/components/Form/SelectField/SelectField.module.css
+++ b/packages/ui/src/components/Form/SelectField/SelectField.module.css
@@ -1,0 +1,132 @@
+/* The trigger replaces a native <select> that used to be styled by the shared control
+   rule in index.css, and it still stands next to InputFields in the same modals, so it
+   repeats that recipe rather than inventing a second one. The chevron is an inline icon
+   now instead of the base64 data-URI background that rule carried, whose stroke was a
+   literal grey and stayed that grey in both themes. */
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  appearance: none;
+  padding: 0.5rem 0.75rem;
+  border: 1px var(--input) solid;
+  border-radius: var(--radius);
+  background-color: var(--background);
+  color: var(--foreground);
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease-out,
+    box-shadow 0.15s ease-out;
+}
+
+/* Field puts the label above the control, so only a labelled trigger needs the gap.
+   The filter on the schedulers page has no label and sits in a centred flex row. */
+.labelled {
+  margin-top: 0.25rem;
+}
+
+.trigger:focus-visible {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 20%, transparent);
+}
+
+.trigger[data-disabled] {
+  cursor: not-allowed;
+  color: var(--muted-foreground);
+}
+
+.value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.icon {
+  display: flex;
+  flex: none;
+  align-items: center;
+  transition: transform 0.15s ease-out;
+}
+
+.trigger[data-popup-open] .icon {
+  transform: rotate(180deg);
+}
+
+.icon > svg {
+  width: 0.7rem;
+  height: 0.7rem;
+  fill: var(--muted-foreground);
+}
+
+/* Three of the four call sites render inside a Modal, whose contentWrapper sits
+   at z-index 1100 (see Modal.module.css). The popup must clear that, so it sits
+   above the modal but below the Toaster (9999), which must always stay on top. */
+.positioner {
+  z-index: 1150;
+}
+
+.popup {
+  min-width: var(--anchor-width);
+  max-height: 50svh;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background-color: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-popover);
+}
+
+.item {
+  display: grid;
+  grid-template-columns: 1rem 1fr;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  cursor: pointer;
+}
+
+/* Base UI moves focus onto the highlighted row, and data-highlighted already shows which
+   row that is, so the global focus ring would draw a second indicator around the first. */
+.item:focus-visible {
+  outline: none;
+}
+
+.item[data-highlighted] {
+  background-color: var(--state-hover);
+}
+
+.item[data-selected] {
+  background-color: var(--state-selected);
+  color: var(--state-selected-foreground);
+}
+
+.item[data-selected][data-highlighted] {
+  background-color: var(--state-selected-hover);
+}
+
+.indicator {
+  display: flex;
+  align-items: center;
+}
+
+.item:not([data-selected]) .indicator {
+  visibility: hidden;
+}
+
+.indicator > svg {
+  width: 0.65rem;
+  height: 0.65rem;
+  fill: currentColor;
+}

--- a/packages/ui/src/components/Form/SelectField/SelectField.tsx
+++ b/packages/ui/src/components/Form/SelectField/SelectField.tsx
@@ -1,25 +1,86 @@
-import { SelectHTMLAttributes } from 'react';
+import { Select } from '@base-ui/react/select';
+import cn from 'clsx';
+import { CheckIcon } from '../../Icons/Check';
+import { ChevronDown } from '../../Icons/ChevronDown';
 import { Field } from '../Field/Field';
+import s from './SelectField.module.css';
 
 export interface SelectItem {
   text: string;
   value: string;
 }
 
-interface SelectFieldProps extends SelectHTMLAttributes<any> {
+interface SelectFieldProps {
   label?: string;
   id?: string;
+  name?: string;
+  className?: string;
   options: SelectItem[];
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  required?: boolean;
+  disabled?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
 }
 
-export const SelectField = ({ label, id, options, ...selectProps }: SelectFieldProps) => (
+export const SelectField = ({
+  label,
+  id,
+  name,
+  className,
+  options,
+  value,
+  defaultValue,
+  onChange,
+  required,
+  disabled,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+}: SelectFieldProps) => (
   <Field label={label} id={id}>
-    <select id={id} {...selectProps}>
-      {options.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.text}
-        </option>
-      ))}
-    </select>
+    <Select.Root
+      id={id}
+      name={name}
+      items={options.map(({ text, value: optionValue }) => ({ label: text, value: optionValue }))}
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={(next) => onChange?.(next as string)}
+      required={required}
+      disabled={disabled}
+    >
+      <Select.Trigger
+        className={cn(s.trigger, { [s.labelled]: !!label }, className)}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+      >
+        <Select.Value className={s.value} />
+        <Select.Icon className={s.icon}>
+          <ChevronDown />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        {/* Base UI defaults to laying the selected item over the trigger, which on the twelve
+            entry language list means a popup taller than the modal it opens in. Anchored below
+            the trigger instead, so the popup can scroll inside its own max-height. */}
+        <Select.Positioner className={s.positioner} sideOffset={4} alignItemWithTrigger={false}>
+          <Select.Popup className={s.popup}>
+            <Select.List>
+              {options.map((option) => (
+                <Select.Item key={option.value} value={option.value} className={s.item}>
+                  {/* Kept mounted so the check column exists on every row: without it the
+                      unselected rows lose their first grid cell and their labels wrap. */}
+                  <Select.ItemIndicator className={s.indicator} keepMounted>
+                    <CheckIcon />
+                  </Select.ItemIndicator>
+                  <Select.ItemText>{option.text}</Select.ItemText>
+                </Select.Item>
+              ))}
+            </Select.List>
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
   </Field>
 );

--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { languages } from '../../constants/languages';
-import { availableJobTabs } from '../../hooks/useDetailsTabs';
+import { availableJobTabs, TabsType } from '../../hooks/useDetailsTabs';
 import { useSettingsStore } from '../../hooks/useSettings';
 import { useUIConfig } from '../../hooks/useUIConfig';
 import { dynamicTranslationKey } from '../../utils/dynamicTranslationKey';
@@ -59,10 +59,13 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
           label={t('SETTINGS.LANGUAGE')}
           id="language"
           options={languages.map((lng) => ({ text: lng, value: lng }))}
-          value={language}
-          onChange={(event) => {
-            i18n.changeLanguage(event.target.value);
-            setSettings({ language: event.target.value });
+          /* The stored setting starts empty, which matched no option and left the control
+             blank until you picked something. initI18n narrows to a supported language, so
+             falling back to the active one shows what the board is actually rendering in. */
+          value={language || i18n.language}
+          onChange={(value) => {
+            i18n.changeLanguage(value);
+            setSettings({ language: value });
           }}
         />
         {uiConfigPollingInterval?.showSetting !== false && (
@@ -79,7 +82,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
               value: `${interval}`,
             }))}
             value={`${pollingInterval}`}
-            onChange={(event) => setSettings({ pollingInterval: +event.target.value })}
+            onChange={(value) => setSettings({ pollingInterval: +value })}
           />
         )}
         <SwitchField
@@ -129,7 +132,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
             value: tab,
           }))}
           value={defaultJobTab}
-          onChange={(event) => setSettings({ defaultJobTab: event.target.value })}
+          onChange={(value) => setSettings({ defaultJobTab: value as TabsType | 'default' })}
         />
         <InputField
           label={t('SETTINGS.JOBS_PER_PAGE')}

--- a/packages/ui/src/hooks/useDetailsTabs.tsx
+++ b/packages/ui/src/hooks/useDetailsTabs.tsx
@@ -40,7 +40,7 @@ export function useDetailsTabs(params: { currentStatus: Status; withTimeline: bo
   }, [params.currentStatus, params.withTimeline]);
 
   useEffect(() => {
-    setSelectedTab(tabs.includes(defaultJobTab) ? defaultJobTab : tabs[0]);
+    setSelectedTab(tabs.find((tab) => tab === defaultJobTab) || tabs[0]);
   }, [defaultJobTab, tabs]);
 
   return {

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -22,7 +22,8 @@ interface SettingsState {
   defaultCollapseDepth: number;
   useCollapsibleJson: boolean;
   darkMode: boolean;
-  defaultJobTab: TabsType;
+  /** 'default' means no explicit preference: fall back to whichever tab renders first. */
+  defaultJobTab: TabsType | 'default';
   sortQueues: boolean;
   sorting: { dashboard: { key: QueueSortKey; direction: SortDirection } };
   overview: { grouped?: boolean };

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -120,8 +120,6 @@ input[type='text'],
 input[type='time'],
 input[type='url'],
 input[type='week'],
-select,
-.select,
 textarea {
   appearance: none;
   background-color: var(--background);
@@ -139,16 +137,6 @@ textarea {
     box-shadow 0.15s ease-out;
 }
 
-select,
-.select {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyMCAyMCI+PHBhdGggc3Ryb2tlPSIjNmI3MjgwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMS41IiBkPSJNNiA4bDQgNCA0LTQiLz48L3N2Zz4');
-  background-position: right 0.5rem center;
-  background-repeat: no-repeat;
-  background-size: 1.5em 1.5em;
-  padding-right: 2.5rem;
-  print-color-adjust: exact;
-}
-
 input[type='date']:focus,
 input[type='datetime-local']:focus,
 input[type='email']:focus,
@@ -161,8 +149,6 @@ input[type='text']:focus,
 input[type='time']:focus,
 input[type='url']:focus,
 input[type='week']:focus,
-select:focus,
-.select:focus,
 textarea:focus {
   outline: none;
   border-color: var(--ring);

--- a/packages/ui/src/pages/SchedulersPage/SchedulerEditModal.tsx
+++ b/packages/ui/src/pages/SchedulersPage/SchedulerEditModal.tsx
@@ -80,8 +80,9 @@ export const SchedulerEditModal = ({
         <SelectField
           label={t('SCHEDULERS.EDIT.KIND')}
           id="scheduler-kind"
+          name="kind"
           value={kind}
-          onChange={(e) => setKind((e.target as HTMLSelectElement).value as ScheduleKind)}
+          onChange={(value) => setKind(value as ScheduleKind)}
           options={[
             { value: 'pattern', text: t('SCHEDULERS.EDIT.KIND_PATTERN') },
             { value: 'every', text: t('SCHEDULERS.EDIT.KIND_EVERY') },

--- a/packages/ui/src/pages/SchedulersPage/SchedulersPage.module.css
+++ b/packages/ui/src/pages/SchedulersPage/SchedulersPage.module.css
@@ -43,6 +43,12 @@
   color: var(--foreground);
 }
 
+/* The trigger is as wide as the value it shows, where the native select was as wide as
+   its longest option, so without a floor the filter resized on every pick. */
+.queueFilter {
+  min-width: 14rem;
+}
+
 .empty {
   margin: 0;
   padding: 2rem 0;

--- a/packages/ui/src/pages/SchedulersPage/SchedulersPage.tsx
+++ b/packages/ui/src/pages/SchedulersPage/SchedulersPage.tsx
@@ -80,9 +80,10 @@ export const SchedulersPage = () => {
           <h2 className={s.title}>{t('SCHEDULERS.TITLE')}</h2>
           <SelectField
             id="scheduler-queue-filter"
+            className={s.queueFilter}
             aria-label={t('SCHEDULERS.FILTER_BY_QUEUE')}
             value={queueFilter}
-            onChange={(e) => setQueueFilter((e.target as HTMLSelectElement).value)}
+            onChange={(value) => setQueueFilter(value)}
             options={[
               { value: ALL_QUEUES, text: t('SCHEDULERS.ALL_QUEUES') },
               ...(queues ?? []).map((queue) => ({

--- a/packages/ui/tests/components/SelectField.spec.tsx
+++ b/packages/ui/tests/components/SelectField.spec.tsx
@@ -1,0 +1,60 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SelectField } from '../../src/components/Form/SelectField/SelectField';
+import { render } from '../testUtils';
+
+const options = [
+  { text: 'Newest first', value: 'desc' },
+  { text: 'Oldest first', value: 'asc' },
+];
+
+it('selects an option with the keyboard', async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(
+    <SelectField
+      label="Order"
+      id="order"
+      options={options}
+      defaultValue="desc"
+      onChange={onChange}
+    />
+  );
+
+  await user.click(screen.getByRole('combobox'));
+  await user.click(await screen.findByRole('option', { name: 'Oldest first' }));
+
+  await waitFor(() => expect(onChange).toHaveBeenCalledWith('asc'));
+});
+
+it('submits its value as part of the surrounding form', async () => {
+  const user = userEvent.setup();
+  const onSubmit = jest.fn((event) => {
+    event.preventDefault();
+    expect(new FormData(event.currentTarget).get('order')).toBe('asc');
+  });
+
+  render(
+    <form onSubmit={onSubmit}>
+      <SelectField label="Order" id="order" name="order" options={options} defaultValue="asc" />
+      <button type="submit">Save</button>
+    </form>
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Save' }));
+
+  await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+});
+
+it('exposes an accessible name from aria-label when no visible label is rendered', async () => {
+  render(
+    <SelectField
+      id="scheduler-queue-filter"
+      aria-label="Order"
+      options={options}
+      defaultValue="desc"
+    />
+  );
+
+  expect(screen.getByRole('combobox', { name: 'Order' })).toBeTruthy();
+});

--- a/packages/ui/tests/components/SettingsModal.spec.tsx
+++ b/packages/ui/tests/components/SettingsModal.spec.tsx
@@ -1,0 +1,36 @@
+import { act, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { SettingsModal } from '../../src/components/SettingsModal/SettingsModal';
+import { useSettingsStore } from '../../src/hooks/useSettings';
+import { createWrapper, render } from '../testUtils';
+
+async function renderWithLanguage(language: string) {
+  act(() => {
+    useSettingsStore.setState({ language });
+  });
+
+  const { Wrapper } = createWrapper({ api: {} });
+  await act(async () => {
+    render(<SettingsModal open onClose={() => {}} />, { wrapper: Wrapper });
+  });
+
+  return screen.getByRole('combobox', { name: /LANGUAGE/ });
+}
+
+describe('SettingsModal', () => {
+  beforeEach(async () => {
+    await act(() => i18n.changeLanguage('en-US'));
+  });
+
+  afterEach(async () => {
+    await act(() => i18n.changeLanguage('cimode'));
+  });
+
+  it('shows the active language when nothing has been chosen yet', async () => {
+    expect((await renderWithLanguage('')).textContent).toBe('en-US');
+  });
+
+  it('shows the stored language once one has been chosen', async () => {
+    expect((await renderWithLanguage('de-DE')).textContent).toBe('de-DE');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,7 @@ __metadata:
     "@tanstack/react-query": "npm:^5.101.2"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@testing-library/user-event": "npm:^14.6.1"
     "@types/identity-obj-proxy": "npm:^3.0.2"
     "@types/jest": "npm:^30.0.0"
     "@types/react": "npm:^19.2.17"
@@ -4503,6 +4504,15 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/f9c7f0915e1b5f7b750e6c7d8b51f091b8ae7ea99bacb761d7b8505ba25de9cfcb749a0f779f1650fb268b499dd79165dc7e1ee0b8b4cb63430d3ddc81ffe044
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10c0/75fea130a52bf320d35d46ed54f3eec77e71a56911b8b69a3fe29497b0b9947b2dc80d30f04054ad4ce7f577856ae3e5397ea7dff0ef14944d3909784c7a93fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

`SelectField` is the last native form control on the board. Everything else is a Base UI primitive already, and #1306 left the Select migration as the next step.

A native `<select>` cannot be styled past its own box, so v9 works around it with a chevron baked into a base64 data URI in `index.css`:

```css
background-image: url('data:image/svg+xml;base64,...stroke="#6b7280"...');
```

That stroke is a literal grey and stays that grey in both themes, so the one arrow on the board ignores the palette everything else reads from. The list it opens is the operating system's: unthemed, and on the schedulers page that is 24 queue names rendered as OS chrome next to a fully themed table.

Two smaller things ride along on the native element. `defaultJobTab` is typed `TabsType`, but the settings modal has always offered a `'default'` entry alongside the real tabs, so the stored value can be a string the type says is impossible; the native select swallows it. And the language setting starts as `''`, which matches no option, so `<select>` computes `selectedIndex: -1` and renders the control blank until you pick something.

## The fix

`SelectField` is Base UI's `Select`. The trigger repeats the shared control recipe from `index.css` rather than inventing a second one, so it sits next to an `InputField` at the same height, radius, padding and focus treatment.

![The schedule type select above the inputs it shares a form with](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/select-04-edit-modal.png)

The popup is the `--popover` surface with `--shadow-popover`, the same layer as the menus and the hover panels, and the rows read from `--state-hover`, `--state-selected` and `--state-selected-hover`, so hover and selection are the one hue at three strengths we settled on in round 3.

![Language select open in the dark theme, selected row and hovered row](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/select-01-settings-dark.png)

![The same select in the light theme](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/select-02-settings-light.png)

`defaultJobTab` becomes `TabsType | 'default'`, with `useDetailsTabs` matching on it instead of `Array.includes`. Base UI's `onValueChange` hands back a `string`, which is what forced the question. The language select falls back to `i18n.language`, which `initI18n` has already narrowed to a supported language, so it shows what the board is actually rendering in.

The base64 chevron, `select` and `.select` all come out of `index.css`. Nothing else uses them: this was the last native select in the tree.

## Three things Base UI defaults got wrong here

**The popup laid itself over the trigger.** That is `alignItemWithTrigger`, and on the twelve entry language list it produces a popup taller than the modal it opens in. Off, so the popup anchors below the trigger and scrolls inside its own `max-height`. The schedulers filter, at 24 queues, is the case that needs it:

![Queue filter on the schedulers page, 24 entries scrolling inside the popup](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/select-03-schedulers-filter.png)

**`Select.ItemIndicator` renders only for the selected row.** Every other row lost its first grid cell and its label wrapped mid word. `keepMounted` plus `visibility: hidden` keeps the column and hides the glyph.

**The highlighted row got two focus indicators.** Base UI moves focus onto the row, so the global `:focus-visible` ring drew a box around something `data-highlighted` already marks. The ring is off on items.

One thing that is not a default: the schedulers filter carries a `min-width`. The trigger is as wide as the value it shows, where the native select was as wide as its longest option, so without a floor the filter resized every time you picked a different queue.

## Tests

229 across 35 suites. Three cover the select (keyboard selection, form submission, and the `aria-label` only case the schedulers filter uses) and two the language fallback; both of those are red against `value={language}`.

`tsc --noEmit`, oxlint and oxfmt clean, both themes checked by hand.

Still on the list from #1306: `Button` onto Base UI, and the docs site screenshots.
