### PR TITLE
feat(ui): follow system theme from a settings dropdown

### DIFF
--- a/packages/ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/packages/ui/src/components/SettingsModal/SettingsModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { languages } from '../../constants/languages';
 import { availableJobTabs, DEFAULT_JOB_TAB, JobTabPreference } from '../../hooks/useDetailsTabs';
-import { useSettingsStore } from '../../hooks/useSettings';
+import { ThemePreference, useSettingsStore } from '../../hooks/useSettings';
 import { useUIConfig } from '../../hooks/useUIConfig';
 import { dynamicTranslationKey } from '../../utils/dynamicTranslationKey';
 import { CollapsibleSection } from '../CollapsibleSection/CollapsibleSection';
@@ -37,7 +37,7 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
     defaultJobTab,
     sortQueues,
     overview,
-    darkMode,
+    theme,
     setSettings,
   } = useSettingsStore((state) => state);
   const { pollingInterval: uiConfigPollingInterval, overview: overviewConfig } = useUIConfig();
@@ -85,11 +85,16 @@ export const SettingsModal = ({ open, onClose }: SettingsModalProps) => {
             onChange={(value) => setSettings({ pollingInterval: +value })}
           />
         )}
-        <SwitchField
-          label={t('SETTINGS.DARK_MODE')}
-          id="dark-mode"
-          checked={darkMode}
-          onCheckedChange={(checked) => setSettings({ darkMode: checked })}
+        <SelectField
+          label={t('SETTINGS.THEME')}
+          id="theme"
+          options={[
+            { text: t('SETTINGS.THEME_OPTIONS.SYSTEM'), value: 'system' },
+            { text: t('SETTINGS.THEME_OPTIONS.LIGHT'), value: 'light' },
+            { text: t('SETTINGS.THEME_OPTIONS.DARK'), value: 'dark' },
+          ]}
+          value={theme}
+          onChange={(value) => setSettings({ theme: value as ThemePreference })}
         />
       </CollapsibleSection>
 

--- a/packages/ui/src/hooks/useDarkMode.ts
+++ b/packages/ui/src/hooks/useDarkMode.ts
@@ -1,14 +1,24 @@
 import { useEffect } from 'react';
 import { useSettingsStore } from './useSettings';
 
+function applyDarkClass(enabled: boolean): void {
+  document.body.classList.toggle('dark-mode', enabled);
+}
+
 export function useDarkMode() {
-  const { darkMode } = useSettingsStore();
+  const theme = useSettingsStore((state) => state.theme);
 
   useEffect(() => {
-    if (darkMode) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
+    if (theme !== 'system') {
+      applyDarkClass(theme === 'dark');
+      return;
     }
-  }, [darkMode]);
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    applyDarkClass(media.matches);
+
+    const onChange = () => applyDarkClass(media.matches);
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, [theme]);
 }

--- a/packages/ui/src/hooks/useSettings.ts
+++ b/packages/ui/src/hooks/useSettings.ts
@@ -7,6 +7,8 @@ import { QueueSortKey, SortDirection } from './useSortQueues';
 /** Which pane the throughput/latency chart tab switcher shows. */
 export type MetricsChartTab = 'throughput' | 'latency';
 
+export type ThemePreference = 'system' | 'light' | 'dark';
+
 interface SettingsState {
   language: string;
   pollingInterval: number;
@@ -21,7 +23,7 @@ interface SettingsState {
   collapseMetrics: boolean;
   defaultCollapseDepth: number;
   useCollapsibleJson: boolean;
-  darkMode: boolean;
+  theme: ThemePreference;
   defaultJobTab: JobTabPreference;
   sortQueues: boolean;
   sorting: { dashboard: { key: QueueSortKey; direction: SortDirection } };
@@ -36,13 +38,20 @@ interface SettingsState {
   setSettings: (settings: Partial<Omit<SettingsState, 'setSettings'>>) => void;
 }
 
-export const SETTINGS_VERSION = 1;
+export const SETTINGS_VERSION = 2;
+
+type LegacySettings = Partial<SettingsState> & { darkMode?: boolean };
 
 export function migrateSettings(persisted: unknown, version: number): SettingsState {
-  const settings = persisted as Partial<SettingsState> | undefined;
+  let settings = persisted as LegacySettings | undefined;
 
   if (version === 0 && settings?.defaultJobTab === 'Data') {
-    return { ...settings, defaultJobTab: DEFAULT_JOB_TAB } as SettingsState;
+    settings = { ...settings, defaultJobTab: DEFAULT_JOB_TAB };
+  }
+
+  if (version < 2 && settings && 'darkMode' in settings) {
+    const { darkMode, ...rest } = settings;
+    settings = { ...rest, theme: darkMode ? 'dark' : 'light' };
   }
 
   return settings as SettingsState;
@@ -64,7 +73,7 @@ export const useSettingsStore = create<SettingsState>()(
       collapseMetrics: false,
       defaultCollapseDepth: 3,
       useCollapsibleJson: true,
-      darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
+      theme: 'system',
       defaultJobTab: DEFAULT_JOB_TAB,
       sortQueues: false,
       sorting: { dashboard: { key: 'alphabetical', direction: 'asc' } },

--- a/packages/ui/src/static/locales/da-DK/messages.json
+++ b/packages/ui/src/static/locales/da-DK/messages.json
@@ -273,7 +273,12 @@
     "COLLAPSE_JOB_ERROR": "Sammenfold jobfejl",
     "DEFAULT_COLLAPSE_DEPTH": "Standard JSON-sammenfoldningsdybde (0-10)",
     "SORT_QUEUES": "Sortér køer (A-Å, grupper først)",
-    "DARK_MODE": "Mørk tilstand",
+    "THEME": "Tema",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Som i systemet",
+      "LIGHT": "Lys",
+      "DARK": "Mørk"
+    },
     "SECTIONS": {
       "GENERAL": "Generelt",
       "QUEUES": "Køer",

--- a/packages/ui/src/static/locales/de-DE/messages.json
+++ b/packages/ui/src/static/locales/de-DE/messages.json
@@ -273,7 +273,12 @@
     "COLLAPSE_JOB_ERROR": "Job-Fehler einklappen",
     "DEFAULT_COLLAPSE_DEPTH": "Standard-JSON-Einklapptiefe (0-10)",
     "SORT_QUEUES": "Warteschlangen sortieren (A-Z, Gruppen zuerst)",
-    "DARK_MODE": "Dunkler Modus",
+    "THEME": "Thema",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Wie im System",
+      "LIGHT": "Hell",
+      "DARK": "Dunkel"
+    },
     "SECTIONS": {
       "GENERAL": "Allgemein",
       "QUEUES": "Warteschlangen",

--- a/packages/ui/src/static/locales/en-GB/messages.json
+++ b/packages/ui/src/static/locales/en-GB/messages.json
@@ -273,7 +273,12 @@
     "COLLAPSE_JOB_ERROR": "Collapse job error",
     "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
     "SORT_QUEUES": "Sort queues (A-Z, groups first)",
-    "DARK_MODE": "Dark mode",
+    "THEME": "Theme",
+    "THEME_OPTIONS": {
+      "SYSTEM": "As in system",
+      "LIGHT": "Light",
+      "DARK": "Dark"
+    },
     "SECTIONS": {
       "GENERAL": "General",
       "QUEUES": "Queues",

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -270,7 +270,12 @@
     "COLLAPSE_JOB_ERROR": "Collapse job error",
     "DEFAULT_COLLAPSE_DEPTH": "Default JSON collapse depth (0-10)",
     "SORT_QUEUES": "Sort queues (A-Z, groups first)",
-    "DARK_MODE": "Dark mode",
+    "THEME": "Theme",
+    "THEME_OPTIONS": {
+      "SYSTEM": "As in system",
+      "LIGHT": "Light",
+      "DARK": "Dark"
+    },
     "SECTIONS": {
       "GENERAL": "General",
       "QUEUES": "Queues",

--- a/packages/ui/src/static/locales/es-ES/messages.json
+++ b/packages/ui/src/static/locales/es-ES/messages.json
@@ -276,7 +276,12 @@
     "COLLAPSE_JOB_ERROR": "Contraer error de tarea",
     "DEFAULT_COLLAPSE_DEPTH": "Profundidad de colapso JSON predeterminada (0-10)",
     "SORT_QUEUES": "Ordenar colas (A-Z, grupos primero)",
-    "DARK_MODE": "Modo oscuro",
+    "THEME": "Tema",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Como en el sistema",
+      "LIGHT": "Claro",
+      "DARK": "Oscuro"
+    },
     "SECTIONS": {
       "GENERAL": "General",
       "QUEUES": "Colas",

--- a/packages/ui/src/static/locales/fr-FR/messages.json
+++ b/packages/ui/src/static/locales/fr-FR/messages.json
@@ -276,7 +276,12 @@
     "COLLAPSE_JOB_ERROR": "Réduire l'erreur de la tâche",
     "DEFAULT_COLLAPSE_DEPTH": "Profondeur de réduction JSON par défaut (0-10)",
     "SORT_QUEUES": "Trier les files (A-Z, groupes en premier)",
-    "DARK_MODE": "Mode sombre",
+    "THEME": "Thème",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Comme le système",
+      "LIGHT": "Clair",
+      "DARK": "Sombre"
+    },
     "SECTIONS": {
       "GENERAL": "Général",
       "QUEUES": "Files",

--- a/packages/ui/src/static/locales/ja-JP/messages.json
+++ b/packages/ui/src/static/locales/ja-JP/messages.json
@@ -269,7 +269,12 @@
     "COLLAPSE_JOB_ERROR": "ジョブエラーを折りたたむ",
     "DEFAULT_COLLAPSE_DEPTH": "デフォルトのJSON折りたたみ深度 (0-10)",
     "SORT_QUEUES": "キューを並び替え (A-Z、グループ優先)",
-    "DARK_MODE": "ダークモード",
+    "THEME": "テーマ",
+    "THEME_OPTIONS": {
+      "SYSTEM": "システム設定に合わせる",
+      "LIGHT": "ライト",
+      "DARK": "ダーク"
+    },
     "SECTIONS": {
       "GENERAL": "一般",
       "QUEUES": "キュー",

--- a/packages/ui/src/static/locales/ko-KR/messages.json
+++ b/packages/ui/src/static/locales/ko-KR/messages.json
@@ -267,7 +267,12 @@
     "COLLAPSE_JOB_ERROR": "작업 오류 접기",
     "DEFAULT_COLLAPSE_DEPTH": "기본 JSON 접기 깊이 (0-10)",
     "SORT_QUEUES": "큐 정렬 (A-Z, 그룹 우선)",
-    "DARK_MODE": "다크 모드",
+    "THEME": "테마",
+    "THEME_OPTIONS": {
+      "SYSTEM": "시스템 설정",
+      "LIGHT": "라이트",
+      "DARK": "다크"
+    },
     "SECTIONS": {
       "GENERAL": "일반",
       "QUEUES": "큐",

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -276,7 +276,12 @@
     "COLLAPSE_JOB_ERROR": "Recolher erros da tarefa",
     "DEFAULT_COLLAPSE_DEPTH": "Profundidade padrão de recolhimento JSON (0-10)",
     "SORT_QUEUES": "Ordenar filas (A-Z, grupos primeiro)",
-    "DARK_MODE": "Modo escuro",
+    "THEME": "Tema",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Como no sistema",
+      "LIGHT": "Claro",
+      "DARK": "Escuro"
+    },
     "SECTIONS": {
       "GENERAL": "Geral",
       "QUEUES": "Filas",

--- a/packages/ui/src/static/locales/ru-RU/messages.json
+++ b/packages/ui/src/static/locales/ru-RU/messages.json
@@ -279,7 +279,12 @@
     "COLLAPSE_JOB_ERROR": "Сворачивать ошибку задачи",
     "DEFAULT_COLLAPSE_DEPTH": "Глубина сворачивания JSON по умолчанию (0–10)",
     "SORT_QUEUES": "Сортировать очереди (A–Z, группы сначала)",
-    "DARK_MODE": "Тёмная тема",
+    "THEME": "Тема",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Как в системе",
+      "LIGHT": "Светлая",
+      "DARK": "Тёмная"
+    },
     "SECTIONS": {
       "GENERAL": "Общие",
       "QUEUES": "Очереди",

--- a/packages/ui/src/static/locales/tr-TR/messages.json
+++ b/packages/ui/src/static/locales/tr-TR/messages.json
@@ -273,7 +273,12 @@
     "COLLAPSE_JOB_ERROR": "İş hatalarını başlangıçta daralt",
     "DEFAULT_COLLAPSE_DEPTH": "Varsayılan JSON daraltma derinliği (0-10)",
     "SORT_QUEUES": "Kuyrukları sırala (A-Z, gruplar önce)",
-    "DARK_MODE": "Karanlık mod",
+    "THEME": "Tema",
+    "THEME_OPTIONS": {
+      "SYSTEM": "Sistemle aynı",
+      "LIGHT": "Açık",
+      "DARK": "Koyu"
+    },
     "SECTIONS": {
       "GENERAL": "Genel",
       "QUEUES": "Kuyruklar",

--- a/packages/ui/src/static/locales/zh-CN/messages.json
+++ b/packages/ui/src/static/locales/zh-CN/messages.json
@@ -267,7 +267,12 @@
     "COLLAPSE_JOB_ERROR": "折叠作业错误",
     "DEFAULT_COLLAPSE_DEPTH": "默认 JSON 折叠深度 (0-10)",
     "SORT_QUEUES": "队列排序 (A-Z，分组优先)",
-    "DARK_MODE": "黑暗模式",
+    "THEME": "主题",
+    "THEME_OPTIONS": {
+      "SYSTEM": "跟随系统",
+      "LIGHT": "浅色",
+      "DARK": "深色"
+    },
     "SECTIONS": {
       "GENERAL": "通用",
       "QUEUES": "队列",

--- a/packages/ui/tests/components/SettingsModal.spec.tsx
+++ b/packages/ui/tests/components/SettingsModal.spec.tsx
@@ -33,4 +33,19 @@ describe('SettingsModal', () => {
   it('shows the stored language once one has been chosen', async () => {
     expect((await renderWithLanguage('de-DE')).textContent).toBe('de-DE');
   });
+
+  it('shows the theme as a dropdown defaulting to the system option', async () => {
+    act(() => {
+      useSettingsStore.setState({ theme: 'system' });
+    });
+
+    const { Wrapper } = createWrapper({ api: {} });
+    await act(async () => {
+      render(<SettingsModal open onClose={() => {}} />, { wrapper: Wrapper });
+    });
+
+    expect(screen.getByRole('combobox', { name: 'SETTINGS.THEME' }).textContent).toBe(
+      'SETTINGS.THEME_OPTIONS.SYSTEM'
+    );
+  });
 });

--- a/packages/ui/tests/hooks/useDarkMode.spec.tsx
+++ b/packages/ui/tests/hooks/useDarkMode.spec.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDarkMode } from '../../src/hooks/useDarkMode';
+import { useSettingsStore } from '../../src/hooks/useSettings';
+
+function mockMatchMedia(matches: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const media = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    dispatchEvent: () => false,
+    dispatch(next: boolean) {
+      media.matches = next;
+      listeners.forEach((listener) => listener({ matches: next } as MediaQueryListEvent));
+    },
+  };
+
+  window.matchMedia = () => media as unknown as MediaQueryList;
+  return media;
+}
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    document.body.classList.remove('dark-mode');
+    mockMatchMedia(false);
+    act(() => {
+      useSettingsStore.setState({ theme: 'system' });
+    });
+  });
+
+  it('adds the dark-mode class when the preference is dark', () => {
+    act(() => {
+      useSettingsStore.setState({ theme: 'dark' });
+    });
+
+    renderHook(() => useDarkMode());
+
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+  });
+
+  it('removes the dark-mode class when the preference is light', () => {
+    document.body.classList.add('dark-mode');
+    act(() => {
+      useSettingsStore.setState({ theme: 'light' });
+    });
+
+    renderHook(() => useDarkMode());
+
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+  });
+
+  it('follows the system preference and updates when it changes', () => {
+    const media = mockMatchMedia(true);
+    act(() => {
+      useSettingsStore.setState({ theme: 'system' });
+    });
+
+    renderHook(() => useDarkMode());
+
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+
+    act(() => media.dispatch(false));
+
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+  });
+
+  it('stops following the system once a fixed theme is chosen', () => {
+    const media = mockMatchMedia(false);
+    act(() => {
+      useSettingsStore.setState({ theme: 'system' });
+    });
+
+    renderHook(() => useDarkMode());
+
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+
+    act(() => {
+      useSettingsStore.setState({ theme: 'light' });
+    });
+
+    act(() => media.dispatch(true));
+
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+  });
+});

--- a/packages/ui/tests/hooks/useDetailsTabs.spec.tsx
+++ b/packages/ui/tests/hooks/useDetailsTabs.spec.tsx
@@ -65,4 +65,23 @@ describe('migrateSettings', () => {
   it('does not rewrite Data once the viewer is already on the current version', () => {
     expect(migrateSettings({ defaultJobTab: 'Data' }, 1).defaultJobTab).toBe('Data');
   });
+
+  it('turns a persisted dark-mode toggle into an explicit theme', () => {
+    expect(migrateSettings({ darkMode: true, jobsPerPage: 50 }, 1)).toEqual({
+      theme: 'dark',
+      jobsPerPage: 50,
+    });
+    expect(migrateSettings({ darkMode: false }, 1)).toEqual({ theme: 'light' });
+  });
+
+  it('applies both v0 and theme migrations together', () => {
+    expect(migrateSettings({ defaultJobTab: 'Data', darkMode: true }, 0)).toEqual({
+      defaultJobTab: DEFAULT_JOB_TAB,
+      theme: 'dark',
+    });
+  });
+
+  it('leaves an already-migrated theme alone', () => {
+    expect(migrateSettings({ theme: 'system' }, 2)).toEqual({ theme: 'system' });
+  });
 });

--- a/packages/ui/tests/setup.ts
+++ b/packages/ui/tests/setup.ts
@@ -40,7 +40,7 @@ if (!global.ResizeObserver) {
   } as unknown as typeof ResizeObserver;
 }
 
-// jsdom has no matchMedia; the settings store reads prefers-color-scheme on load.
+// jsdom has no matchMedia; the theme setting follows prefers-color-scheme when set to system.
 if (!window.matchMedia) {
   window.matchMedia = (query: string) =>
     ({


### PR DESCRIPTION
Replaces the dark mode switch with a theme dropdown: light, dark, and "as in system".

If you pick the system option, the board follows the OS color scheme and updates when it changes. An existing dark mode preference is kept as light or dark.