### PR TITLE
fix(api): close the FlowProducer before reassigning it in job-flow tests

### DIFF
--- a/packages/api/tests/api/job-flow.spec.ts
+++ b/packages/api/tests/api/job-flow.spec.ts
@@ -83,8 +83,13 @@ describe('Job flow', () => {
 
   it('resolves the flow tree when queues use a custom prefix', async () => {
     const customPrefix = 'custom-prefix';
+    // Every connection opened in beforeEach has to be closed before its variable is
+    // reassigned, or afterEach only ever closes the replacement. The queues were
+    // already handled; the FlowProducer was not, so its Redis connection outlived
+    // the run and kept the worker process alive.
     await parentQueue.close();
     await childQueue.close();
+    await flowProducer.close();
 
     parentQueue = new Queue('FlowParent', { connection, prefix: customPrefix });
     childQueue = new Queue('FlowChild', { connection, prefix: customPrefix });


### PR DESCRIPTION
Closes #1374.

## Cause

`tests/api/job-flow.spec.ts`, the custom-prefix test. It rebuilds its fixtures with a different prefix and closes the two queues before reassigning them — but not the `FlowProducer`:

```ts
await parentQueue.close();
await childQueue.close();
// flowProducer never closed here
...
flowProducer = new FlowProducer({ connection, prefix: customPrefix });
```

`afterEach` closes `flowProducer`, but by then the variable points at the replacement. The instance created in `beforeEach` is never closed, so its Redis connection outlives the run and keeps the worker alive.

## Evidence

Run alone on `main`, this spec does not merely warn — it **hangs**:

```
Tests:       4 passed, 4 total
Jest did not exit one second after the test run has completed.
```

Still running after 75s, killed manually. With the fix it exits in **1.2s**.

That is also why the issue's traceback fingers this suite indirectly: the force-exit warning is printed after the whole run, so it lands next to whichever spec happened to report last. I bisected every spec in `tests/api` individually against `jest.config.default.js` — every other one exits cleanly, and both bisect passes stalled at exactly this file.

## Result

Full `packages/api` suite before:

```
A worker process has failed to exit gracefully and has been force exited...
Tests:       2 skipped, 284 passed, 286 total
Time:        17.556 s
```

After:

```
Tests:       2 skipped, 284 passed, 286 total
Time:        12.299 s
```

Warning gone, same 284 passing, and the run is ~5s faster since jest no longer waits on the dead handle before force-exiting.

## Scope

One added `await flowProducer.close();`, plus a comment recording the invariant — every connection opened in `beforeEach` has to be closed before its variable is reassigned, or `afterEach` only ever closes the replacement. No production code and no test assertions touched.
