### PR TITLE
chore(deps): bump zustand to v5

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -9,6 +9,6 @@
     "@bull-board/api": "9.3.1"
   },
   "peerDependencies": {
-    "bullmq": "^5.0.0"
+    "bullmq": "^5.79.2 || ^6.0.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -87,6 +87,6 @@
     "react-router-dom": "^5.3.4",
     "recharts": "^3.10.1",
     "ts-jest": "^29.4.12",
-    "zustand": "4.5.7"
+    "zustand": "5.0.15"
   }
 }

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -28,13 +28,8 @@ export const Menu = () => {
   const { searchTerm, setSearchTerm } = useQueueSearch();
   const { hasHistoryProvider = false } = useUIConfig();
 
-  const { expandAll, collapseAll, isMenuOpen } = useMenuState(
-    useShallow(({ expandAll, collapseAll, isMenuOpen }) => ({
-      expandAll,
-      collapseAll,
-      isMenuOpen,
-    }))
-  );
+  const expandAll = useMenuState((state) => state.expandAll);
+  const collapseAll = useMenuState((state) => state.collapseAll);
 
   const tree = toTree(
     queues?.filter((queue: any) =>
@@ -45,8 +40,12 @@ export const Menu = () => {
 
   const groupPaths = useMemo(() => collectGroupPaths(tree), [tree]);
   const hasGroups = groupPaths.length > 0;
-  const allExpanded = hasGroups && groupPaths.every((p) => isMenuOpen(p));
-  const allCollapsed = hasGroups && groupPaths.every((p) => !isMenuOpen(p));
+  const { allExpanded, allCollapsed } = useMenuState(
+    useShallow((state) => ({
+      allExpanded: hasGroups && groupPaths.every((p) => state.isMenuOpen(p)),
+      allCollapsed: hasGroups && groupPaths.every((p) => !state.isMenuOpen(p)),
+    }))
+  );
   const showJobSchedulers = queues?.some((queue) => queue.jobSchedulerCount > 0);
 
   return (

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -2,6 +2,7 @@ import cn from 'clsx';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 import { useMenuState } from '../../hooks/useMenuState';
 import { useQueues } from '../../hooks/useQueues';
 import { useQueueSearch } from '../../hooks/useQueueSearch';
@@ -28,11 +29,11 @@ export const Menu = () => {
   const { hasHistoryProvider = false } = useUIConfig();
 
   const { expandAll, collapseAll, isMenuOpen } = useMenuState(
-    ({ expandAll, collapseAll, isMenuOpen }) => ({
+    useShallow(({ expandAll, collapseAll, isMenuOpen }) => ({
       expandAll,
       collapseAll,
       isMenuOpen,
-    })
+    }))
   );
 
   const tree = toTree(

--- a/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
@@ -21,11 +21,12 @@ export const MenuTree = ({
 }) => {
   const { t } = useTranslation();
   const selectedStatuses = useSelectedStatuses();
-  const { toggleMenu, isMenuOpen } = useMenuState(
-    useShallow(({ toggleMenu, isMenuOpen }) => ({
-      isMenuOpen,
-      toggleMenu,
-    }))
+  const toggleMenu = useMenuState((state) => state.toggleMenu);
+  const childPaths = tree.children.map((node) =>
+    parentPath ? `${parentPath}/${node.name}` : node.name
+  );
+  const openStates = useMenuState(
+    useShallow((state) => childPaths.map((path) => state.isMenuOpen(path)))
   );
 
   return (
@@ -33,11 +34,11 @@ export const MenuTree = ({
       className={cn(s.menu, level > 0 && s.level)}
       style={{ '--level': level } as React.CSSProperties}
     >
-      {tree.children.map((node) => {
+      {tree.children.map((node, index) => {
         const isLeafNode = !node.children.length;
         const displayName = node.name;
-        const menuPath = parentPath ? `${parentPath}/${node.name}` : node.name;
-        const isOpen = isMenuOpen(menuPath);
+        const menuPath = childPaths[index];
+        const isOpen = openStates[index];
 
         return (
           <li key={node.name}>

--- a/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
+++ b/packages/ui/src/components/Menu/MenuTree/MenuTree.tsx
@@ -1,6 +1,7 @@
 import cn from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 import { useMenuState } from '../../../hooks/useMenuState';
 import { useSelectedStatuses } from '../../../hooks/useSelectedStatuses';
 import { links } from '../../../utils/links';
@@ -20,10 +21,12 @@ export const MenuTree = ({
 }) => {
   const { t } = useTranslation();
   const selectedStatuses = useSelectedStatuses();
-  const { toggleMenu, isMenuOpen } = useMenuState(({ toggleMenu, isMenuOpen }) => ({
-    isMenuOpen,
-    toggleMenu,
-  }));
+  const { toggleMenu, isMenuOpen } = useMenuState(
+    useShallow(({ toggleMenu, isMenuOpen }) => ({
+      isMenuOpen,
+      toggleMenu,
+    }))
+  );
 
   return (
     <ul

--- a/packages/ui/src/components/OverviewControls/OverviewControls.tsx
+++ b/packages/ui/src/components/OverviewControls/OverviewControls.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
 import { useOverviewState } from '../../hooks/useMenuState';
 import { Button } from '../Button/Button';
 import { ChevronDown } from '../Icons/ChevronDown';
@@ -12,7 +13,11 @@ interface OverviewControlsProps {
 export const OverviewControls = ({ grouped, groupPaths }: OverviewControlsProps) => {
   const { t } = useTranslation();
   const { expandAll, collapseAll, isMenuOpen } = useOverviewState(
-    ({ expandAll, collapseAll, isMenuOpen }) => ({ expandAll, collapseAll, isMenuOpen })
+    useShallow(({ expandAll, collapseAll, isMenuOpen }) => ({
+      expandAll,
+      collapseAll,
+      isMenuOpen,
+    }))
   );
 
   if (!grouped) {

--- a/packages/ui/src/components/OverviewControls/OverviewControls.tsx
+++ b/packages/ui/src/components/OverviewControls/OverviewControls.tsx
@@ -12,20 +12,18 @@ interface OverviewControlsProps {
 
 export const OverviewControls = ({ grouped, groupPaths }: OverviewControlsProps) => {
   const { t } = useTranslation();
-  const { expandAll, collapseAll, isMenuOpen } = useOverviewState(
-    useShallow(({ expandAll, collapseAll, isMenuOpen }) => ({
-      expandAll,
-      collapseAll,
-      isMenuOpen,
+  const expandAll = useOverviewState((state) => state.expandAll);
+  const collapseAll = useOverviewState((state) => state.collapseAll);
+  const { allExpanded, allCollapsed } = useOverviewState(
+    useShallow((state) => ({
+      allExpanded: groupPaths.every((path) => state.isMenuOpen(path)),
+      allCollapsed: groupPaths.every((path) => !state.isMenuOpen(path)),
     }))
   );
 
   if (!grouped) {
     return null;
   }
-
-  const allExpanded = groupPaths.every((path) => isMenuOpen(path));
-  const allCollapsed = groupPaths.every((path) => !isMenuOpen(path));
 
   return (
     <div className={s.expandActions}>

--- a/packages/ui/src/components/QueueMetrics/QueueMetrics.tsx
+++ b/packages/ui/src/components/QueueMetrics/QueueMetrics.tsx
@@ -1,5 +1,6 @@
 import type { AppQueue } from '@bull-board/api/typings/app';
 import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '../../hooks/useSettings';
 import { useUIConfig } from '../../hooks/useUIConfig';
 import { Card } from '../Card/Card';
@@ -16,10 +17,12 @@ export type Range = '60m' | '7d' | '30d' | '90d';
 
 export const QueueMetrics = ({ queue }: QueueMetricsProps) => {
   const { hasHistoryProvider = false, hasLatencyHistory = false } = useUIConfig();
-  const { collapseMetrics: collapsed, setSettings } = useSettingsStore((state) => ({
-    collapseMetrics: state.collapseMetrics,
-    setSettings: state.setSettings,
-  }));
+  const { collapseMetrics: collapsed, setSettings } = useSettingsStore(
+    useShallow((state) => ({
+      collapseMetrics: state.collapseMetrics,
+      setSettings: state.setSettings,
+    }))
+  );
   const [range, setRange] = useState<Range>('60m');
 
   const historyEnabled = range !== '60m' && hasHistoryProvider;

--- a/packages/ui/src/hooks/useJob.ts
+++ b/packages/ui/src/hooks/useJob.ts
@@ -1,6 +1,7 @@
 import type { AppJob } from '@bull-board/api/typings/app';
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
 import { JobActions, Status } from '../../typings/app';
 import { getConfirmFor } from '../utils/getConfirmFor';
 import { queryKeys } from './queryKeys';
@@ -31,10 +32,10 @@ export function useJob(): JobState & { actions: JobActions } {
   const { t } = useTranslation();
 
   const { confirmJobActions, pollingInterval } = useSettingsStore(
-    ({ confirmJobActions, pollingInterval }) => ({
+    useShallow(({ confirmJobActions, pollingInterval }) => ({
       confirmJobActions,
       pollingInterval,
-    })
+    }))
   );
 
   const { openConfirm } = useConfirm();

--- a/packages/ui/src/hooks/useJobFlow.ts
+++ b/packages/ui/src/hooks/useJobFlow.ts
@@ -17,9 +17,7 @@ export function useJobFlow(): JobFlowState {
   const activeQueueName = useActiveQueueName();
   const activeJobId = useActiveJobId();
 
-  const { pollingInterval } = useSettingsStore(({ pollingInterval }) => ({
-    pollingInterval,
-  }));
+  const pollingInterval = useSettingsStore((state) => state.pollingInterval);
 
   const { data, isPending, error } = useQuery({
     queryKey: queryKeys.jobFlow(activeQueueName, activeJobId),

--- a/packages/ui/src/hooks/useJobSchedulers.ts
+++ b/packages/ui/src/hooks/useJobSchedulers.ts
@@ -1,6 +1,7 @@
 import type { AppJobScheduler, JobSchedulerRepeatOptions } from '@bull-board/api/typings/app';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
 import { runWithToast } from '../utils/actionToast';
 import { getConfirmFor } from '../utils/getConfirmFor';
 import { queryKeys } from './queryKeys';
@@ -14,7 +15,10 @@ export function useJobSchedulers(queueName?: string) {
   const queryClient = useQueryClient();
   const { openConfirm } = useConfirm();
   const { pollingInterval, confirmQueueActions } = useSettingsStore(
-    ({ pollingInterval, confirmQueueActions }) => ({ pollingInterval, confirmQueueActions })
+    useShallow(({ pollingInterval, confirmQueueActions }) => ({
+      pollingInterval,
+      confirmQueueActions,
+    }))
   );
 
   const { data, isPending } = useQuery({

--- a/packages/ui/src/hooks/useQueues.ts
+++ b/packages/ui/src/hooks/useQueues.ts
@@ -3,6 +3,7 @@ import type { JobCleanStatus, JobRetryStatus } from '@bull-board/api/typings/app
 import { GetQueuesResponse } from '@bull-board/api/typings/responses';
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
 import { QueueActions } from '../../typings/app';
 import { runWithToast } from '../utils/actionToast';
 import type { RetriableFailedJobs } from '../utils/failedRetries';
@@ -31,11 +32,11 @@ export function useQueues(): QueuesState & { actions: QueueActions } {
   const activeQueueName = useActiveQueueName();
   const selectedStatuses = useSelectedStatuses();
   const { pollingInterval, jobsPerPage, confirmQueueActions } = useSettingsStore(
-    ({ pollingInterval, jobsPerPage, confirmQueueActions }) => ({
+    useShallow(({ pollingInterval, jobsPerPage, confirmQueueActions }) => ({
       pollingInterval,
       jobsPerPage,
       confirmQueueActions,
-    })
+    }))
   );
   const { openConfirm } = useConfirm();
 

--- a/packages/ui/src/hooks/useSortQueues.ts
+++ b/packages/ui/src/hooks/useSortQueues.ts
@@ -1,5 +1,6 @@
 import type { AppQueue } from '@bull-board/api/typings/app';
 import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from './useSettings';
 
 export type QueueSortKey = 'alphabetical' | keyof AppQueue['counts'];
@@ -11,7 +12,7 @@ export function useSortQueues(queues: AppQueue[]) {
       dashboard: { key: sortKey, direction: sortDirection },
     },
     setSettings,
-  } = useSettingsStore(({ setSettings, sorting }) => ({ sorting, setSettings }));
+  } = useSettingsStore(useShallow(({ setSettings, sorting }) => ({ sorting, setSettings })));
 
   const sortedQueues = queues.slice(0).sort((a, z) => {
     if (sortKey === 'alphabetical') {

--- a/packages/ui/tests/components/Menu.spec.tsx
+++ b/packages/ui/tests/components/Menu.spec.tsx
@@ -1,6 +1,7 @@
 import type { GetQueuesResponse } from '@bull-board/api/typings/responses';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { Menu } from '../../src/components/Menu/Menu';
+import { useMenuState } from '../../src/hooks/useMenuState';
 import { useSettingsStore } from '../../src/hooks/useSettings';
 import { createWrapper, render, makeQueue } from '../testUtils';
 
@@ -12,6 +13,7 @@ beforeEach(() => {
     sortQueues: false,
     sidebarCollapsed: false,
   });
+  useMenuState.setState({ state: {} });
 });
 
 function renderMenu(hasHistoryProvider: boolean | undefined, jobSchedulerCount = 0) {
@@ -61,4 +63,42 @@ it('does not render the schedulers nav link when nothing is scheduled', async ()
   renderMenu(false, 0);
 
   expect(screen.queryByText('MENU.SCHEDULERS')).toBeNull();
+});
+
+it('collapses and reopens a queue group when its header is clicked', async () => {
+  const getQueues = jest.fn(() =>
+    Promise.resolve<GetQueuesResponse>({ queues: [makeQueue('billing.invoices')] })
+  );
+  const { Wrapper } = createWrapper({ api: { getQueues }, uiConfig: {} });
+  render(<Menu />, { wrapper: Wrapper });
+
+  const group = await screen.findByText('billing');
+  expect(screen.queryByText('invoices')).toBeTruthy();
+
+  fireEvent.click(group);
+  await waitFor(() => expect(screen.queryByText('invoices')).toBeNull());
+
+  fireEvent.click(screen.getByText('billing'));
+  await waitFor(() => expect(screen.queryByText('invoices')).toBeTruthy());
+});
+
+it('drives expand-all and collapse-all from the current group state', async () => {
+  const getQueues = jest.fn(() =>
+    Promise.resolve<GetQueuesResponse>({ queues: [makeQueue('billing.invoices')] })
+  );
+  const { Wrapper } = createWrapper({ api: { getQueues }, uiConfig: {} });
+  render(<Menu />, { wrapper: Wrapper });
+
+  const expand = await screen.findByTitle('MENU.EXPAND_ALL');
+  const collapse = screen.getByTitle('MENU.COLLAPSE_ALL');
+  expect(expand.hasAttribute('disabled')).toBe(true);
+  expect(collapse.hasAttribute('disabled')).toBe(false);
+
+  fireEvent.click(collapse);
+  await waitFor(() => expect(screen.queryByText('invoices')).toBeNull());
+  expect(expand.hasAttribute('disabled')).toBe(false);
+  expect(collapse.hasAttribute('disabled')).toBe(true);
+
+  fireEvent.click(expand);
+  await waitFor(() => expect(screen.queryByText('invoices')).toBeTruthy());
 });

--- a/packages/ui/tests/components/OverviewControls.spec.tsx
+++ b/packages/ui/tests/components/OverviewControls.spec.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { OverviewControls } from '../../src/components/OverviewControls/OverviewControls';
+import { useOverviewState } from '../../src/hooks/useMenuState';
+import { createWrapper, render } from '../testUtils';
+
+beforeEach(() => {
+  useOverviewState.setState({ state: {} });
+});
+
+function renderControls() {
+  const { Wrapper } = createWrapper({ api: {}, uiConfig: {} });
+  render(<OverviewControls grouped groupPaths={['billing', 'emails']} />, { wrapper: Wrapper });
+  return {
+    expand: screen.getByTitle('MENU.EXPAND_ALL'),
+    collapse: screen.getByTitle('MENU.COLLAPSE_ALL'),
+  };
+}
+
+it('renders nothing when the overview is not grouped', () => {
+  const { Wrapper } = createWrapper({ api: {}, uiConfig: {} });
+  const { container } = render(<OverviewControls grouped={false} groupPaths={['billing']} />, {
+    wrapper: Wrapper,
+  });
+
+  expect(container.textContent).toBe('');
+});
+
+it('reflects the collapse state of every group path it is given', () => {
+  const { expand, collapse } = renderControls();
+
+  expect(expand.hasAttribute('disabled')).toBe(true);
+  expect(collapse.hasAttribute('disabled')).toBe(false);
+
+  fireEvent.click(collapse);
+
+  expect(useOverviewState.getState().state).toEqual({ billing: false, emails: false });
+  expect(expand.hasAttribute('disabled')).toBe(false);
+  expect(collapse.hasAttribute('disabled')).toBe(true);
+
+  fireEvent.click(expand);
+
+  expect(expand.hasAttribute('disabled')).toBe(true);
+  expect(collapse.hasAttribute('disabled')).toBe(false);
+});

--- a/packages/ui/tests/hooks/useSortQueues.spec.tsx
+++ b/packages/ui/tests/hooks/useSortQueues.spec.tsx
@@ -1,0 +1,24 @@
+import { act, renderHook } from '@testing-library/react';
+import { useSettingsStore } from '../../src/hooks/useSettings';
+import { useSortQueues } from '../../src/hooks/useSortQueues';
+import { makeQueue } from '../testUtils';
+
+beforeEach(() => {
+  useSettingsStore.setState({ sorting: { dashboard: { key: 'alphabetical', direction: 'asc' } } });
+});
+
+const queues = [
+  { ...makeQueue('beta'), displayName: 'beta' },
+  { ...makeQueue('alpha'), displayName: 'alpha' },
+];
+
+it('re-sorts when the sort key changes', () => {
+  const { result } = renderHook(() => useSortQueues(queues));
+
+  expect(result.current.sortedQueues.map((queue) => queue.displayName)).toEqual(['alpha', 'beta']);
+
+  act(() => result.current.onSort('alphabetical'));
+
+  expect(result.current.sortDirection).toBe('desc');
+  expect(result.current.sortedQueues.map((queue) => queue.displayName)).toEqual(['beta', 'alpha']);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,7 +820,7 @@ __metadata:
     react-router-dom: "npm:^5.3.4"
     recharts: "npm:^3.10.1"
     ts-jest: "npm:^29.4.12"
-    zustand: "npm:4.5.7"
+    zustand: "npm:5.0.15"
   languageName: unknown
   linkType: soft
 
@@ -16574,15 +16574,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:4.5.7":
-  version: 4.5.7
-  resolution: "zustand@npm:4.5.7"
-  dependencies:
-    use-sync-external-store: "npm:^1.2.2"
+"zustand@npm:5.0.15":
+  version: 5.0.15
+  resolution: "zustand@npm:5.0.15"
   peerDependencies:
-    "@types/react": ">=16.8"
+    "@types/react": ">=18.0.0"
     immer: ">=9.0.6"
-    react: ">=16.8"
+    react: ">=18.0.0"
+    use-sync-external-store: ">=1.2.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -16590,7 +16589,9 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 10c0/55559e37a82f0c06cadc61cb08f08314c0fe05d6a93815e41e3376130c13db22a5017cbb0cd1f018c82f2dad0051afe3592561d40f980bd4082e32005e8a950c
+    use-sync-external-store:
+      optional: true
+  checksum: 10c0/ed3a883950a8c22d98e8c72cef103af18043ce66b45faf218ad20ccc8ee29716aacfc6b0a3e783b2152ea38b7663f3982bb6bf2b13ce3df692b05276446afa04
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,7 +763,7 @@ __metadata:
   dependencies:
     "@bull-board/api": "npm:9.3.1"
   peerDependencies:
-    bullmq: ^5.0.0
+    bullmq: ^5.79.2 || ^6.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Bumps `zustand` from 4.5.7 to 5.0.15 in `@bull-board/ui`.

v5 dropped the cached-snapshot layer, so selectors returning a fresh object loop. Nine call sites did that; eight now use `useShallow` and `useJobFlow` just selects the scalar.

`useShallow` is not enough for `Menu`, `MenuTree` and `OverviewControls`. They selected only the store's actions, which are stable references, and called `isMenuOpen(path)` during render. v4 re-rendered them on every store update because the selector object was always new; with `useShallow` the slice is always equal, so collapsing a group did nothing. They now select the derived booleans instead. There was no coverage for expand/collapse at all, so the suite stayed green on a broken menu; the added tests fail without the fix.

Last commit widens the `bullmq` peer range in the private `test-utils` workspace to `^5.79.2 || ^6.0.0`, matching `@bull-board/api`. No install changes today, it just stops the range going stale.
