### PR TITLE
feat(ui): finish the Base UI component migration

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,22 +1,21 @@
+import { Button as BaseButton, type ButtonProps as BaseButtonProps } from '@base-ui/react/button';
 import cn from 'clsx';
 import React from 'react';
 import s from './Button.module.css';
 
-interface ButtonProps extends React.DetailedHTMLProps<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
-> {
+interface ButtonProps extends Omit<BaseButtonProps, 'className'> {
+  className?: string;
   isActive?: boolean;
   theme?: 'basic' | 'primary' | 'default';
   compact?: boolean;
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = React.forwardRef<HTMLElement, ButtonProps>(
   (
     { children, className, isActive = false, theme = 'default', compact, ...rest }: ButtonProps,
     forwardedRef
   ) => (
-    <button
+    <BaseButton
       type="button"
       ref={forwardedRef}
       {...rest}
@@ -26,6 +25,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       })}
     >
       {children}
-    </button>
+    </BaseButton>
   )
 );

--- a/packages/ui/src/components/Form/CheckboxField/CheckboxField.tsx
+++ b/packages/ui/src/components/Form/CheckboxField/CheckboxField.tsx
@@ -10,7 +10,7 @@ interface CheckboxFieldProps extends CheckboxRootProps {
 }
 
 export const CheckboxField = ({ label, id, description, ...checkboxProps }: CheckboxFieldProps) => (
-  <Field label={label} id={id} inline={true} description={description}>
+  <Field label={label} inline={true} description={description}>
     <Checkbox.Root id={id} {...checkboxProps} className={s.checkbox}>
       <Checkbox.Indicator className={s.indicator}>
         <CheckIcon />

--- a/packages/ui/src/components/Form/Field/Field.module.css
+++ b/packages/ui/src/components/Form/Field/Field.module.css
@@ -25,6 +25,7 @@
 
 .description {
   display: block;
+  margin: 0;
   flex-basis: 100%;
   margin-top: 0.15rem;
   font-size: 0.8rem;

--- a/packages/ui/src/components/Form/Field/Field.tsx
+++ b/packages/ui/src/components/Form/Field/Field.tsx
@@ -1,25 +1,25 @@
+import { Field as BaseField } from '@base-ui/react/field';
 import cn from 'clsx';
 import { PropsWithChildren } from 'react';
 import s from './Field.module.css';
 
 interface FieldProps {
   label?: string;
-  id?: string;
   inline?: boolean;
   description?: string;
 }
 
-export const Field = ({
-  label,
-  id,
-  inline,
-  description,
-  children,
-}: PropsWithChildren<FieldProps>) => (
-  <div className={cn(s.field, { [s.inline]: inline })}>
-    {!!label && !inline && <label htmlFor={id}>{label}</label>}
-    {children}
-    {!!label && inline && <label htmlFor={id}>{label}</label>}
-    {!!description && <span className={s.description}>{description}</span>}
-  </div>
-);
+export const Field = ({ label, inline, description, children }: PropsWithChildren<FieldProps>) => {
+  const labelElement = !!label && <BaseField.Label>{label}</BaseField.Label>;
+
+  return (
+    <BaseField.Root className={cn(s.field, { [s.inline]: inline })}>
+      {!inline && labelElement}
+      {children}
+      {inline && labelElement}
+      {!!description && (
+        <BaseField.Description className={s.description}>{description}</BaseField.Description>
+      )}
+    </BaseField.Root>
+  );
+};

--- a/packages/ui/src/components/Form/InputField/InputField.tsx
+++ b/packages/ui/src/components/Form/InputField/InputField.tsx
@@ -1,3 +1,4 @@
+import { Field as BaseField } from '@base-ui/react/field';
 import { InputHTMLAttributes } from 'react';
 import { Field } from '../Field/Field';
 
@@ -6,7 +7,7 @@ interface InputFieldProps extends InputHTMLAttributes<any> {
 }
 
 export const InputField = ({ label, id, ...inputProps }: InputFieldProps) => (
-  <Field label={label} id={id}>
-    <input id={id} type="text" {...inputProps} />
+  <Field label={label}>
+    <BaseField.Control id={id} type="text" {...inputProps} />
   </Field>
 );

--- a/packages/ui/src/components/Form/JsonField/JsonField.tsx
+++ b/packages/ui/src/components/Form/JsonField/JsonField.tsx
@@ -8,7 +8,7 @@ interface JsonFieldProps extends Omit<HTMLProps<HTMLInputElement>, 'value' | 're
 }
 
 export const JsonField = ({ label, id, value, ...rest }: JsonFieldProps) => (
-  <Field label={label} id={id}>
+  <Field label={label}>
     <JsonEditor doc={value || {}} id={id} {...rest} />
   </Field>
 );

--- a/packages/ui/src/components/Form/SelectField/SelectField.tsx
+++ b/packages/ui/src/components/Form/SelectField/SelectField.tsx
@@ -39,7 +39,7 @@ export const SelectField = ({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
 }: SelectFieldProps) => (
-  <Field label={label} id={id}>
+  <Field label={label}>
     <Select.Root
       id={id}
       name={name}

--- a/packages/ui/src/components/Form/SwitchField/SwitchField.tsx
+++ b/packages/ui/src/components/Form/SwitchField/SwitchField.tsx
@@ -9,7 +9,7 @@ interface SwitchFieldProps extends SwitchRootProps {
 }
 
 export const SwitchField = ({ label, id, description, ...switchProps }: SwitchFieldProps) => (
-  <Field label={label} id={id} inline={true} description={description}>
+  <Field label={label} inline={true} description={description}>
     <Switch.Root id={id} {...switchProps} className={s.switch}>
       <Switch.Thumb className={s.thumb} />
     </Switch.Root>

--- a/packages/ui/src/components/JobCard/Details/Details.module.css
+++ b/packages/ui/src/components/JobCard/Details/Details.module.css
@@ -5,8 +5,6 @@
 }
 
 .tabActions {
-  list-style: none;
-  padding: 0;
   margin: var(--card-padding) 0;
   display: flex;
   gap: 0.5rem;

--- a/packages/ui/src/components/JobCard/Details/Details.tsx
+++ b/packages/ui/src/components/JobCard/Details/Details.tsx
@@ -1,6 +1,7 @@
+import { Tabs } from '@base-ui/react/tabs';
 import type { AppJob, Status } from '@bull-board/api/typings/app';
 import { useTranslation } from 'react-i18next';
-import { useDetailsTabs } from '../../../hooks/useDetailsTabs';
+import { TabsType, useDetailsTabs } from '../../../hooks/useDetailsTabs';
 import { dynamicTranslationKey } from '../../../utils/dynamicTranslationKey';
 import { Button } from '../../Button/Button';
 import { DetailsContent } from './DetailsContent/DetailsContent';
@@ -14,7 +15,7 @@ interface DetailsProps {
 }
 
 export const Details = ({ status, job, actions, withTimeline = false }: DetailsProps) => {
-  const { tabs, selectedTab } = useDetailsTabs({ currentStatus: status, withTimeline });
+  const { tabs, selectedTab, selectTab } = useDetailsTabs({ currentStatus: status, withTimeline });
   const { t } = useTranslation();
 
   if (tabs.length === 0) {
@@ -22,19 +23,23 @@ export const Details = ({ status, job, actions, withTimeline = false }: DetailsP
   }
 
   return (
-    <div className={s.details}>
-      <ul className={s.tabActions}>
+    <Tabs.Root
+      className={s.details}
+      value={selectedTab}
+      onValueChange={(value) => selectTab(value as TabsType)}
+    >
+      <Tabs.List className={s.tabActions}>
         {tabs.map((tab) => (
-          <li key={tab.title}>
-            <Button onClick={tab.selectTab} isActive={tab.isActive}>
-              {t(dynamicTranslationKey(`JOB.TABS.${tab.title.toUpperCase()}`))}
-            </Button>
-          </li>
+          <Tabs.Tab key={tab} value={tab} render={<Button isActive={tab === selectedTab} />}>
+            {t(dynamicTranslationKey(`JOB.TABS.${tab.toUpperCase()}`))}
+          </Tabs.Tab>
         ))}
-      </ul>
-      <div className={s.tabContent}>
-        <DetailsContent selectedTab={selectedTab} job={job} actions={actions} status={status} />
-      </div>
-    </div>
+      </Tabs.List>
+      {tabs.map((tab) => (
+        <Tabs.Panel key={tab} value={tab} className={s.tabContent}>
+          <DetailsContent selectedTab={tab} job={job} actions={actions} status={status} />
+        </Tabs.Panel>
+      ))}
+    </Tabs.Root>
   );
 };

--- a/packages/ui/src/components/JobCard/Progress/Progress.module.css
+++ b/packages/ui/src/components/JobCard/Progress/Progress.module.css
@@ -3,6 +3,10 @@
   height: 80px;
 }
 
+.progress svg {
+  display: block;
+}
+
 .progress circle {
   transition: stroke-dashoffset 500ms ease-in-out;
   fill: none;

--- a/packages/ui/src/components/JobCard/Progress/Progress.tsx
+++ b/packages/ui/src/components/JobCard/Progress/Progress.tsx
@@ -1,3 +1,4 @@
+import { Progress as BaseProgress } from '@base-ui/react/progress';
 import { STATUSES } from '@bull-board/api/constants/statuses';
 import type { Status } from '@bull-board/api/typings/app';
 import cn from 'clsx';
@@ -44,24 +45,26 @@ export const Progress = ({ progress, status, className, strokeWidth = 6 }: Progr
   };
 
   return (
-    <svg className={cn(s.progress, className)} width="100%" height="100%">
-      <circle {...commonProps} />
-      <circle
-        className={cn({
-          [s.failed]: status === STATUSES.failed,
-          [s.success]: status !== STATUSES.failed,
-        })}
-        pathLength={100}
-        strokeDasharray={100}
-        strokeDashoffset={100 - percentage}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        transform="rotate(-90)"
-        {...commonProps}
-      />
-      <text x="50%" y="50%" textAnchor="middle" dominantBaseline="central">
-        <tspan dominantBaseline="central">{`${Math.round(percentage)}%`}</tspan>
-      </text>
-    </svg>
+    <BaseProgress.Root className={cn(s.progress, className)} value={percentage}>
+      <svg width="100%" height="100%">
+        <circle {...commonProps} />
+        <circle
+          className={cn({
+            [s.failed]: status === STATUSES.failed,
+            [s.success]: status !== STATUSES.failed,
+          })}
+          pathLength={100}
+          strokeDasharray={100}
+          strokeDashoffset={100 - percentage}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          transform="rotate(-90)"
+          {...commonProps}
+        />
+        <text x="50%" y="50%" textAnchor="middle" dominantBaseline="central">
+          <tspan dominantBaseline="central">{`${Math.round(percentage)}%`}</tspan>
+        </text>
+      </svg>
+    </BaseProgress.Root>
   );
 };

--- a/packages/ui/src/components/RangeSelector/RangeSelector.module.css
+++ b/packages/ui/src/components/RangeSelector/RangeSelector.module.css
@@ -6,8 +6,7 @@
   background-color: var(--background);
 }
 
-.rangeButton,
-.rangeButtonActive {
+.rangeButton {
   border: none;
   background: none;
   cursor: pointer;
@@ -21,7 +20,7 @@
     opacity 0.15s ease;
 }
 
-.rangeButton {
+.rangeButton:not([data-pressed]) {
   opacity: 0.55;
 }
 
@@ -33,12 +32,12 @@
   background-color: var(--state-hover);
 }
 
-.rangeButtonActive {
+.rangeButton[data-pressed] {
   opacity: 1;
   background-color: var(--state-selected);
   color: var(--state-selected-foreground);
 }
 
-.rangeButtonActive:hover {
+.rangeButton[data-pressed]:hover {
   background-color: var(--state-selected-hover);
 }

--- a/packages/ui/src/components/RangeSelector/RangeSelector.tsx
+++ b/packages/ui/src/components/RangeSelector/RangeSelector.tsx
@@ -1,3 +1,5 @@
+import { Toggle } from '@base-ui/react/toggle';
+import { ToggleGroup } from '@base-ui/react/toggle-group';
 import cn from 'clsx';
 import s from './RangeSelector.module.css';
 
@@ -16,18 +18,20 @@ export const RangeSelector = <T extends string>({
   getLabel,
   className,
 }: RangeSelectorProps<T>) => (
-  <div className={cn(s.rangeSelector, className)} role="tablist">
+  <ToggleGroup
+    className={cn(s.rangeSelector, className)}
+    value={[value]}
+    onValueChange={(pressed) => {
+      const [next] = pressed;
+      if (next) {
+        onChange(next as T);
+      }
+    }}
+  >
     {ranges.map((range) => (
-      <button
-        key={range}
-        type="button"
-        role="tab"
-        aria-selected={value === range}
-        className={value === range ? s.rangeButtonActive : s.rangeButton}
-        onClick={() => onChange(range)}
-      >
+      <Toggle key={range} value={range} className={s.rangeButton}>
         {getLabel(range)}
-      </button>
+      </Toggle>
     ))}
-  </div>
+  </ToggleGroup>
 );

--- a/packages/ui/src/hooks/useDetailsTabs.tsx
+++ b/packages/ui/src/hooks/useDetailsTabs.tsx
@@ -1,6 +1,6 @@
 import { STATUSES } from '@bull-board/api/constants/statuses';
 import type { JobDetailsTab, Status } from '@bull-board/api/typings/app';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSettingsStore } from './useSettings';
 import { useUIConfig } from './useUIConfig';
 
@@ -35,42 +35,30 @@ export function resolveSelectedTab(
   return tabs[0];
 }
 
+function buildTabs(currentStatus: Status, withTimeline: boolean): TabsType[] {
+  const base = availableJobTabs.filter((tab) => tab !== 'Error' && tab !== 'Timeline');
+  const tabs: TabsType[] =
+    currentStatus === STATUSES.failed ? ['Error', ...base] : [...base, 'Error'];
+
+  return withTimeline ? [...tabs, 'Timeline'] : tabs;
+}
+
 export function useDetailsTabs(params: { currentStatus: Status; withTimeline: boolean }) {
-  const [tabs, updateTabs] = useState<TabsType[]>([]);
   const { defaultJobTab } = useSettingsStore();
   const configuredDefault = useUIConfig()?.jobDetails?.defaultTab;
 
-  const [selectedTab, setSelectedTab] = useState<TabsType>(
-    resolveSelectedTab(tabs, defaultJobTab, configuredDefault)
+  const tabs = useMemo(
+    () => buildTabs(params.currentStatus, params.withTimeline),
+    [params.currentStatus, params.withTimeline]
   );
 
-  useEffect(() => {
-    let nextTabs: TabsType[] = availableJobTabs.filter(
-      (tab) => tab !== 'Error' && tab !== 'Timeline'
-    );
-    if (params.currentStatus === STATUSES.failed) {
-      nextTabs = ['Error', ...nextTabs];
-    } else {
-      nextTabs = [...nextTabs, 'Error'];
-    }
-
-    if (params.withTimeline) {
-      nextTabs.push('Timeline');
-    }
-
-    updateTabs(nextTabs);
-  }, [params.currentStatus, params.withTimeline]);
+  const [selectedTab, setSelectedTab] = useState<TabsType>(() =>
+    resolveSelectedTab(tabs, defaultJobTab, configuredDefault)
+  );
 
   useEffect(() => {
     setSelectedTab(resolveSelectedTab(tabs, defaultJobTab, configuredDefault));
   }, [defaultJobTab, configuredDefault, tabs]);
 
-  return {
-    tabs: tabs?.map((title) => ({
-      title,
-      isActive: title === selectedTab,
-      selectTab: () => setSelectedTab(title),
-    })),
-    selectedTab,
-  };
+  return { tabs, selectedTab, selectTab: setSelectedTab };
 }

--- a/packages/ui/tests/components/JobDetailsTabs.spec.tsx
+++ b/packages/ui/tests/components/JobDetailsTabs.spec.tsx
@@ -1,0 +1,92 @@
+import type { AppJob, Status } from '@bull-board/api/typings/app';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Details } from '../../src/components/JobCard/Details/Details';
+import { useSettingsStore } from '../../src/hooks/useSettings';
+import { createWrapper, render } from '../testUtils';
+
+// The real module spins up a web worker through `import.meta.url`, which Jest cannot parse.
+jest.mock('../../src/utils/highlight/highlight', () => ({
+  asyncHighlight: (code: string) => Promise.resolve(code),
+}));
+
+const job = {
+  id: '1',
+  name: 'process',
+  data: { hello: 'world' },
+  returnValue: null,
+  opts: { attempts: 3 },
+  progress: 0,
+  stacktrace: [],
+  failedReason: '',
+} as unknown as AppJob;
+
+function renderDetails(status: Status = 'completed') {
+  const { Wrapper } = createWrapper({ api: {} });
+  return render(
+    <Details status={status} job={job} actions={{ getJobLogs: () => Promise.resolve([]) }} />,
+    { wrapper: Wrapper }
+  );
+}
+
+beforeEach(() => {
+  useSettingsStore.setState({ collapseJobData: false, useCollapsibleJson: false });
+});
+
+it('exposes the tab strip as a tablist with a single selected tab', () => {
+  renderDetails();
+
+  const tabs = screen.getAllByRole('tab');
+
+  expect(screen.getByRole('tablist')).toBeTruthy();
+  expect(tabs.map((tab) => tab.textContent)).toEqual([
+    'JOB.TABS.DATA',
+    'JOB.TABS.PROGRESS',
+    'JOB.TABS.OPTIONS',
+    'JOB.TABS.LOGS',
+    'JOB.TABS.ERROR',
+  ]);
+  expect(tabs.filter((tab) => tab.getAttribute('aria-selected') === 'true')).toHaveLength(1);
+});
+
+it('links the visible panel back to the tab that opened it', () => {
+  renderDetails();
+
+  const panel = screen.getByRole('tabpanel');
+  const selectedTab = screen.getByRole('tab', { selected: true });
+
+  expect(panel.getAttribute('aria-labelledby')).toBe(selectedTab.getAttribute('id'));
+  expect(selectedTab.getAttribute('aria-controls')).toBe(panel.getAttribute('id'));
+});
+
+it('moves between tabs with the arrow keys', async () => {
+  const user = userEvent.setup();
+  renderDetails();
+
+  await user.tab();
+  await user.keyboard('{ArrowRight}{Enter}');
+
+  await waitFor(() =>
+    expect(screen.getByRole('tab', { selected: true }).textContent).toBe('JOB.TABS.PROGRESS')
+  );
+  expect(screen.getByText('JOB.NO_PROGRESS')).toBeTruthy();
+});
+
+it('keeps only the selected tab panel mounted', async () => {
+  const user = userEvent.setup();
+  renderDetails();
+
+  expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+
+  await user.click(screen.getByRole('tab', { name: 'JOB.TABS.OPTIONS' }));
+
+  await waitFor(() => expect(screen.getByText(/attempts/)).toBeTruthy());
+  expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+});
+
+it('opens a failed job on its error tab', () => {
+  renderDetails('failed');
+
+  expect(screen.getByRole('tab', { selected: true }).textContent).toBe('JOB.TABS.ERROR');
+  expect(screen.getAllByRole('tab')[0].textContent).toBe('JOB.TABS.ERROR');
+});

--- a/packages/ui/tests/components/JobProgress.spec.tsx
+++ b/packages/ui/tests/components/JobProgress.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { Progress } from '../../src/components/JobCard/Progress/Progress';
+
+it('reports the completion percentage to assistive technology', () => {
+  render(<Progress progress={42} status="active" />);
+
+  const progressbar = screen.getByRole('progressbar');
+
+  expect(progressbar.getAttribute('aria-valuenow')).toBe('42');
+  expect(progressbar.getAttribute('aria-valuemin')).toBe('0');
+  expect(progressbar.getAttribute('aria-valuemax')).toBe('100');
+});
+
+it('reads the percentage out of the object form of progress', () => {
+  render(<Progress progress={{ progress: 70, note: 'resizing' }} status="active" />);
+
+  expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('70');
+});
+
+it('renders nothing when the job reports no progress', () => {
+  const { container } = render(<Progress progress={null} status="active" />);
+
+  expect(container.firstChild).toBeNull();
+});

--- a/packages/ui/tests/components/QueueMetrics.spec.tsx
+++ b/packages/ui/tests/components/QueueMetrics.spec.tsx
@@ -2,7 +2,7 @@ import type {
   GetMetricsHistoryResponse,
   GetQueueMetricsResponse,
 } from '@bull-board/api/typings/responses';
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { QueueMetrics } from '../../src/components/QueueMetrics/QueueMetrics';
 import { useSettingsStore } from '../../src/hooks/useSettings';
 import { createWrapper, deferred, makeQueue, render } from '../testUtils';
@@ -49,7 +49,7 @@ it('collapse toggle persists to settings and hides the chart/summary/range-selec
   expect(toggle.getAttribute('aria-expanded')).toBe('true');
   // Expanded: legend, range selector, and native summary stats are present.
   expect(screen.getByText('METRICS.COMPLETED')).toBeTruthy();
-  expect(screen.getByRole('tablist')).toBeTruthy();
+  expect(screen.getByRole('group')).toBeTruthy();
   expect(screen.getByText('METRICS.COMPLETED_PER_MIN')).toBeTruthy();
 
   fireEvent.click(toggle);
@@ -57,28 +57,29 @@ it('collapse toggle persists to settings and hides the chart/summary/range-selec
   expect(useSettingsStore.getState().collapseMetrics).toBe(true);
   expect(toggle.getAttribute('aria-expanded')).toBe('false');
   expect(screen.queryByText('METRICS.COMPLETED')).toBeNull();
-  expect(screen.queryByRole('tablist')).toBeNull();
+  expect(screen.queryByRole('group')).toBeNull();
   expect(screen.queryByText('METRICS.COMPLETED_PER_MIN')).toBeNull();
 });
 
-it('hides the range-selector tablist when hasHistoryProvider is false', async () => {
+it('hides the range selector when hasHistoryProvider is false', async () => {
   const getMetrics = jest.fn(() => Promise.resolve(withMetrics()));
 
   renderQueueMetrics(getMetrics, undefined, false);
 
   await screen.findByRole('button', { name: 'METRICS.TITLE' });
-  expect(screen.queryByRole('tablist')).toBeNull();
+  expect(screen.queryByRole('group')).toBeNull();
 });
 
-it('shows the range-selector tablist with all four range tabs when hasHistoryProvider is true', async () => {
+it('shows the range selector with all four ranges when hasHistoryProvider is true', async () => {
   const getMetrics = jest.fn(() => Promise.resolve(withMetrics()));
 
   renderQueueMetrics(getMetrics, undefined, true);
 
-  const tablist = await screen.findByRole('tablist');
-  const tabs = screen.getAllByRole('tab');
-  expect(tabs).toHaveLength(4);
-  expect(tablist).toBeTruthy();
+  const group = await screen.findByRole('group');
+  expect(within(group).getAllByRole('button')).toHaveLength(4);
+  expect(within(group).getByRole('button', { pressed: true }).textContent).toBe(
+    'METRICS.RANGE_60M'
+  );
   expect(screen.getByText('METRICS.RANGE_60M')).toBeTruthy();
   expect(screen.getByText('METRICS.RANGE_7D')).toBeTruthy();
   expect(screen.getByText('METRICS.RANGE_30D')).toBeTruthy();
@@ -92,7 +93,7 @@ it('switches from native to history metrics and calls getHistoryMetrics with the
 
   const { queue } = renderQueueMetrics(getMetrics, getHistoryMetrics, true);
 
-  await screen.findByRole('tablist');
+  await screen.findByRole('group');
   expect(getHistoryMetrics).not.toHaveBeenCalled();
 
   fireEvent.click(screen.getByText('METRICS.RANGE_7D'));
@@ -124,7 +125,7 @@ it('shows the bare empty state when there is no data and no history provider', a
   renderQueueMetrics(getMetrics, undefined, false);
 
   await waitFor(() => expect(screen.getByText('METRICS.EMPTY')).toBeTruthy());
-  expect(screen.queryByRole('tablist')).toBeNull();
+  expect(screen.queryByRole('group')).toBeNull();
 });
 
 it('shows the history-empty state when the history query resolves with no points', async () => {
@@ -133,7 +134,7 @@ it('shows the history-empty state when the history query resolves with no points
 
   renderQueueMetrics(getMetrics, getHistoryMetrics, true);
 
-  await screen.findByRole('tablist');
+  await screen.findByRole('group');
   fireEvent.click(screen.getByText('METRICS.RANGE_7D'));
 
   await waitFor(() => expect(screen.getByText('METRICS.HISTORY_EMPTY')).toBeTruthy());
@@ -150,8 +151,8 @@ describe('empty native buffer with recorded history', () => {
 
     renderQueueMetrics(getMetrics, undefined, true);
 
-    await screen.findByRole('tablist');
-    expect(screen.getAllByRole('tab')).toHaveLength(4);
+    const group = await screen.findByRole('group');
+    expect(within(group).getAllByRole('button')).toHaveLength(4);
     // 60m is still the selected range, and it has genuinely nothing to show.
     await waitFor(() => expect(screen.getByText('METRICS.EMPTY')).toBeTruthy());
   });


### PR DESCRIPTION
Finishes step 3 of #1293. Master already ran Dialog, Menu, Select, Switch, Checkbox, Collapsible,
Tooltip and Toast on Base UI; this is the rest of the list. Five commits, one component each.

- **Button** onto `@base-ui/react/button`. Same props, same classes, plus the `render` prop the
  tab strip below needs.
- **Job detail tabs** onto `Tabs`. They were a `<ul>` of buttons: no tab roles, no
  `aria-selected`, no arrow keys, no link from the panel back to its tab. Each tab is still the
  same `Button`, passed through `Tabs.Tab`'s `render`.
- **Metrics range control** onto `ToggleGroup`. It claimed `role="tablist"` with no tab panels
  behind it, and in 60m mode there is no latency panel to point at, so it is a segmented
  single-select rather than tabs. Gains roving tabindex and arrow keys.
- **Form fields** onto `Field`, which replaces the `htmlFor` we threaded by hand with Base UI's
  own label wiring, so every control now resolves to its label.
- **Job progress ring** wrapped in `Progress.Root`, so it reports `role="progressbar"` with
  `aria-valuenow` instead of only rendering the percentage as text.

Making the tabs controlled surfaced a bug in `useDetailsTabs`: the list was built in an effect
starting from `[]`, so `selectedTab` was `undefined` on the first render. It is a pure function of
job status and timeline visibility, so it is derived during render now.

Left alone on purpose: `StatusTabs` (NavLinks driving the URL, so Tabs is the wrong primitive),
`SidebarToggle` (a disclosure with `aria-expanded`, which `aria-pressed` would fight), and
`Pagination` (no Base UI equivalent).

Nothing changes visually. Tabs, both metrics controls and the progress ring:

![Queue page](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-base-ui-migration/queue-page.png)

Form fields:

![Settings form fields](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-base-ui-migration/form-fields.png)

260 tests across 41 suites, typecheck, oxlint and oxfmt green. New specs cover the tab roles,
panel wiring, arrow keys and the progressbar values, and both fail against the pre-migration
components.
