### PR TITLE
feat(ui): move Tooltip onto Base UI

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "@tanstack/react-query": "^5.101.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/identity-obj-proxy": "^3.0.2",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.2.17",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@base-ui/react/tooltip';
 import React, { Suspense, useEffect } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { ConfirmModal } from './components/ConfirmModal/ConfirmModal';
@@ -60,7 +61,7 @@ export const App = () => {
   }, [isMobile, sidebarCollapsed]);
 
   return (
-    <>
+    <Tooltip.Provider delay={400} closeDelay={100}>
       <Header>
         <div className="header-title-group">
           {!isMobile && <SidebarToggle />}
@@ -85,6 +86,6 @@ export const App = () => {
         </div>
       </main>
       <Toaster />
-    </>
+    </Tooltip.Provider>
   );
 };

--- a/packages/ui/src/components/QueueCard/QueueCard.tsx
+++ b/packages/ui/src/components/QueueCard/QueueCard.tsx
@@ -45,7 +45,7 @@ export const QueueCard = ({ queue, displayName }: IQueueCardProps) => {
             {label}
           </NavLink>
           {!!queue.description && (
-            <Tooltip title={queue.description} className={s.infoTip} multiline={true}>
+            <Tooltip title={queue.description} className={s.infoTip}>
               <InfoIcon />
             </Tooltip>
           )}

--- a/packages/ui/src/components/Tooltip/Tooltip.module.css
+++ b/packages/ui/src/components/Tooltip/Tooltip.module.css
@@ -1,52 +1,40 @@
-.tooltip {
+/* Relative, not static: consumers (e.g. QueueCard's .infoTip) raise this element above a
+   sibling absolutely-positioned overlay with their own z-index, which does nothing unless
+   this element is itself positioned. */
+.trigger {
+  display: inline-flex;
   position: relative;
 }
 
-/* Same surface as the chart tooltips and the hover panels: popover fill, hairline border,
-   the shared elevation. A tooltip is a floating layer like any other, and inverting it into
-   a foreground-coloured pill made it the one thing on the board that ignored the palette. */
-.tooltip:before {
-  content: attr(data-title);
-  padding: 0.3em 0.55em;
-  background-color: var(--popover);
-  color: var(--popover-foreground);
+/* Portalled to document.body, so it stacks as a sibling of the fixed header (z-index 99)
+   and the sticky bar (z-index 2), both of which would otherwise paint over it. Placed
+   above DropdownContent (100) and Modal's overlay/content (1000/1100): a tooltip should
+   still surface if its trigger ever ends up inside a modal. Kept below Toaster (9999) so
+   a toast notification is never hidden behind a transient hover hint. */
+.positioner {
+  z-index: 1200;
+}
+
+/* The same surface as the chart tooltips and the hover panels, which is where the CSS bubble
+   was already headed. `max-width` replaces the old `multiline` flag: a short label still sits
+   on one line, and a sentence wraps without the call site having to say so. */
+.popup {
+  max-width: 20rem;
+  padding: 0.4rem 0.55rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
+  background-color: var(--popover);
+  color: var(--popover-foreground);
   box-shadow: var(--shadow-popover);
   font-size: 0.72rem;
-  font-weight: 400;
-  position: absolute;
-  bottom: 100%;
-  margin-bottom: 0.75rem;
-  left: 50%;
-  transform: translateX(-50%) translateY(-25%);
-  transition: transform 250ms ease-in-out, opacity 250ms ease-in-out;
-  pointer-events: none;
-  opacity: 0;
-  z-index: 2;
-  white-space: nowrap;
-}
-
-.tooltip:hover:before,
-.tooltip:focus-within:before {
-  transform: translateX(-50%) translateY(0);
-  opacity: 1;
-}
-
-/* Anchored to the trigger's left edge rather than centred on it: a sentence-length
-   bubble centred on an icon near the left of a card would spill past the viewport. */
-.multiline:before {
-  white-space: normal;
-  width: max-content;
-  max-width: 15rem;
-  text-align: left;
   line-height: 1.4;
-  padding: 0.4em 0.6em;
-  left: 0;
-  transform: translateY(-25%);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
 
-.multiline:hover:before,
-.multiline:focus-within:before {
-  transform: translateY(0);
+.popup[data-starting-style],
+.popup[data-ending-style] {
+  opacity: 0;
+  transform: translateY(-4px);
 }

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,4 @@
+import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip';
 import cn from 'clsx';
 import { PropsWithChildren } from 'react';
 import s from './Tooltip.module.css';
@@ -5,17 +6,17 @@ import s from './Tooltip.module.css';
 interface TooltipProps {
   title: string;
   className?: string;
-  /** Lets the bubble wrap onto several lines, for sentences rather than short labels. */
-  multiline?: boolean;
 }
 
-export const Tooltip = ({
-  title,
-  className,
-  multiline,
-  children,
-}: PropsWithChildren<TooltipProps>) => (
-  <span data-title={title} className={cn(s.tooltip, multiline && s.multiline, className)}>
-    {children}
-  </span>
+export const Tooltip = ({ title, className, children }: PropsWithChildren<TooltipProps>) => (
+  <BaseTooltip.Root>
+    <BaseTooltip.Trigger render={<span className={cn(s.trigger, className)} />}>
+      {children}
+    </BaseTooltip.Trigger>
+    <BaseTooltip.Portal>
+      <BaseTooltip.Positioner className={s.positioner} side="top" sideOffset={6}>
+        <BaseTooltip.Popup className={s.popup}>{title}</BaseTooltip.Popup>
+      </BaseTooltip.Positioner>
+    </BaseTooltip.Portal>
+  </BaseTooltip.Root>
 );

--- a/packages/ui/tests/components/Tooltip.spec.tsx
+++ b/packages/ui/tests/components/Tooltip.spec.tsx
@@ -1,0 +1,46 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tooltip } from '../../src/components/Tooltip/Tooltip';
+import { render } from '../testUtils';
+
+it('opens on hover and names the trigger', async () => {
+  const user = userEvent.setup();
+  render(
+    <Tooltip title="Retry this job">
+      <button type="button">Retry</button>
+    </Tooltip>
+  );
+
+  await user.hover(screen.getByRole('button', { name: 'Retry' }));
+
+  await waitFor(() => expect(screen.getByText('Retry this job')).toBeTruthy());
+});
+
+it('opens on keyboard focus', async () => {
+  const user = userEvent.setup();
+  render(
+    <Tooltip title="Retry this job">
+      <button type="button">Retry</button>
+    </Tooltip>
+  );
+
+  await user.tab();
+
+  await waitFor(() => expect(screen.getByText('Retry this job')).toBeTruthy());
+});
+
+it('closes on escape', async () => {
+  const user = userEvent.setup();
+  render(
+    <Tooltip title="Retry this job">
+      <button type="button">Retry</button>
+    </Tooltip>
+  );
+
+  await user.hover(screen.getByRole('button', { name: 'Retry' }));
+  await waitFor(() => expect(screen.getByText('Retry this job')).toBeTruthy());
+
+  await user.keyboard('{Escape}');
+
+  await waitFor(() => expect(screen.queryByText('Retry this job')).toBeNull());
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,7 @@ __metadata:
     "@tanstack/react-query": "npm:^5.101.2"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@testing-library/user-event": "npm:^14.6.1"
     "@types/identity-obj-proxy": "npm:^3.0.2"
     "@types/jest": "npm:^30.0.0"
     "@types/react": "npm:^19.2.17"
@@ -4503,6 +4504,15 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/f9c7f0915e1b5f7b750e6c7d8b51f091b8ae7ea99bacb761d7b8505ba25de9cfcb749a0f779f1650fb268b499dd79165dc7e1ee0b8b4cb63430d3ddc81ffe044
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10c0/75fea130a52bf320d35d46ed54f3eec77e71a56911b8b69a3fe29497b0b9947b2dc80d30f04054ad4ce7f577856ae3e5397ea7dff0ef14944d3909784c7a93fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #1356.

## Problem

The queue description tooltip is unreadable: the sticky status bar, the group header and the next queue card all paint over it.

Tooltip is the last hand-rolled primitive on the board. It is a `::before` on a wrapper span, with the text in a `data-title` attribute, positioned by hand and drawn at `z-index: 2` inside the card it belongs to. `QueueCard`'s `.infoTip` is also `z-index: 2`, so the bubble is stacked inside the card rather than above the page. Everything that comes later in the document and stacks at the same level wins: `StickyHeader` is `position: sticky; z-index: 2`, and a neighbouring card is simply a later sibling. Nothing is clipping the bubble, it is being covered, which is why it looks cut off at whichever edge it meets first.

The `multiline` prop exists for the same reason. A hand-positioned bubble needs `nowrap` and centring for a short label, and wrapping, a `max-width` and left anchoring for a sentence, because a centred sentence on an icon near the left of a card runs off the viewport. The call site has to know which one it is passing.

## The fix

`Tooltip` is Base UI's `Tooltip`. The popup is portalled to the body, so it is no longer inside the card's stacking context, and the `z-index` on the positioner puts it above the header (99), the sticky bar (2), the menus (100) and a modal (1000/1100), and below the toaster (9999) so a notification is never hidden behind a hover hint.

![Queue description tooltip clearing the group header and the neighbouring card](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/tooltip-01-card-description.png)

![A job action tooltip painting over the sticky action bar](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/tooltip-02-sticky.png)

![The description tooltip in the light theme](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-v9-followups/tooltip-03-light.png)

The surface is unchanged from round 3 of #1306: `--popover` fill, hairline border, `--shadow-popover`, the same layer as the chart tooltips.

`multiline` is gone. A real positioner handles the collision itself, so the two cases collapse into one `max-width: 20rem`: a short label still sits on one line, a sentence wraps. `QueueCard` drops its `multiline={true}` and nothing else changes.

## What it costs

`Tooltip.Provider` goes around the app. That is what gives every tooltip the shared 400ms open delay and a 100ms grace period, so moving between two adjacent action icons does not replay the delay.

The trigger keeps `position: relative`. `.infoTip` raises itself above `.link:after`, the overlay that makes the whole card clickable, and that `z-index` does nothing on a static element.

Escape closes an open tooltip now, which the CSS one had no way to do.

## Tests

227 across 34 suites, three of them new: opens on hover, opens on keyboard focus, closes on escape. All three are red against the old component, which put the text in an attribute rather than in the document.

`tsc --noEmit`, oxlint and oxfmt clean, both themes checked by hand.
