### PR TITLE
feat(ui): support a custom icon per miscLinks entry

### DIFF
--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -518,11 +518,6 @@ export type BoardOptions = {
 export type IMiscLink = {
   text: string;
   url: string;
-  /**
-   * URL or static path to an image shown before the link text. The board's own icons are inline
-   * SVGs coloured by CSS, which an external image cannot inherit, so pick one that reads on both
-   * the light and dark dropdown background.
-   */
   icon?: string;
 };
 

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -518,6 +518,12 @@ export type BoardOptions = {
 export type IMiscLink = {
   text: string;
   url: string;
+  /**
+   * URL or static path to an image shown before the link text. The board's own icons are inline
+   * SVGs coloured by CSS, which an external image cannot inherit, so pick one that reads on both
+   * the light and dark dropdown background.
+   */
+  icon?: string;
 };
 
 /**

--- a/packages/ui/src/components/CustomLinksDropdown/CustomLinksDropdown.tsx
+++ b/packages/ui/src/components/CustomLinksDropdown/CustomLinksDropdown.tsx
@@ -24,6 +24,7 @@ export const CustomLinksDropdown = ({ options = [], className }: CustomLinksDrop
         <DropdownContent>
           {options.map((option) => (
             <Menu.LinkItem key={option.url} href={option.url} closeOnClick>
+              {!!option.icon && <img src={option.icon} alt="" />}
               {option.text}
             </Menu.LinkItem>
           ))}

--- a/packages/ui/src/components/DropdownContent/DropdownContent.module.css
+++ b/packages/ui/src/components/DropdownContent/DropdownContent.module.css
@@ -33,6 +33,16 @@
   fill: var(--muted-foreground);
 }
 
+/* Caller-supplied link icons. Sized to match the built-in svgs above, but left uncoloured:
+   `fill` does nothing to an `img`, so the image has to carry its own colour. */
+.content > [role='menuitem'] > img {
+  margin-right: 0.5rem;
+  width: 1.18em;
+  height: 1em;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
 .content > [role='menuitem']:hover,
 .content > [role='menuitem'][data-highlighted] {
   color: inherit;

--- a/packages/ui/src/components/DropdownContent/DropdownContent.module.css
+++ b/packages/ui/src/components/DropdownContent/DropdownContent.module.css
@@ -33,8 +33,6 @@
   fill: var(--muted-foreground);
 }
 
-/* Caller-supplied link icons. Sized to match the built-in svgs above, but left uncoloured:
-   `fill` does nothing to an `img`, so the image has to carry its own colour. */
 .content > [role='menuitem'] > img {
   margin-right: 0.5rem;
   width: 1.18em;

--- a/packages/ui/tests/components/CustomLinksDropdown.spec.tsx
+++ b/packages/ui/tests/components/CustomLinksDropdown.spec.tsx
@@ -32,8 +32,6 @@ it('shows the icon of an option that has one', async () => {
   const icon = itemNamed('Logout')?.querySelector('img');
 
   expect(icon?.getAttribute('src')).toBe('https://cdn.example.com/logout.svg');
-  // The link text already says what the item does, so repeating it would only add noise for a
-  // screen reader.
   expect(icon?.getAttribute('alt')).toBe('');
 });
 

--- a/packages/ui/tests/components/CustomLinksDropdown.spec.tsx
+++ b/packages/ui/tests/components/CustomLinksDropdown.spec.tsx
@@ -1,0 +1,44 @@
+import type { UIConfig } from '@bull-board/api/typings/app';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { CustomLinksDropdown } from '../../src/components/CustomLinksDropdown/CustomLinksDropdown';
+import { render } from '../testUtils';
+
+async function openDropdown(options: UIConfig['miscLinks']) {
+  render(<CustomLinksDropdown className="trigger" options={options} />);
+
+  fireEvent.click(screen.getAllByRole('button')[0]);
+  await waitFor(() => expect(screen.getByRole('menu')).toBeTruthy());
+}
+
+function itemNamed(text: string) {
+  return screen.getByText(text).closest('[role="menuitem"]');
+}
+
+it('renders a link per option', async () => {
+  await openDropdown([
+    { text: 'Logout', url: '/logout' },
+    { text: 'Docs', url: 'https://example.com/docs' },
+  ]);
+
+  expect(itemNamed('Logout')?.getAttribute('href')).toBe('/logout');
+  expect(itemNamed('Docs')?.getAttribute('href')).toBe('https://example.com/docs');
+});
+
+it('shows the icon of an option that has one', async () => {
+  await openDropdown([
+    { text: 'Logout', url: '/logout', icon: 'https://cdn.example.com/logout.svg' },
+  ]);
+
+  const icon = itemNamed('Logout')?.querySelector('img');
+
+  expect(icon?.getAttribute('src')).toBe('https://cdn.example.com/logout.svg');
+  // The link text already says what the item does, so repeating it would only add noise for a
+  // screen reader.
+  expect(icon?.getAttribute('alt')).toBe('');
+});
+
+it('renders no image for an option without an icon', async () => {
+  await openDropdown([{ text: 'Logout', url: '/logout' }]);
+
+  expect(itemNamed('Logout')?.querySelector('img')).toBeNull();
+});

--- a/website/docs/configuration/ui-config.md
+++ b/website/docs/configuration/ui-config.md
@@ -46,7 +46,7 @@ All fields are optional. Defaults are applied by `createBullBoard` where noted.
 | `boardLogo.path` | `string` | — | URL or static path to the logo image (required when `boardLogo` is set). |
 | `boardLogo.width` | `number \| string` | — | Logo width (px number or CSS length). |
 | `boardLogo.height` | `number \| string` | — | Logo height (px number or CSS length). |
-| `miscLinks` | `Array<{ text: string; url: string; icon?: string }>` | `[]` | Extra links in the header menu (logout, etc.). `icon` is an optional URL or static path to an image shown before the link text; the board's own icons are inline SVGs coloured by CSS, which an external image cannot inherit, so pick one that reads on both the light and dark dropdown background. |
+| `miscLinks` | `Array<{ text: string; url: string; icon?: string }>` | `[]` | Extra links in the header menu (logout, etc.). `icon` is an optional URL or static path to an image shown before the link text; it is rendered as-is, so pick one that reads on both the light and dark dropdown background. |
 | `hideDocsLink` | `boolean` | `false` | Hide the header Docs icon that links to the bull-board documentation site. |
 | `queueSortOptions` | `Array<{ key: string; label: string }>` | — | Custom sort keys for the queue list. |
 | `favIcon.default` | `string` | `'static/images/logo.svg'` | Favicon when the tab is inactive. |

--- a/website/docs/configuration/ui-config.md
+++ b/website/docs/configuration/ui-config.md
@@ -25,7 +25,7 @@ createBullBoard({
         width: '120px',
         height: 32,
       },
-      miscLinks: [{ text: 'Logout', url: '/logout' }],
+      miscLinks: [{ text: 'Logout', url: '/logout', icon: '/static/logout.svg' }],
       hideRedisDetails: true,
       showMetrics: true,
       hideDocsLink: false,
@@ -46,7 +46,7 @@ All fields are optional. Defaults are applied by `createBullBoard` where noted.
 | `boardLogo.path` | `string` | — | URL or static path to the logo image (required when `boardLogo` is set). |
 | `boardLogo.width` | `number \| string` | — | Logo width (px number or CSS length). |
 | `boardLogo.height` | `number \| string` | — | Logo height (px number or CSS length). |
-| `miscLinks` | `Array<{ text: string; url: string }>` | `[]` | Extra links in the header menu (logout, etc.). |
+| `miscLinks` | `Array<{ text: string; url: string; icon?: string }>` | `[]` | Extra links in the header menu (logout, etc.). `icon` is an optional URL or static path to an image shown before the link text; the board's own icons are inline SVGs coloured by CSS, which an external image cannot inherit, so pick one that reads on both the light and dark dropdown background. |
 | `hideDocsLink` | `boolean` | `false` | Hide the header Docs icon that links to the bull-board documentation site. |
 | `queueSortOptions` | `Array<{ key: string; label: string }>` | — | Custom sort keys for the queue list. |
 | `favIcon.default` | `string` | `'static/images/logo.svg'` | Favicon when the tab is inactive. |


### PR DESCRIPTION
Closes #1276.

`miscLinks` entries render as bare text today, which is why the reporter ended up injecting HTML through middleware. This adds the optional `icon` you suggested in the thread:

```ts
miscLinks: [{ text: 'Logout', url: '/logout', icon: '/static/logout.svg' }],
```

A URL rather than a key, since the board's own icons are inline SVGs, and because `boardLogo.path` and `favIcon` already take a caller string straight into `src` and `href`. The dropdown has a leading icon slot already, the one the queue actions menu uses, so the image drops into it. `option.url` was an `href` before this, and an `img src` cannot run a `javascript:` URL, so nothing new opens up.

One thing worth knowing. The built-in icons take their colour from `fill: var(--muted-foreground)`, which an `img` cannot inherit, and the dropdown background follows the theme, so a dark monochrome icon disappears in dark mode. A CSS filter would fix that and wreck a colour logo, so instead it is sized to match the built-ins and left to carry its own colour, with the docs saying as much. Tell me if you would rather it sat in a neutral chip.

`alt=""`, since the link text beside it already names the destination. No new translation keys.

The component had no tests before; it has three now, and the icon one fails when the render is reverted.

**Worth deciding before this merges**: the workaround in the linked repo injects a header button rather than a menu item, so what they actually want may be a top-level entry next to Redis and Docs. This does what the issue title asks for. Say the word and I will build the other one instead.
