### PR TITLE
fix(ui): move the schedulers link into the queue tab row

### DIFF
--- a/packages/ui/src/components/Icons/Schedulers.tsx
+++ b/packages/ui/src/components/Icons/Schedulers.tsx
@@ -1,0 +1,4 @@
+import { CalendarClock } from 'lucide-react';
+import { createIcon } from './createIcon';
+
+export const SchedulersIcon = createIcon(CalendarClock);

--- a/packages/ui/src/components/StatusTabs/StatusTabs.module.css
+++ b/packages/ui/src/components/StatusTabs/StatusTabs.module.css
@@ -134,6 +134,9 @@
 }
 
 .trailing {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
   flex-shrink: 0;
   margin-left: auto;
   padding-left: 0.5rem;

--- a/packages/ui/src/pages/QueuePage/QueuePage.module.css
+++ b/packages/ui/src/pages/QueuePage/QueuePage.module.css
@@ -1,12 +1,47 @@
 .schedulersLink {
-  align-self: center;
-  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
   color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.5;
   text-decoration: none;
   white-space: nowrap;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease;
 }
 
-.schedulersLink:hover {
+.schedulersLink:hover,
+.schedulersLink:focus-visible {
+  background-color: var(--state-hover);
   color: var(--foreground);
-  text-decoration: underline;
+}
+
+.schedulersLink svg {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
+
+.schedulersCount {
+  background-color: var(--muted);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  padding: 0.25em 0.5em;
+  line-height: 1;
+  border-radius: 500rem;
+}
+
+@media (max-width: 768px) {
+  .schedulersLabel {
+    display: none;
+  }
+
+  .schedulersLink {
+    min-height: 2.25rem;
+    padding: 0 0.5rem;
+  }
 }

--- a/packages/ui/src/pages/QueuePage/QueuePage.tsx
+++ b/packages/ui/src/pages/QueuePage/QueuePage.tsx
@@ -3,6 +3,7 @@ import type { AppJob } from '@bull-board/api/typings/app';
 import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { SchedulersIcon } from '../../components/Icons/Schedulers';
 import { JobCard } from '../../components/JobCard/JobCard';
 import { Loader } from '../../components/Loader/Loader';
 import { Pagination } from '../../components/Pagination/Pagination';
@@ -69,14 +70,6 @@ export const QueuePage = () => {
       <StickyHeader
         actions={
           <>
-            {schedulerCount > 0 && (
-              <Link
-                className={s.schedulersLink}
-                to={links.jobSchedulers({ queueName: queue.name })}
-              >
-                {t('QUEUE.SCHEDULERS_LINK', { count: schedulerCount })}
-              </Link>
-            )}
             {queue.jobs.length > 0 && !queue.readOnlyMode && (
               <QueueActions
                 queue={queue}
@@ -94,6 +87,17 @@ export const QueuePage = () => {
         }
       >
         <StatusMenu queue={queue}>
+          {schedulerCount > 0 && (
+            <Link
+              className={s.schedulersLink}
+              to={links.jobSchedulers({ queueName: queue.name })}
+              aria-label={t('QUEUE.SCHEDULERS_LINK', { count: schedulerCount })}
+            >
+              <SchedulersIcon />
+              <span className={s.schedulersLabel}>{t('SCHEDULERS.TITLE')}</span>
+              <span className={s.schedulersCount}>{schedulerCount}</span>
+            </Link>
+          )}
           <WorkersBadge queue={queue} />
           {!queue.readOnlyMode && (
             <QueueDropdownActions

--- a/packages/ui/tests/pages/QueuePage.spec.tsx
+++ b/packages/ui/tests/pages/QueuePage.spec.tsx
@@ -1,0 +1,44 @@
+import type { AppQueue } from '@bull-board/api/typings/app';
+import type { GetQueuesResponse } from '@bull-board/api/typings/responses';
+import { waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { useSettingsStore } from '../../src/hooks/useSettings';
+import { QueuePage } from '../../src/pages/QueuePage/QueuePage';
+import { createWrapper, makeQueue, render } from '../testUtils';
+
+jest.mock('../../src/utils/highlight/highlight', () => ({
+  asyncHighlight: async (code: string) => code,
+}));
+
+beforeEach(() => {
+  useSettingsStore.setState({ pollingInterval: 0, jobsPerPage: 10 });
+});
+
+function renderPage(overrides: Partial<AppQueue> = {}) {
+  const queues = [makeQueue('reports', { jobSchedulerCount: 2, ...overrides })];
+  const getQueues = jest.fn(() => Promise.resolve<GetQueuesResponse>({ queues }));
+  const { Wrapper } = createWrapper({
+    api: { getQueues },
+    history: createMemoryHistory({ initialEntries: ['/queue/reports'] }),
+  });
+
+  const { container } = render(<QueuePage />, { wrapper: Wrapper });
+
+  const schedulersLink = () => container.querySelector('a[href*="/job-schedulers"]');
+
+  return { container, schedulersLink };
+}
+
+it('renders the schedulers link in the status tab row', async () => {
+  const { container, schedulersLink } = renderPage();
+
+  await waitFor(() => expect(schedulersLink()).toBeTruthy());
+  expect(container.querySelector('.statusBar a[href*="/job-schedulers"]')).toBeTruthy();
+  expect(container.querySelector('.actionContainer a[href*="/job-schedulers"]')).toBeNull();
+});
+
+it('keeps the schedulers link on a read only queue', async () => {
+  const { schedulersLink } = renderPage({ readOnlyMode: true });
+
+  await waitFor(() => expect(schedulersLink()).toBeTruthy());
+});


### PR DESCRIPTION
Closes #1329.

The schedulers link was the first child of the sticky actions row below the tabs, alongside `QueueActions` and `Pagination`. Both of those render nothing on a typical queue on the latest tab, so that row existed to hold one small link spread against empty space, and without the link the row collapses entirely because the container has an `:empty` rule. The link also used `align-self: center` while that container flips to a column under 768px, so it was left aligned on desktop and centre aligned on mobile, and at 0.8rem with no padding and no hover fill it did not match the 0.9rem buttons beside it.

It now sits in the tab row's trailing slot, before the workers badge and the `...` button, restyled to the workers badge's weight: icon, label, and a count pill that matches the tab badges. Under 768px the label drops and the icon plus count remain, with the tap target raised to 36px so it lines up with the dropdown trigger next to it.

Moving it there rather than into the `...` dropdown, which is what the issue suggested, keeps it reachable. That dropdown is hidden in read only mode, the sidebar is not rendered at all on mobile, and the mobile queue dropdown has no schedulers entry, so on a read only board on a phone this link is the only route to the schedulers view.

Two visible consequences. The actions row now disappears on queues where nothing else fills it, which is the orphan row going away. And the trailing slot permanently takes some width from the scrollable tab strip, so on a narrow window one more status tab sits behind the scroll fade than before.

`.trailing` in `StatusTabs.module.css` became a flex row with a gap, since it now holds three items instead of two. No locale changes: the visible label reuses `SCHEDULERS.TITLE` and the existing `QUEUE.SCHEDULERS_LINK` string becomes the link's `aria-label`, which is what a screen reader gets on mobile where the label is hidden.

`packages/ui/tests/pages/QueuePage.spec.tsx` asserts the link renders inside the status tab row and not in the actions row, and that it survives read only mode. The first assertion fails on master.

Desktop, before and after:

<img width="1440" src="https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-schedulers-link/before-desktop-light.png" />

<img width="1440" src="https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-schedulers-link/after-desktop-light.png" />

Mobile at 390px, before and after:

<img width="390" src="https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-schedulers-link/before-mobile-light.png" />

<img width="390" src="https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-schedulers-link/after-mobile-light.png" />

The actions row on a tab that does fill it, unchanged apart from the link no longer being there:

<img width="1440" src="https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-schedulers-link/after-failed-tab.png" />
