### PR TITLE
feat(demo): show schedulers, latency, job data schema and default job options

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -283,6 +283,16 @@ interface DemoQueueProfile {
 // 12:5m 13:10m 14:30m 15:1h 16:6h 17:overflow
 const DEMO_QUEUE_PROFILES: DemoQueueProfile[] = [
   {
+    // Steady, near-perfect and fast: an append-only log behaves nothing like the queues that
+    // retry, so the history charts have one flat line to compare the spiky ones against.
+    name: 'Compliance.AuditLog',
+    baseVolume: 5200,
+    failRate: 0.001,
+    runtimePeakBucket: 2,
+    waitPeakBucket: 1,
+    queueAgeBaselineMs: 800,
+  },
+  {
     name: 'Orders.Fulfillment',
     baseVolume: 1800,
     failRate: 0.04,
@@ -707,8 +717,16 @@ const run = async () => {
   const newRegistration = createQueueMQ('Notifications.User.NewRegistration', { attempts: 2 });
   const resetPassword = createQueueMQ('Notifications;User;ResetPassword', { attempts: 2 });
 
+  // Read-only on the board, so the difference between a queue you can act on and one you can
+  // only watch is visible. Its retention options give the info panel something to show too.
+  const auditLog = createQueueMQ('Compliance.AuditLog', {
+    attempts: 1,
+    removeOnComplete: { age: 604800, count: 5000 },
+    removeOnFail: false,
+  });
+
   const groupedQueues = groupedQueueDefs.map(([name, opts]) => createQueueMQ(name, opts));
-  const simQueues = [...groupedQueues, newRegistration, resetPassword];
+  const simQueues = [...groupedQueues, newRegistration, resetPassword, auditLog];
 
   simQueues.forEach((queue) => setupSimWorker(queue.name));
   await Promise.all(simQueues.map(seedQueue));
@@ -816,6 +834,12 @@ const run = async () => {
     new BullMQAdapter(ordersFulfillment, { delimiter: '.' }),
     ...groupedQueues.map((queue) => new BullMQAdapter(queue, { delimiter: '.' })),
     new BullMQAdapter(newRegistration, { delimiter: '.' }),
+    new BullMQAdapter(auditLog, {
+      delimiter: '.',
+      displayName: 'Audit log',
+      description: 'Append-only compliance trail. Read-only on the board.',
+      readOnlyMode: true,
+    }),
     new BullMQAdapter(resetPassword, {
       delimiter: ';',
       displayName: 'Reset Password',
@@ -840,6 +864,20 @@ const run = async () => {
       },
     }),
   ];
+
+  // Formatters run on the way out, so a queue whose payload carries a secret can still be
+  // inspected on the board without the secret being on the board.
+  const resetPasswordAdapter = bullMQAdapters.find(
+    (adapter) => adapter.getName() === resetPassword.name
+  )!;
+  resetPasswordAdapter.setFormatter('data', (data: Record<string, any>) => {
+    if (!data || typeof data !== 'object') return data;
+    const redacted: Record<string, any> = { ...data };
+    for (const key of Object.keys(redacted)) {
+      if (/token|secret|apikey|password/i.test(key)) redacted[key] = '***';
+    }
+    return redacted;
+  });
 
   await backfillDemoHistory(bullMQAdapters.map((adapter) => adapter.getName()));
 

--- a/website/demo/rsbuild.config.ts
+++ b/website/demo/rsbuild.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         // must match the provider wired up in src/mocks/handlers.ts.
         hasHistoryProvider: true,
         hasHistoryUsage: true,
+        hasLatencyHistory: true,
         canPurgeHistory: true,
       }),
     },

--- a/website/demo/src/mocks/MockAdapter.ts
+++ b/website/demo/src/mocks/MockAdapter.ts
@@ -8,6 +8,7 @@ import type {
   JobStatus,
   MetricsType,
   QueueJob,
+  QueueDefaultJobOptions,
   QueueJobOptions,
   QueueMetrics,
   QueueWorker,
@@ -47,7 +48,12 @@ export class MockAdapter extends BaseAdapter {
       description: mockQueue.description ?? '',
       displayName: mockQueue.displayName ?? '',
       delimiter: mockQueue.delimiter,
+      jobDataSchema: mockQueue.jobDataSchema,
     });
+  }
+
+  getQueueDefaultJobOptions(): QueueDefaultJobOptions {
+    return this.mockQueue.defaultJobOptions;
   }
 
   getName(): string {
@@ -222,22 +228,37 @@ export class MockAdapter extends BaseAdapter {
     this.mockQueue.globalConcurrency = concurrency;
   }
 
-  async removeJobScheduler(_id: string): Promise<boolean> {
-    return false;
+  async removeJobScheduler(id: string): Promise<boolean> {
+    const before = this.mockQueue.schedulers.length;
+    this.mockQueue.schedulers = this.mockQueue.schedulers.filter(
+      (scheduler) => scheduler.id !== id
+    );
+    return this.mockQueue.schedulers.length < before;
   }
 
   async getJobSchedulers(): Promise<Omit<AppJobScheduler, 'queueName'>[]> {
-    return [];
+    return this.mockQueue.schedulers;
   }
 
   async getJobSchedulersCount(): Promise<number> {
-    return 0;
+    return this.mockQueue.schedulers.length;
   }
 
   async updateJobScheduler(
-    _id: string,
-    _repeat: JobSchedulerRepeatOptions
+    id: string,
+    repeat: JobSchedulerRepeatOptions
   ): Promise<JobSchedulerUpdateResult> {
-    throw new Error('The demo has no schedulers to update');
+    const scheduler = this.mockQueue.schedulers.find((entry) => entry.id === id);
+    if (!scheduler) return 'not-found';
+    if (!repeat.pattern && !repeat.every) return 'invalid-schedule';
+
+    Object.assign(scheduler, {
+      pattern: repeat.pattern,
+      every: repeat.every,
+      tz: repeat.tz,
+      limit: repeat.limit,
+      endDate: repeat.endDate,
+    });
+    return 'updated';
   }
 }

--- a/website/demo/src/mocks/MockMetricsHistoryProvider.ts
+++ b/website/demo/src/mocks/MockMetricsHistoryProvider.ts
@@ -7,6 +7,8 @@ import type {
   MetricsHistoryQueueUsage,
   MetricsHistoryTierUsage,
   MetricsHistoryUsage,
+  MetricsLatencyPoint,
+  MetricsLatencyQuery,
   MetricsType,
 } from '@bull-board/api/typings/app';
 import { hashStr, mulberry32 } from './prng';
@@ -140,7 +142,11 @@ export class MockMetricsHistoryProvider implements MetricsHistoryProvider {
     to,
     granularity,
   }: MetricsHistoryQuery): Promise<MetricsHistoryPoint[]> {
-    const series = this.store.get(queue ?? GLOBAL_QUEUE)?.[metric];
+    // Only the two counter metrics are synthesised. Queue age is a gauge the recorder samples
+    // from a live queue, which the demo has no equivalent of, so it answers empty rather than
+    // inventing a shape the real provider would not produce.
+    const series =
+      metric === 'queueage' ? undefined : this.store.get(queue ?? GLOBAL_QUEUE)?.[metric];
     if (!series) {
       return [];
     }
@@ -162,6 +168,59 @@ export class MockMetricsHistoryProvider implements MetricsHistoryProvider {
       .filter(([, value]) => value > 0)
       .map(([ts, value]) => ({ ts, value }))
       .sort((a, b) => a.ts - b.ts);
+  }
+
+  /**
+   * Run time and wait time percentiles, so the queue view and the history page offer the
+   * Latency tab beside Throughput rather than hiding it. Shapes rather than samples: a
+   * log-normal-ish spread whose p99 pulls far above its p50, run time tracking the same
+   * daily curve as throughput and wait time spiking where the backlog would.
+   */
+  async getLatency({
+    queue,
+    metric,
+    from,
+    to,
+    granularity,
+    percentiles,
+  }: MetricsLatencyQuery): Promise<MetricsLatencyPoint[]> {
+    const seed = `${queue ?? GLOBAL_QUEUE}:${metric}`;
+    // Wait time is the slower, spikier of the two: a job waits behind the backlog, then runs.
+    const base = metric === 'waittime' ? 850 : 240;
+    const bucketMs = granularity === 'hour' ? HOUR_MS : DAY_MS;
+    const align = granularity === 'hour' ? alignHour : alignDay;
+
+    if (granularity === 'range') {
+      return [this.latencyPoint(align(from), seed, base, percentiles)];
+    }
+
+    const points: MetricsLatencyPoint[] = [];
+    for (let bucket = align(from); bucket <= to; bucket += bucketMs) {
+      points.push(this.latencyPoint(bucket, seed, base, percentiles));
+    }
+    return points;
+  }
+
+  private latencyPoint(
+    ts: number,
+    seed: string,
+    base: number,
+    percentiles: number[]
+  ): MetricsLatencyPoint {
+    const rand = mulberry32(hashStr(`${seed}:${ts}`));
+    const hourOfDay = new Date(ts).getUTCHours();
+    // Same afternoon peak the throughput curve has, so latency and volume tell one story.
+    const load = 1 + 0.45 * Math.sin(((hourOfDay - 4) / 24) * TAU);
+    const p50 = Math.round(base * load * (0.85 + rand() * 0.3));
+    const values: Record<string, number> = {};
+
+    for (const percentile of percentiles) {
+      // Percentiles fan out multiplicatively, the way a real latency distribution does.
+      const spread = Math.pow(1 + (percentile - 50) / 100, 2.4);
+      values[String(percentile)] = Math.round(p50 * Math.max(1, spread));
+    }
+
+    return { ts, count: 40 + Math.round(rand() * 260), values };
   }
 
   async getUsage(): Promise<MetricsHistoryUsage> {

--- a/website/demo/src/mocks/fixtures.ts
+++ b/website/demo/src/mocks/fixtures.ts
@@ -1,12 +1,7 @@
+import type { QueueDefaultJobOptions } from '@bull-board/api/typings/app';
 import { faker } from '@faker-js/faker';
 import { addMinutes, subMinutes, subSeconds } from 'date-fns';
-import {
-  DemoJob,
-  DemoQueue,
-  DemoState,
-  Status,
-  nextJobId,
-} from './state';
+import { DemoJob, DemoQueue, DemoState, Status, nextJobId } from './state';
 
 faker.seed(424242);
 
@@ -22,6 +17,10 @@ interface QueueSpec {
   globalConcurrency?: number | null;
   jobCount: number;
   jobNames: string[];
+  /** Shown in the queue info panel, and used as the starting point in the add-job form. */
+  defaultJobOptions?: QueueDefaultJobOptions;
+  /** JSON Schema the add-job form prefills, autocompletes and validates against. */
+  jobDataSchema?: Record<string, any>;
   buildData: () => Record<string, unknown>;
   // If set, each job gets an externalUrl produced from its data.
   externalUrl?: (data: Record<string, unknown>) => DemoJob['externalUrl'];
@@ -34,6 +33,28 @@ const queueSpecs: QueueSpec[] = [
     description: 'Triggered on signup completion — onboarding drip.',
     jobCount: 140,
     jobNames: ['send-welcome', 'send-verification', 'send-tips'],
+    // The one queue carrying a schema, so "Add job" shows the prefill, the autocomplete and
+    // the inline validation a schema buys you, while the rest show the plain editor.
+    jobDataSchema: {
+      type: 'object',
+      required: ['to', 'userId', 'template'],
+      properties: {
+        to: { type: 'string', format: 'email', description: 'Address the email is sent to.' },
+        userId: { type: 'string', description: 'Internal id of the signing-up user.' },
+        firstName: { type: 'string', description: 'Used in the greeting line.' },
+        template: {
+          type: 'string',
+          enum: ['welcome-v2', 'welcome-enterprise', 'welcome-free-tier'],
+          description: 'Which onboarding template to render.',
+        },
+        locale: {
+          type: 'string',
+          enum: ['en-US', 'fr-FR', 'de-DE', 'es-ES'],
+          description: 'BCP-47 locale for the email template.',
+        },
+      },
+      additionalProperties: false,
+    },
     buildData: () => ({
       to: faker.internet.email(),
       userId: faker.string.uuid(),
@@ -80,7 +101,8 @@ const queueSpecs: QueueSpec[] = [
   {
     name: 'billing:invoices',
     displayName: 'Invoices',
-    description: 'Scheduled every morning at 06:00 UTC. Read-only. Data formatter redacts API keys.',
+    description:
+      'Scheduled every morning at 06:00 UTC. Read-only. Data formatter redacts API keys.',
     readOnlyMode: true,
     jobCount: 95,
     jobNames: ['generate-invoice', 'send-invoice', 'charge-invoice'],
@@ -257,9 +279,7 @@ function pickState(isPaused: boolean): JobState {
   }
 
   const entries = Object.entries(stateWeights).filter(([, w]) => w > 0) as [JobState, number][];
-  return faker.helpers.weightedArrayElement(
-    entries.map(([value, weight]) => ({ value, weight }))
-  );
+  return faker.helpers.weightedArrayElement(entries.map(([value, weight]) => ({ value, weight })));
 }
 
 const ERROR_TYPES = [
@@ -369,8 +389,7 @@ function buildLogs(count: number): string[] {
 function buildRichLogs(): string[] {
   const start = faker.date.recent({ days: 1 });
   const lines: string[] = [];
-  const tick = (ms: number) =>
-    new Date(start.getTime() + ms).toISOString();
+  const tick = (ms: number) => new Date(start.getTime() + ms).toISOString();
   let t = 0;
   lines.push(`[${tick(t)}] INFO  Starting batch 1 of 50`);
   t += 333;
@@ -559,6 +578,16 @@ function buildQueue(spec: QueueSpec): DemoQueue {
       'paused',
     ],
     jobs,
+    schedulers: [],
+    // Every queue in a real deployment has these, even if only BullMQ's own defaults, so the
+    // info panel's Default job options section has something to show on any queue you open.
+    defaultJobOptions: spec.defaultJobOptions ?? {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+      removeOnComplete: { age: 86400, count: 1000 },
+      removeOnFail: { age: 604800 },
+    },
+    jobDataSchema: spec.jobDataSchema,
   };
 }
 
@@ -659,17 +688,10 @@ function seedCronJobs(state: DemoState): void {
       lastRunId: faker.string.alphanumeric(10),
       runCount: faker.number.int({ min: 1, max: 1500 }),
     };
-    const job = buildJob(
-      cron.name,
-      [def.name],
-      'delayed',
-      () => data
-    );
+    const job = buildJob(cron.name, [def.name], 'delayed', () => data);
     job.name = def.name;
     const repeat: Record<string, unknown> =
-      'pattern' in def
-        ? { pattern: def.pattern, tz: def.tz }
-        : { every: def.every };
+      'pattern' in def ? { pattern: def.pattern, tz: def.tz } : { every: def.every };
     const key =
       'pattern' in def
         ? `__default__:${def.name}:${def.pattern}:${def.tz ?? ''}`
@@ -685,6 +707,21 @@ function seedCronJobs(state: DemoState): void {
     job.finishedOn = null;
     job.timestamp = addMinutes(new Date(), -5).getTime();
     cron.jobs.unshift(job);
+
+    // The same definition, surfaced as a scheduler. Without this the Schedulers view has
+    // nothing to list and the sidebar never offers it, which is the one part of the board
+    // the demo could not show.
+    cron.schedulers.push({
+      id: def.name,
+      name: def.name,
+      ...('pattern' in def ? { pattern: def.pattern, tz: def.tz } : { every: def.every }),
+      next: Date.now() + def.nextInMs,
+      nextRunJobId: String(job.id),
+      lastRun: 'every' in def ? Date.now() + def.nextInMs - def.every! : undefined,
+      iterationCount: data.runCount,
+      template: { data, opts: { attempts: 3, backoff: { type: 'exponential', delay: 5000 } } },
+    });
+
     replaced++;
     if (replaced > scheduleDefs.length) break;
   }
@@ -696,9 +733,7 @@ function seedCronJobs(state: DemoState): void {
     const job = buildJob(cron.name, [def.name], 'completed', () => data);
     job.name = def.name;
     const repeat: Record<string, unknown> =
-      'pattern' in def
-        ? { pattern: def.pattern, tz: def.tz }
-        : { every: def.every };
+      'pattern' in def ? { pattern: def.pattern, tz: def.tz } : { every: def.every };
     job.opts = { ...job.opts, repeat };
     cron.jobs.unshift(job);
   }
@@ -707,11 +742,18 @@ function seedCronJobs(state: DemoState): void {
 // Attach richer multi-line logs to 5 active jobs spread across different queues
 // so the Logs tab has something meaty to show.
 function seedRichLogs(state: DemoState): void {
-  const targets = ['reports:export', 'billing:charges', 'emails:marketing', 'notifications:push', 'reports:nightly'];
+  const targets = [
+    'reports:export',
+    'billing:charges',
+    'emails:marketing',
+    'notifications:push',
+    'reports:nightly',
+  ];
   for (const qName of targets) {
     const q = state.queues.find((s) => s.name === qName);
     if (!q) continue;
-    const activeJob = q.jobs.find((j) => j.state === 'active') ?? q.jobs.find((j) => j.state === 'completed');
+    const activeJob =
+      q.jobs.find((j) => j.state === 'active') ?? q.jobs.find((j) => j.state === 'completed');
     if (activeJob) activeJob.logs = buildRichLogs();
   }
 }
@@ -726,4 +768,3 @@ export function seedFixtures(target: DemoState): void {
   buildFlows(target);
   seedRichLogs(target);
 }
-

--- a/website/demo/src/mocks/state.ts
+++ b/website/demo/src/mocks/state.ts
@@ -1,8 +1,18 @@
 // Reuse the real @bull-board/api types. If the API surface changes, the demo
 // fails to compile instead of silently drifting from production shapes.
-import type { AppJob, AppQueue, JobCounts, Status } from '@bull-board/api/typings/app';
+import type {
+  AppJob,
+  AppJobScheduler,
+  AppQueue,
+  JobCounts,
+  QueueDefaultJobOptions,
+  Status,
+} from '@bull-board/api/typings/app';
 
 export type { AppJob, JobCounts, Status };
+
+/** A scheduler as the adapter hands it back: the queue is implied by the queue it hangs off. */
+export type DemoScheduler = Omit<AppJobScheduler, 'queueName'>;
 
 export type JobState = Exclude<Status, 'latest'>;
 
@@ -14,11 +24,20 @@ export interface DemoJob extends AppJob {
   childRefs?: Array<{ queueName: string; jobId: string }>;
 }
 
-// Demo-side shape of a queue: the same fields the UI reads off `AppQueue`,
-// minus the server-computed `counts`/`pagination` (derived at read time) and
-// with `jobs` typed as `DemoJob` so state.ts handlers can mutate them.
-export type DemoQueue = Omit<AppQueue, 'counts' | 'pagination' | 'jobs'> & {
+// Demo-side shape of a queue: the same fields the UI reads off `AppQueue`, minus everything
+// the queues handler derives per request (`counts`, `pagination`, and the `jobSchedulerCount`
+// and `hasWorkers` it asks the adapter for), and with `jobs` typed as `DemoJob` so state.ts
+// handlers can mutate them.
+export type DemoQueue = Omit<
+  AppQueue,
+  'counts' | 'pagination' | 'jobs' | 'jobSchedulerCount' | 'hasWorkers'
+> & {
   jobs: DemoJob[];
+  schedulers: DemoScheduler[];
+  /** Served by the default-job-options endpoint, and shown in the queue info panel. */
+  defaultJobOptions: QueueDefaultJobOptions;
+  /** JSON Schema for the add-job form: prefill, autocomplete and inline validation. */
+  jobDataSchema?: Record<string, any>;
 };
 
 export interface DemoState {


### PR DESCRIPTION
## Problem

The live demo cannot show several things the docs describe.

`getJobSchedulers()` returns `[]` and `getJobSchedulersCount()` returns `0`, so the Schedulers entry never appears in the sidebar. That is on a demo which ships a queue called `scheduled:cron`, described as "Repeatable jobs: cron patterns and fixed intervals", and which already builds eight schedule definitions in `seedCronJobs` and uses them only to shape delayed jobs.

`getQueueDefaultJobOptions()` is the base `{}`, so the queue info panel's Default job options section is always empty. No queue carries a `jobDataSchema`, so Add job never shows the prefill, the autocomplete or the validation. And the history provider has no `getLatency`, which is what gates the Throughput/Latency tabs, so the latency chart cannot be reached anywhere in the demo.

`website/demo` also does not typecheck. `DemoQueue` is missing `jobSchedulerCount` and `hasWorkers`, and the history provider indexes its series map with `'queueage'`, which does not exist on it.

## The fix

Schedulers come from the eight definitions `seedCronJobs` already has, surfaced through the adapter. `removeJobScheduler` and `updateJobScheduler` now act on the mock instead of returning `false` and throwing.

Default job options per queue, so the info panel section renders on any queue you open. A `jobDataSchema` on `emails:welcome` alone, so Add job shows what a schema buys you there and the plain editor everywhere else.

`getLatency` synthesises run and wait percentiles. Shapes rather than samples: a spread whose p99 pulls well above its p50, run time on the same daily curve as throughput, wait time spikier because a job waits behind the backlog before it runs. The static uiConfig in `rsbuild.config.ts` gains `hasLatencyHistory`, since the demo serves that file rather than deriving the flags from a provider.

For the typecheck, the queues handler derives `jobSchedulerCount` and `hasWorkers` from the adapter on every request, so the fix is to omit them from `DemoQueue` rather than store them. Queue age is a gauge the recorder samples from a live queue, which the demo has no equivalent of, so `getHistory` says so explicitly instead of indexing a map that has no such key.

## example.ts

The local dev board got the same look over. It already had schedulers, flows, a job data schema, external job URLs and latency backfill, and was missing three things: a read-only queue, a formatter, and a queue whose retention options are worth showing.

`Compliance.AuditLog` covers all three. Read-only on the board, so the difference between a queue you can act on and one you can only watch is visible. Retention options on the queue itself, so the info panel has something to show. And Reset Password gains a `setFormatter('data')` that redacts anything key-shaped, which is the seam the formatters recipe documents and nothing in the example exercised.

It also gets a history profile, so it is not the one queue missing from the metrics charts.

## Testing

`tsc --noEmit` on the demo is clean, which it was not before. The demo and docs site both build. `example.ts` boots and serves the board, with the new queue seeded and processing.

Nothing here ships: `@bull-board/demo` is private, and `example.ts` is a dev entry point.
