### PR TITLE
fix(api): keep bull repeatables armed when cleaning delayed jobs

### DIFF
--- a/packages/api/src/handlers/cleanJob.ts
+++ b/packages/api/src/handlers/cleanJob.ts
@@ -19,9 +19,24 @@ function isJobSchedulerRun(error: unknown): boolean {
 async function cleanJob(
   _req: BullBoardRequest,
   job: QueueJob,
-  _queue: BaseAdapter
+  queue: BaseAdapter
 ): Promise<ControllerHandlerReturnType> {
   const jobId = job.toJSON().id ?? 'unknown id';
+
+  // Bull deletes the run a repeatable is waiting on without complaint, stranding the schedule, so
+  // the adapter is asked up front. BullMQ answers null here and raises the error below instead.
+  const armedSchedulerId = await queue.getArmedJobSchedulerId(job);
+
+  if (armedSchedulerId) {
+    return errorResponse(400, 'ERRORS.JOB_BELONGS_TO_JOB_SCHEDULER', {
+      message: {
+        key: 'ERRORS.JOB_BELONGS_TO_JOB_SCHEDULER_DETAILS',
+        options: { jobId, jobSchedulerId: armedSchedulerId },
+      },
+      code: 'JOB_BELONGS_TO_JOB_SCHEDULER',
+      jobSchedulerId: armedSchedulerId,
+    });
+  }
 
   try {
     await job.remove();

--- a/packages/api/src/handlers/cleanJob.ts
+++ b/packages/api/src/handlers/cleanJob.ts
@@ -23,8 +23,6 @@ async function cleanJob(
 ): Promise<ControllerHandlerReturnType> {
   const jobId = job.toJSON().id ?? 'unknown id';
 
-  // Bull deletes the run a repeatable is waiting on without complaint, stranding the schedule, so
-  // the adapter is asked up front. BullMQ answers null here and raises the error below instead.
   const armedSchedulerId = await queue.getArmedJobSchedulerId(job);
 
   if (armedSchedulerId) {

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -132,11 +132,6 @@ export abstract class BaseAdapter {
 
   public abstract promoteAll(): Promise<void>;
 
-  /**
-   * Id of the job scheduler `job` is the currently armed run of, or null when removing the job is
-   * safe. BullMQ enforces this inside its own Lua and raises `JobBelongsToJobScheduler`, so only
-   * Bull, which has no such protection, has to answer by looking the schedule up itself.
-   */
   public async getArmedJobSchedulerId(_job: QueueJob): Promise<string | null> {
     return null;
   }

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -132,6 +132,15 @@ export abstract class BaseAdapter {
 
   public abstract promoteAll(): Promise<void>;
 
+  /**
+   * Id of the job scheduler `job` is the currently armed run of, or null when removing the job is
+   * safe. BullMQ enforces this inside its own Lua and raises `JobBelongsToJobScheduler`, so only
+   * Bull, which has no such protection, has to answer by looking the schedule up itself.
+   */
+  public async getArmedJobSchedulerId(_job: QueueJob): Promise<string | null> {
+    return null;
+  }
+
   public abstract removeJobScheduler(id: string): Promise<boolean>;
 
   /**

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -19,7 +19,7 @@ import {
 import { STATUSES } from '../constants/statuses';
 import { BaseAdapter } from './base';
 
-/** Bull stamps `prevMillis` onto every run a repeatable produces but leaves it out of its types. */
+// `prevMillis` is written by Bull onto every repeatable run but missing from its types.
 function repeatOptionsOf(job: Job): JobOptions & { prevMillis?: number } {
   return (job?.opts ?? {}) as JobOptions & { prevMillis?: number };
 }
@@ -52,7 +52,6 @@ export class BullAdapter extends BaseAdapter {
   public async clean(jobStatus: JobCleanStatus, graceTimeMs: number): Promise<any> {
     const armedRuns = await this.getArmedSchedulerRuns();
 
-    // Nothing is scheduled, so there is nothing to strand and Bull's own sweep is left alone.
     if (armedRuns.size === 0) {
       return this.queue.clean(graceTimeMs, jobStatus as any);
     }
@@ -206,11 +205,6 @@ export class BullAdapter extends BaseAdapter {
     return (this.queue as { defaultJobOptions?: QueueDefaultJobOptions }).defaultJobOptions ?? {};
   }
 
-  /**
-   * Repeat key mapped to the run time its schedule currently points at. Bull tracks the pending
-   * run only through this pairing, so the job holding it is the one thing keeping the schedule
-   * able to fire again.
-   */
   private async getArmedSchedulerRuns(): Promise<Map<string, number>> {
     const repeatables = await this.queue.getRepeatableJobs();
 
@@ -220,16 +214,9 @@ export class BullAdapter extends BaseAdapter {
   private isArmedSchedulerRun(job: Job, armedRuns: Map<string, number>): boolean {
     const { repeat, prevMillis } = repeatOptionsOf(job);
 
-    // Past runs of the same schedule carry the repeat options too, so the key alone says nothing.
-    // Only the run the schedule points at is protected.
     return !!repeat?.key && armedRuns.get(repeat.key) === prevMillis;
   }
 
-  /**
-   * Bull's `clean` deletes straight out of Redis with no notion of which delayed job a repeatable
-   * is waiting on, which is what leaves a schedule registered but unable to fire (issue #294).
-   * This walks the same set and applies the same grace rule, minus the armed runs.
-   */
   private async cleanSparingArmedRuns(
     jobStatus: JobCleanStatus,
     graceTimeMs: number,
@@ -244,8 +231,6 @@ export class BullAdapter extends BaseAdapter {
         continue;
       }
 
-      // Bull compares against the first timestamp a job actually carries, so anything touched
-      // inside the grace window survives.
       const timestamp = job.finishedOn ?? job.processedOn ?? job.timestamp;
 
       if (timestamp && timestamp >= maxTimestamp) {
@@ -256,8 +241,7 @@ export class BullAdapter extends BaseAdapter {
         await job.remove();
         removed.push(String(job.id));
       } catch {
-        // Bull's own sweep skips jobs a worker holds a lock on rather than failing outright, and
-        // `remove` throws on exactly those, so they drop out here the same way.
+        // Locked by a worker, which Bull's own sweep skips too.
       }
     }
 

--- a/packages/api/src/queueAdapters/bull.ts
+++ b/packages/api/src/queueAdapters/bull.ts
@@ -1,4 +1,4 @@
-import BullQueue, { Job, Queue } from 'bull';
+import BullQueue, { Job, JobOptions, Queue } from 'bull';
 import {
   AppJobScheduler,
   JobCleanStatus,
@@ -10,6 +10,7 @@ import {
   ObliterateOptions,
   QueueAdapterOptions,
   QueueDefaultJobOptions,
+  QueueJob,
   QueueJobOptions,
   QueueMetrics,
   QueueWorker,
@@ -17,6 +18,11 @@ import {
 } from '../../typings/app';
 import { STATUSES } from '../constants/statuses';
 import { BaseAdapter } from './base';
+
+/** Bull stamps `prevMillis` onto every run a repeatable produces but leaves it out of its types. */
+function repeatOptionsOf(job: Job): JobOptions & { prevMillis?: number } {
+  return (job?.opts ?? {}) as JobOptions & { prevMillis?: number };
+}
 
 export class BullAdapter extends BaseAdapter {
   constructor(
@@ -43,8 +49,27 @@ export class BullAdapter extends BaseAdapter {
     return this.normalizeWorkers(clients as unknown as Record<string, string>[]);
   }
 
-  public clean(jobStatus: JobCleanStatus, graceTimeMs: number): Promise<any> {
-    return this.queue.clean(graceTimeMs, jobStatus as any);
+  public async clean(jobStatus: JobCleanStatus, graceTimeMs: number): Promise<any> {
+    const armedRuns = await this.getArmedSchedulerRuns();
+
+    // Nothing is scheduled, so there is nothing to strand and Bull's own sweep is left alone.
+    if (armedRuns.size === 0) {
+      return this.queue.clean(graceTimeMs, jobStatus as any);
+    }
+
+    return this.cleanSparingArmedRuns(jobStatus, graceTimeMs, armedRuns);
+  }
+
+  public async getArmedJobSchedulerId(job: QueueJob): Promise<string | null> {
+    const repeatKey = repeatOptionsOf(job as Job).repeat?.key;
+
+    if (!repeatKey) {
+      return null;
+    }
+
+    const armedRuns = await this.getArmedSchedulerRuns();
+
+    return this.isArmedSchedulerRun(job as Job, armedRuns) ? repeatKey : null;
   }
 
   public addJob(name: string, data: any, options: QueueJobOptions) {
@@ -179,6 +204,64 @@ export class BullAdapter extends BaseAdapter {
 
   public getQueueDefaultJobOptions(): QueueDefaultJobOptions {
     return (this.queue as { defaultJobOptions?: QueueDefaultJobOptions }).defaultJobOptions ?? {};
+  }
+
+  /**
+   * Repeat key mapped to the run time its schedule currently points at. Bull tracks the pending
+   * run only through this pairing, so the job holding it is the one thing keeping the schedule
+   * able to fire again.
+   */
+  private async getArmedSchedulerRuns(): Promise<Map<string, number>> {
+    const repeatables = await this.queue.getRepeatableJobs();
+
+    return new Map(repeatables.map((repeatable) => [repeatable.key, repeatable.next]));
+  }
+
+  private isArmedSchedulerRun(job: Job, armedRuns: Map<string, number>): boolean {
+    const { repeat, prevMillis } = repeatOptionsOf(job);
+
+    // Past runs of the same schedule carry the repeat options too, so the key alone says nothing.
+    // Only the run the schedule points at is protected.
+    return !!repeat?.key && armedRuns.get(repeat.key) === prevMillis;
+  }
+
+  /**
+   * Bull's `clean` deletes straight out of Redis with no notion of which delayed job a repeatable
+   * is waiting on, which is what leaves a schedule registered but unable to fire (issue #294).
+   * This walks the same set and applies the same grace rule, minus the armed runs.
+   */
+  private async cleanSparingArmedRuns(
+    jobStatus: JobCleanStatus,
+    graceTimeMs: number,
+    armedRuns: Map<string, number>
+  ): Promise<string[]> {
+    const jobs = await this.queue.getJobs([jobStatus as any]);
+    const maxTimestamp = Date.now() - graceTimeMs;
+    const removed: string[] = [];
+
+    for (const job of jobs) {
+      if (!job || this.isArmedSchedulerRun(job, armedRuns)) {
+        continue;
+      }
+
+      // Bull compares against the first timestamp a job actually carries, so anything touched
+      // inside the grace window survives.
+      const timestamp = job.finishedOn ?? job.processedOn ?? job.timestamp;
+
+      if (timestamp && timestamp >= maxTimestamp) {
+        continue;
+      }
+
+      try {
+        await job.remove();
+        removed.push(String(job.id));
+      } catch {
+        // Bull's own sweep skips jobs a worker holds a lock on rather than failing outright, and
+        // `remove` throws on exactly those, so they drop out here the same way.
+      }
+    }
+
+    return removed;
   }
 
   private alignJobData(job: Job) {

--- a/packages/api/tests/api/bull-scheduled-job-removal.spec.ts
+++ b/packages/api/tests/api/bull-scheduled-job-removal.spec.ts
@@ -1,0 +1,162 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullAdapter } from '@bull-board/api/bullAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import Queue from 'bull';
+import request from 'supertest';
+
+jest.setTimeout(30_000);
+
+/**
+ * BullMQ refuses to drop the run a scheduler is waiting on from inside its own Lua, so the
+ * equivalent BullMQ suite (scheduled-job-removal.spec.ts) only has to assert the error surface.
+ * Bull has no such protection, which is what issue #294 reports: cleaning delayed jobs takes the
+ * armed run with it and leaves a repeatable registered that can never fire again.
+ */
+describe('Bull scheduled job removal', () => {
+  let serverAdapter: ExpressAdapter;
+  let testQueue: Queue.Queue;
+
+  const redis = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  /** Matches the grace window `cleanAllHandler` applies, so jobs have to age past it to qualify. */
+  const CLEAN_GRACE_MS = 5000;
+
+  beforeEach(async () => {
+    serverAdapter = new ExpressAdapter();
+    testQueue = new Queue('BullScheduledJobTest', { redis });
+
+    await testQueue.obliterate({ force: true });
+
+    createBullBoard({
+      queues: [new BullAdapter(testQueue)],
+      serverAdapter,
+    });
+  });
+
+  afterEach(async () => {
+    await testQueue.obliterate({ force: true });
+    await testQueue.close();
+  });
+
+  /** Bull skips anything whose timestamp falls inside the grace window, fix or no fix. */
+  const ageBeyondGrace = () => new Promise((resolve) => setTimeout(resolve, CLEAN_GRACE_MS + 200));
+
+  /** Bull writes `prevMillis` onto a repeatable run's options but leaves it out of its types. */
+  const optsOf = (job: Queue.Job) => job.opts as Queue.JobOptions & { prevMillis?: number };
+
+  const client = () => (testQueue as any).client as { hset: (...args: any[]) => Promise<unknown> };
+  const toKey = (jobId: Queue.JobId) => (testQueue as any).toKey(jobId) as string;
+
+  async function getArmedRun() {
+    const delayed = await testQueue.getDelayed();
+    const armed = delayed.find((job) => !!job.opts?.repeat?.key);
+
+    if (!armed) {
+      throw new Error('Repeatable job should have produced a delayed run');
+    }
+
+    return armed;
+  }
+
+  describe('Cleaning every delayed job', () => {
+    it('removes ordinary and past runs but leaves the armed run and its schedule', async () => {
+      await testQueue.add('scheduled-task', {}, { repeat: { every: 60_000 } });
+      const ordinaryJob = await testQueue.add('ordinary-task', {}, { delay: 120_000 });
+
+      const armedRun = await getArmedRun();
+      expect(await testQueue.getRepeatableJobs()).toHaveLength(1);
+
+      // A run the schedule has already moved past keeps its repeat options but is no longer the
+      // one anything points at, so nothing depends on it staying around. Adding it through
+      // `repeat` would just hand back the armed run, so its options are written directly.
+      const pastRun = await testQueue.add('scheduled-task', {}, { delay: 120_000 });
+      await client().hset(
+        toKey(pastRun.id),
+        'opts',
+        JSON.stringify({
+          ...optsOf(armedRun),
+          jobId: pastRun.id,
+          prevMillis: (optsOf(armedRun).prevMillis as number) - 60_000,
+        })
+      );
+
+      await ageBeyondGrace();
+
+      await request(serverAdapter.getRouter())
+        .put(`/api/queues/${testQueue.name}/clean/delayed`)
+        .expect(200);
+
+      // Both of these are what the operator asked to clean, so they go.
+      expect(await testQueue.getJob(ordinaryJob.id)).toBeNull();
+      expect(await testQueue.getJob(pastRun.id)).toBeNull();
+
+      // The armed run does not, because without it the schedule below can never fire again.
+      const delayedAfter = await testQueue.getDelayed();
+      expect(delayedAfter.map((job) => job.id)).toEqual([armedRun.id]);
+
+      const repeatables = await testQueue.getRepeatableJobs();
+      expect(repeatables).toHaveLength(1);
+      expect(repeatables[0].next).toBe(optsOf(armedRun).prevMillis);
+    });
+
+    it('is unaffected on a queue that has no repeatables', async () => {
+      const ordinaryJob = await testQueue.add('ordinary-task', {}, { delay: 120_000 });
+
+      await ageBeyondGrace();
+
+      await request(serverAdapter.getRouter())
+        .put(`/api/queues/${testQueue.name}/clean/delayed`)
+        .expect(200);
+
+      expect(await testQueue.getJob(ordinaryJob.id)).toBeNull();
+      expect(await testQueue.getDelayed()).toHaveLength(0);
+    });
+
+    it('still respects the grace window', async () => {
+      const freshJob = await testQueue.add('ordinary-task', {}, { delay: 120_000 });
+      await testQueue.add('scheduled-task', {}, { repeat: { every: 60_000 } });
+
+      await request(serverAdapter.getRouter())
+        .put(`/api/queues/${testQueue.name}/clean/delayed`)
+        .expect(200);
+
+      // Created well inside the grace window, so Bull spares it and so do we.
+      expect(await testQueue.getJob(freshJob.id)).not.toBeNull();
+    });
+  });
+
+  describe('Cleaning a single job', () => {
+    it('refuses to remove the armed run and names the schedule responsible', async () => {
+      await testQueue.add('scheduled-task', {}, { repeat: { every: 60_000 } });
+      const armedRun = await getArmedRun();
+
+      const { body } = await request(serverAdapter.getRouter())
+        .put(`/api/queues/${testQueue.name}/${armedRun.id}/clean`)
+        .expect(400);
+
+      expect(body).toMatchObject({
+        code: 'JOB_BELONGS_TO_JOB_SCHEDULER',
+        jobSchedulerId: armedRun.opts.repeat?.key,
+      });
+      expect(body.error).toEqual({ key: 'ERRORS.JOB_BELONGS_TO_JOB_SCHEDULER' });
+
+      expect(await testQueue.getJob(armedRun.id)).not.toBeNull();
+      expect(await testQueue.getRepeatableJobs()).toHaveLength(1);
+    });
+
+    it('removes an ordinary job while a schedule is registered', async () => {
+      await testQueue.add('scheduled-task', {}, { repeat: { every: 60_000 } });
+      const ordinaryJob = await testQueue.add('ordinary-task', {}, { delay: 120_000 });
+
+      await request(serverAdapter.getRouter())
+        .put(`/api/queues/${testQueue.name}/${ordinaryJob.id}/clean`)
+        .expect(204);
+
+      expect(await testQueue.getJob(ordinaryJob.id)).toBeNull();
+      expect(await testQueue.getRepeatableJobs()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/api/tests/api/bull-scheduled-job-removal.spec.ts
+++ b/packages/api/tests/api/bull-scheduled-job-removal.spec.ts
@@ -6,12 +6,6 @@ import request from 'supertest';
 
 jest.setTimeout(30_000);
 
-/**
- * BullMQ refuses to drop the run a scheduler is waiting on from inside its own Lua, so the
- * equivalent BullMQ suite (scheduled-job-removal.spec.ts) only has to assert the error surface.
- * Bull has no such protection, which is what issue #294 reports: cleaning delayed jobs takes the
- * armed run with it and leaves a repeatable registered that can never fire again.
- */
 describe('Bull scheduled job removal', () => {
   let serverAdapter: ExpressAdapter;
   let testQueue: Queue.Queue;
@@ -21,7 +15,6 @@ describe('Bull scheduled job removal', () => {
     port: +(process.env.REDIS_PORT || 6379),
   };
 
-  /** Matches the grace window `cleanAllHandler` applies, so jobs have to age past it to qualify. */
   const CLEAN_GRACE_MS = 5000;
 
   beforeEach(async () => {
@@ -41,10 +34,8 @@ describe('Bull scheduled job removal', () => {
     await testQueue.close();
   });
 
-  /** Bull skips anything whose timestamp falls inside the grace window, fix or no fix. */
   const ageBeyondGrace = () => new Promise((resolve) => setTimeout(resolve, CLEAN_GRACE_MS + 200));
 
-  /** Bull writes `prevMillis` onto a repeatable run's options but leaves it out of its types. */
   const optsOf = (job: Queue.Job) => job.opts as Queue.JobOptions & { prevMillis?: number };
 
   const client = () => (testQueue as any).client as { hset: (...args: any[]) => Promise<unknown> };
@@ -69,9 +60,6 @@ describe('Bull scheduled job removal', () => {
       const armedRun = await getArmedRun();
       expect(await testQueue.getRepeatableJobs()).toHaveLength(1);
 
-      // A run the schedule has already moved past keeps its repeat options but is no longer the
-      // one anything points at, so nothing depends on it staying around. Adding it through
-      // `repeat` would just hand back the armed run, so its options are written directly.
       const pastRun = await testQueue.add('scheduled-task', {}, { delay: 120_000 });
       await client().hset(
         toKey(pastRun.id),
@@ -89,11 +77,9 @@ describe('Bull scheduled job removal', () => {
         .put(`/api/queues/${testQueue.name}/clean/delayed`)
         .expect(200);
 
-      // Both of these are what the operator asked to clean, so they go.
       expect(await testQueue.getJob(ordinaryJob.id)).toBeNull();
       expect(await testQueue.getJob(pastRun.id)).toBeNull();
 
-      // The armed run does not, because without it the schedule below can never fire again.
       const delayedAfter = await testQueue.getDelayed();
       expect(delayedAfter.map((job) => job.id)).toEqual([armedRun.id]);
 
@@ -123,7 +109,6 @@ describe('Bull scheduled job removal', () => {
         .put(`/api/queues/${testQueue.name}/clean/delayed`)
         .expect(200);
 
-      // Created well inside the grace window, so Bull spares it and so do we.
       expect(await testQueue.getJob(freshJob.id)).not.toBeNull();
     });
   });


### PR DESCRIPTION
Closes #294.

Cleaning delayed jobs on a Bull queue deletes the run a repeatable is waiting on. The schedule stays registered and never fires again. Removing that job on its own does the same and answers 204.

BullMQ fixed this in 5.16.0: `cleanSet.lua` calls `isJobSchedulerJob` and skips the armed run, and single removal raises `JobBelongsToJobScheduler`, which `cleanJob` already turns into a 400. I bisected it, 5.15.0 is broken and 5.16.0 is not. Bull has nothing equivalent and 4.16.5 is the last release, so the guard has to live here.

`BullAdapter.clean` delegates to `queue.clean` untouched when the queue has no repeatables. Otherwise it walks the set itself with Bull's own grace rule, first of `finishedOn`, `processedOn`, `timestamp`, locked jobs skipped, and leaves the armed run behind. Identifying that run needs both halves of the pairing: `opts.repeat.key` registered, and `opts.prevMillis` equal to its `next`. The key alone also matches past runs, which are ordinary jobs and should still clean. The md5 in the job id is not the repeatable key.

`BaseAdapter.getArmedJobSchedulerId` returns null by default, so BullMQ keeps relying on its own error. Bull overrides it, `cleanJob` asks before removing, and you get the same 400 with the same `jobSchedulerId`. No new translation keys.

## Tests

`bull-scheduled-job-removal.spec.ts`, the Bull sibling of the BullMQ suite. Both central cases fail on master, the bulk clean leaving the delayed set empty and the single one answering 204. Two controls in there guard the other direction: a queue with no repeatables cleans exactly as before, and the grace window still holds.
