### PR TITLE
feat(api): add before/after hooks for fine-grained request access control

### DIFF
--- a/packages/api/src/hooks.ts
+++ b/packages/api/src/hooks.ts
@@ -18,11 +18,17 @@ export function wrapHandlerWithHooks(
     const context = { method, route: routePath, request: request as BullBoardRequest };
 
     if (hooks.before) {
-      const beforeResult = await hooks.before(context);
+      let beforeResult;
+      try {
+        beforeResult = await hooks.before(context);
+      } catch {
+        return errorResponse(500, 'ERRORS.INTERNAL_SERVER_ERROR');
+      }
+
       if (beforeResult && beforeResult.allow === false) {
         return errorResponse(
           beforeResult.status ?? 403,
-          'ERRORS.FORBIDDEN',
+          beforeResult.errorKey ?? 'ERRORS.FORBIDDEN',
           beforeResult.message ? { message: beforeResult.message } : {}
         );
       }

--- a/packages/api/src/hooks.ts
+++ b/packages/api/src/hooks.ts
@@ -1,0 +1,35 @@
+import {
+  AppControllerRoute,
+  BoardHooks,
+  BullBoardRequest,
+  ControllerHandlerReturnType,
+} from '../typings/app';
+import { errorResponse } from './errors';
+
+export function wrapHandlerWithHooks(
+  route: AppControllerRoute,
+  hooks: BoardHooks
+): AppControllerRoute['handler'] {
+  const originalHandler = route.handler;
+  const method = Array.isArray(route.method) ? route.method[0] : route.method;
+  const routePath = Array.isArray(route.route) ? route.route[0] : route.route;
+
+  return async (request?: BullBoardRequest): Promise<ControllerHandlerReturnType> => {
+    const context = { method, route: routePath, request: request as BullBoardRequest };
+
+    if (hooks.before) {
+      const beforeResult = await hooks.before(context);
+      if (beforeResult && beforeResult.allow === false) {
+        return errorResponse(
+          beforeResult.status ?? 403,
+          'ERRORS.FORBIDDEN',
+          beforeResult.message ? { message: beforeResult.message } : {}
+        );
+      }
+    }
+
+    const result = await originalHandler(request);
+
+    return hooks.after ? hooks.after(context, result) : result;
+  };
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -7,6 +7,7 @@ import {
   createMetricsHistoryUsageHandler,
 } from './handlers/metricsHistoryStorage';
 import { createMetricsLatencyHandler } from './handlers/metricsLatency';
+import { wrapHandlerWithHooks } from './hooks';
 import { BaseAdapter } from './queueAdapters/base';
 import { getQueuesApi } from './queuesApi';
 import { appRoutes } from './routes';
@@ -66,6 +67,10 @@ export function createBullBoard({
     }
   }
 
+  const finalApiRoutes = options.hooks
+    ? apiRoutes.map((route) => ({ ...route, handler: wrapHandlerWithHooks(route, options.hooks!) }))
+    : apiRoutes;
+
   serverAdapter
     .setQueues(bullBoardQueues)
     .setViewsPath(path.join(uiBasePath, 'dist'))
@@ -87,7 +92,7 @@ export function createBullBoard({
     })
     .setEntryRoute(appRoutes.entryPoint)
     .setErrorHandler(errorHandler)
-    .setApiRoutes(apiRoutes);
+    .setApiRoutes(finalApiRoutes);
 
   return { setQueues, replaceQueues, addQueue, removeQueue };
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -67,8 +67,11 @@ export function createBullBoard({
     }
   }
 
-  const finalApiRoutes = options.hooks
-    ? apiRoutes.map((route) => ({ ...route, handler: wrapHandlerWithHooks(route, options.hooks!) }))
+  const finalApiRoutes = options.handlerHooks
+    ? apiRoutes.map((route) => ({
+        ...route,
+        handler: wrapHandlerWithHooks(route, options.handlerHooks!),
+      }))
     : apiRoutes;
 
   serverAdapter

--- a/packages/api/tests/api/hooks.spec.ts
+++ b/packages/api/tests/api/hooks.spec.ts
@@ -18,9 +18,16 @@ describe('hooks', () => {
   });
 
   afterEach(async () => {
-    for (const queue of queueList) {
-      await queue.close();
-    }
+    await Promise.allSettled(
+      queueList.map(async (queue) => {
+        try {
+          await queue.waitUntilReady();
+        } catch {
+          // ignore
+        }
+        return queue.close();
+      })
+    );
   });
 
   describe('before hook', () => {

--- a/packages/api/tests/api/hooks.spec.ts
+++ b/packages/api/tests/api/hooks.spec.ts
@@ -33,19 +33,16 @@ describe('hooks', () => {
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { before } },
+        options: { handlerHooks: { before } },
       });
 
-      await request(serverAdapter.getRouter())
+      const res = await request(serverAdapter.getRouter())
         .get('/api/queues')
         .expect('Content-Type', /json/)
-        .expect(403)
-        .then((res) => {
-          const body = JSON.parse(res.text);
-          expect(body.error).toEqual({ key: 'ERRORS.FORBIDDEN' });
-          expect(body.message).toBe('nope');
-        });
+        .expect(403);
 
+      expect(res.body.error).toEqual({ key: 'ERRORS.FORBIDDEN' });
+      expect(res.body.message).toBe('nope');
       expect(before).toHaveBeenCalledWith(
         expect.objectContaining({ method: 'get', route: '/api/queues' })
       );
@@ -58,30 +55,53 @@ describe('hooks', () => {
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { before: () => ({ allow: false }) } },
+        options: { handlerHooks: { before: () => ({ allow: false }) } },
       });
 
-      await request(serverAdapter.getRouter())
-        .get('/api/queues')
-        .expect(403)
-        .then((res) => {
-          const body = JSON.parse(res.text);
-          expect(body.error).toEqual({ key: 'ERRORS.FORBIDDEN' });
-          expect(body.message).toBeUndefined();
-        });
+      const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(403);
+
+      expect(res.body.error).toEqual({ key: 'ERRORS.FORBIDDEN' });
+      expect(res.body.message).toBeUndefined();
     });
 
-    it('should respect a custom status from the before hook', async () => {
+    it('should respect a custom status and errorKey from the before hook', async () => {
       const paintQueue = new Queue('Paint', { connection });
       queueList.push(paintQueue);
 
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { before: () => ({ allow: false, status: 400 }) } },
+        options: {
+          handlerHooks: {
+            before: () => ({ allow: false, status: 400, errorKey: 'ERRORS.INVALID_QUEUE' }),
+          },
+        },
       });
 
-      await request(serverAdapter.getRouter()).get('/api/queues').expect(400);
+      const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(400);
+
+      expect(res.body.error).toEqual({ key: 'ERRORS.INVALID_QUEUE' });
+    });
+
+    it('should return a 500 when the before hook throws', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: {
+          handlerHooks: {
+            before: () => {
+              throw new Error('boom');
+            },
+          },
+        },
+      });
+
+      const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(500);
+
+      expect(res.body.error).toEqual({ key: 'ERRORS.INTERNAL_SERVER_ERROR' });
     });
 
     it('should allow the request through when before hook allows', async () => {
@@ -91,18 +111,16 @@ describe('hooks', () => {
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { before: () => ({ allow: true }) } },
+        options: { handlerHooks: { before: () => ({ allow: true }) } },
       });
 
-      await request(serverAdapter.getRouter())
+      const res = await request(serverAdapter.getRouter())
         .get('/api/queues')
         .expect('Content-Type', /json/)
-        .expect(200)
-        .then((res) => {
-          const queues = JSON.parse(res.text).queues;
-          expect(queues).toHaveLength(1);
-          expect(queues[0].name).toBe(paintQueue.name);
-        });
+        .expect(200);
+
+      expect(res.body.queues).toHaveLength(1);
+      expect(res.body.queues[0].name).toBe(paintQueue.name);
     });
 
     it('should allow the request through when only an after hook is provided', async () => {
@@ -112,7 +130,7 @@ describe('hooks', () => {
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { after: (_ctx, result) => result } },
+        options: { handlerHooks: { after: (_ctx, result) => result } },
       });
 
       await request(serverAdapter.getRouter()).get('/api/queues').expect(200);
@@ -132,18 +150,13 @@ describe('hooks', () => {
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { after } },
+        options: { handlerHooks: { after } },
       });
 
-      await request(serverAdapter.getRouter())
-        .get('/api/queues')
-        .expect(200)
-        .then((res) => {
-          const body = JSON.parse(res.text);
-          expect(body.injected).toBe(true);
-          expect(body.queues).toHaveLength(1);
-        });
+      const res = await request(serverAdapter.getRouter()).get('/api/queues').expect(200);
 
+      expect(res.body.injected).toBe(true);
+      expect(res.body.queues).toHaveLength(1);
       expect(after).toHaveBeenCalledWith(
         expect.objectContaining({ method: 'get', route: '/api/queues' }),
         expect.objectContaining({ body: expect.objectContaining({ queues: expect.any(Array) }) })
@@ -159,7 +172,7 @@ describe('hooks', () => {
       createBullBoard({
         queues: [new BullMQAdapter(paintQueue)],
         serverAdapter,
-        options: { hooks: { before: () => ({ allow: false }), after } },
+        options: { handlerHooks: { before: () => ({ allow: false }), after } },
       });
 
       await request(serverAdapter.getRouter()).get('/api/queues').expect(403);
@@ -175,14 +188,12 @@ describe('hooks', () => {
 
       createBullBoard({ queues: [new BullMQAdapter(paintQueue)], serverAdapter });
 
-      await request(serverAdapter.getRouter())
+      const res = await request(serverAdapter.getRouter())
         .get('/api/queues')
         .expect('Content-Type', /json/)
-        .expect(200)
-        .then((res) => {
-          const queues = JSON.parse(res.text).queues;
-          expect(queues).toHaveLength(1);
-        });
+        .expect(200);
+
+      expect(res.body.queues).toHaveLength(1);
     });
   });
 });

--- a/packages/api/tests/api/hooks.spec.ts
+++ b/packages/api/tests/api/hooks.spec.ts
@@ -1,0 +1,188 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { Queue } from 'bullmq';
+import request from 'supertest';
+
+describe('hooks', () => {
+  let serverAdapter: ExpressAdapter;
+  const queueList: Queue[] = [];
+  const connection = {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: +(process.env.REDIS_PORT || 6379),
+  };
+
+  beforeEach(() => {
+    serverAdapter = new ExpressAdapter();
+    queueList.length = 0;
+  });
+
+  afterEach(async () => {
+    for (const queue of queueList) {
+      await queue.close();
+    }
+  });
+
+  describe('before hook', () => {
+    it('should block a request when before hook denies', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      const before = jest.fn().mockReturnValue({ allow: false, message: 'nope' });
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { before } },
+      });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect('Content-Type', /json/)
+        .expect(403)
+        .then((res) => {
+          const body = JSON.parse(res.text);
+          expect(body.error).toEqual({ key: 'ERRORS.FORBIDDEN' });
+          expect(body.message).toBe('nope');
+        });
+
+      expect(before).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'get', route: '/api/queues' })
+      );
+    });
+
+    it('should use a default 403 status and no message when none is provided', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { before: () => ({ allow: false }) } },
+      });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect(403)
+        .then((res) => {
+          const body = JSON.parse(res.text);
+          expect(body.error).toEqual({ key: 'ERRORS.FORBIDDEN' });
+          expect(body.message).toBeUndefined();
+        });
+    });
+
+    it('should respect a custom status from the before hook', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { before: () => ({ allow: false, status: 400 }) } },
+      });
+
+      await request(serverAdapter.getRouter()).get('/api/queues').expect(400);
+    });
+
+    it('should allow the request through when before hook allows', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { before: () => ({ allow: true }) } },
+      });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then((res) => {
+          const queues = JSON.parse(res.text).queues;
+          expect(queues).toHaveLength(1);
+          expect(queues[0].name).toBe(paintQueue.name);
+        });
+    });
+
+    it('should allow the request through when only an after hook is provided', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { after: (_ctx, result) => result } },
+      });
+
+      await request(serverAdapter.getRouter()).get('/api/queues').expect(200);
+    });
+  });
+
+  describe('after hook', () => {
+    it('should be called with the handler result and can modify it', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      const after = jest.fn().mockImplementation((_ctx, result) => ({
+        ...result,
+        body: { ...result.body, injected: true },
+      }));
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { after } },
+      });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect(200)
+        .then((res) => {
+          const body = JSON.parse(res.text);
+          expect(body.injected).toBe(true);
+          expect(body.queues).toHaveLength(1);
+        });
+
+      expect(after).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'get', route: '/api/queues' }),
+        expect.objectContaining({ body: expect.objectContaining({ queues: expect.any(Array) }) })
+      );
+    });
+
+    it('should not run the after hook when before hook denies', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      const after = jest.fn().mockImplementation((_ctx, result) => result);
+
+      createBullBoard({
+        queues: [new BullMQAdapter(paintQueue)],
+        serverAdapter,
+        options: { hooks: { before: () => ({ allow: false }), after } },
+      });
+
+      await request(serverAdapter.getRouter()).get('/api/queues').expect(403);
+
+      expect(after).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('should behave normally when no hooks are provided', async () => {
+      const paintQueue = new Queue('Paint', { connection });
+      queueList.push(paintQueue);
+
+      createBullBoard({ queues: [new BullMQAdapter(paintQueue)], serverAdapter });
+
+      await request(serverAdapter.getRouter())
+        .get('/api/queues')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then((res) => {
+          const queues = JSON.parse(res.text).queues;
+          expect(queues).toHaveLength(1);
+        });
+    });
+  });
+});

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -9,6 +9,25 @@ export type JobRetryStatus = 'completed' | 'failed';
 
 export type MetricsType = 'completed' | 'failed';
 
+export type HookContext = {
+  method: HTTPMethod;
+  route: string;
+  request: BullBoardRequest;
+};
+
+export type BeforeHookResult = { allow: boolean; status?: HTTPStatus; message?: string } | void;
+
+export type BeforeHook = (context: HookContext) => Promisify<BeforeHookResult>;
+export type AfterHook = (
+  context: HookContext,
+  result: ControllerHandlerReturnType
+) => Promisify<ControllerHandlerReturnType>;
+
+export type BoardHooks = {
+  before?: BeforeHook;
+  after?: AfterHook;
+};
+
 /**
  * Metrics readable from history. Wider than MetricsType, which is also the argument to
  * BullMQ's own getMetrics and must stay limited to what BullMQ buffers.
@@ -405,6 +424,7 @@ export type ControllerHandlerReturnType = {
  * keys through a `t()` typed against that file, so a key it does not know fails the build.
  */
 export type ErrorTranslationKey =
+  | 'ERRORS.FORBIDDEN'
   | 'ERRORS.INTERNAL_SERVER_ERROR'
   | 'ERRORS.INVALID_BEFORE_DATE'
   | 'ERRORS.INVALID_CONCURRENCY'
@@ -514,6 +534,7 @@ export type BoardOptions = {
   uiBasePath?: string;
   uiConfig?: UIConfig;
   historyProvider?: MetricsHistoryProvider;
+  hooks?: BoardHooks;
 };
 
 export type IMiscLink = {

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -15,7 +15,12 @@ export type HookContext = {
   request: BullBoardRequest;
 };
 
-export type BeforeHookResult = { allow: boolean; status?: HTTPStatus; message?: string } | void;
+export type BeforeHookResult = {
+  allow: boolean;
+  status?: HTTPStatus;
+  message?: string;
+  errorKey?: ErrorTranslationKey;
+} | void;
 
 export type BeforeHook = (context: HookContext) => Promisify<BeforeHookResult>;
 export type AfterHook = (
@@ -534,7 +539,7 @@ export type BoardOptions = {
   uiBasePath?: string;
   uiConfig?: UIConfig;
   historyProvider?: MetricsHistoryProvider;
-  hooks?: BoardHooks;
+  handlerHooks?: BoardHooks;
 };
 
 export type IMiscLink = {

--- a/packages/ui/src/static/locales/da-DK/messages.json
+++ b/packages/ui/src/static/locales/da-DK/messages.json
@@ -313,6 +313,7 @@
     "COPY_FAILED": "Kunne ikke kopiere til udklipsholder. Din browser understøtter muligvis ikke denne funktion, eller siden serveres ikke over HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Intern serverfejl",
     "INVALID_BEFORE_DATE": "Ugyldig before: forventede YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Ugyldig værdi for samtidighed",

--- a/packages/ui/src/static/locales/de-DE/messages.json
+++ b/packages/ui/src/static/locales/de-DE/messages.json
@@ -313,6 +313,7 @@
     "COPY_FAILED": "Kopieren in die Zwischenablage fehlgeschlagen. Ihr Browser unterstützt diese Funktion möglicherweise nicht oder die Seite wird nicht über HTTPS bereitgestellt."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Interner Serverfehler",
     "INVALID_BEFORE_DATE": "Ungültiges before: erwartet wird YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Ungültiger Wert für die Parallelität",

--- a/packages/ui/src/static/locales/en-GB/messages.json
+++ b/packages/ui/src/static/locales/en-GB/messages.json
@@ -313,6 +313,7 @@
     "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Internal server error",
     "INVALID_BEFORE_DATE": "Invalid before: expected YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Invalid concurrency value",

--- a/packages/ui/src/static/locales/en-US/messages.json
+++ b/packages/ui/src/static/locales/en-US/messages.json
@@ -310,6 +310,7 @@
     "COPY_FAILED": "Failed to copy to clipboard. Your browser may not support this feature or the page is not served over HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Internal server error",
     "INVALID_BEFORE_DATE": "Invalid before: expected YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Invalid concurrency value",

--- a/packages/ui/src/static/locales/es-ES/messages.json
+++ b/packages/ui/src/static/locales/es-ES/messages.json
@@ -316,6 +316,7 @@
     "COPY_FAILED": "No se pudo copiar al portapapeles. Es posible que tu navegador no admita esta función o que la página no se sirva a través de HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Error interno del servidor",
     "INVALID_BEFORE_DATE": "Valor de before no válido: se esperaba YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Valor de concurrencia no válido",

--- a/packages/ui/src/static/locales/fr-FR/messages.json
+++ b/packages/ui/src/static/locales/fr-FR/messages.json
@@ -316,6 +316,7 @@
     "COPY_FAILED": "Échec de la copie dans le presse-papiers. Votre navigateur peut ne pas prendre en charge cette fonctionnalité ou la page n'est pas servie via HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Erreur interne du serveur",
     "INVALID_BEFORE_DATE": "Valeur before invalide : format YYYY-MM-DD attendu",
     "INVALID_CONCURRENCY": "Valeur de concurrence invalide",

--- a/packages/ui/src/static/locales/ja-JP/messages.json
+++ b/packages/ui/src/static/locales/ja-JP/messages.json
@@ -309,6 +309,7 @@
     "COPY_FAILED": "クリップボードへのコピーに失敗しました。お使いのブラウザがこの機能をサポートしていないか、ページがHTTPSで提供されていない可能性があります。"
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "サーバー内部エラー",
     "INVALID_BEFORE_DATE": "before が不正です。YYYY-MM-DD 形式で指定してください",
     "INVALID_CONCURRENCY": "同時実行数の値が不正です",

--- a/packages/ui/src/static/locales/ko-KR/messages.json
+++ b/packages/ui/src/static/locales/ko-KR/messages.json
@@ -307,6 +307,7 @@
     "COPY_FAILED": "클립보드에 복사하지 못했습니다. 브라우저가 이 기능을 지원하지 않거나 페이지가 HTTPS를 통해 제공되지 않을 수 있습니다."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "서버 내부 오류",
     "INVALID_BEFORE_DATE": "before 값이 올바르지 않습니다. YYYY-MM-DD 형식이어야 합니다",
     "INVALID_CONCURRENCY": "동시성 값이 올바르지 않습니다",

--- a/packages/ui/src/static/locales/pt-BR/messages.json
+++ b/packages/ui/src/static/locales/pt-BR/messages.json
@@ -316,6 +316,7 @@
     "COPY_FAILED": "Falha ao copiar para a área de transferência. Seu navegador pode não suportar este recurso ou a página não está sendo servida via HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Erro interno do servidor",
     "INVALID_BEFORE_DATE": "Valor de before inválido: esperado YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Valor de concorrência inválido",

--- a/packages/ui/src/static/locales/ru-RU/messages.json
+++ b/packages/ui/src/static/locales/ru-RU/messages.json
@@ -319,6 +319,7 @@
     "COPY_FAILED": "Не удалось скопировать в буфер обмена. Возможно, браузер не поддерживает эту функцию или страница открыта не по HTTPS."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Внутренняя ошибка сервера",
     "INVALID_BEFORE_DATE": "Некорректный before: ожидается YYYY-MM-DD",
     "INVALID_CONCURRENCY": "Некорректное значение параллелизма",

--- a/packages/ui/src/static/locales/tr-TR/messages.json
+++ b/packages/ui/src/static/locales/tr-TR/messages.json
@@ -313,6 +313,7 @@
     "COPY_FAILED": "Panoya kopyalanamadı. Tarayıcınız bu özelliği desteklemiyor veya sayfa HTTPS üzerinden sunulmuyor olabilir."
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "Sunucu iç hatası",
     "INVALID_BEFORE_DATE": "Geçersiz before değeri: YYYY-MM-DD bekleniyor",
     "INVALID_CONCURRENCY": "Geçersiz eşzamanlılık değeri",

--- a/packages/ui/src/static/locales/zh-CN/messages.json
+++ b/packages/ui/src/static/locales/zh-CN/messages.json
@@ -307,6 +307,7 @@
     "COPY_FAILED": "复制到剪贴板失败。您的浏览器可能不支持此功能，或者页面未通过 HTTPS 提供服务。"
   },
   "ERRORS": {
+    "FORBIDDEN": "Forbidden",
     "INTERNAL_SERVER_ERROR": "服务器内部错误",
     "INVALID_BEFORE_DATE": "before 无效：应为 YYYY-MM-DD",
     "INVALID_CONCURRENCY": "并发数无效",


### PR DESCRIPTION
## Summary

Adds an optional `hooks` config to `createBullBoard()` for fine-grained, per-request access control — addresses #780.

Rather than a per-handler/per-queue permission system, this implements two generic hook points wired centrally in `createBullBoard` (not duplicated per server adapter), as discussed in #780:

- **`before(context)`** — runs before any API route handler. Can deny the request (`{ allow: false, status?, message? }`), short-circuiting with an error response before the handler runs.
- **`after(context, result)`** — runs after the handler, receives the result, and can modify the response body (e.g. filtering fields a given caller shouldn't see).

Both are fully optional and additive — omitting `hooks` preserves current behavior exactly.

## Example

```ts
createBullBoard({
  queues,
  serverAdapter,
  options: {
    hooks: {
      before: (ctx) => {
        if (isReadOnlyUser(ctx.request) && ctx.method !== 'get') {
          return { allow: false, message: 'Read-only access' };
        }
        return { allow: true };
      },
      after: (ctx, result) => {
        // e.g. strip sensitive fields for certain roles
        return result;
      },
    },
  },
});
```

## Implementation notes

- Wired once in `packages/api/src/index.ts` (wraps `apiRoutes` before `.setApiRoutes()`), so no server adapter package needs changes — works identically across Express/Fastify/Koa/etc.
- Denied requests use the existing `errorResponse()` / `ErrorTranslationKey` convention (added `ERRORS.FORBIDDEN`) rather than a raw string, per the repo's i18n approach. `message` (the caller-supplied reason) is passed through as the existing free-text `message` field.
- Ran `sync:locales` after adding the new key.

## Tests

Added `packages/api/tests/api/hooks.spec.ts` covering:
- before-hook deny (custom message, default message, custom status)
- before-hook allow
- after-hook modifying the response
- after-hook not running when before-hook denies
- backward compatibility with no hooks configured

**Note:** `hooks.spec.ts` occasionally shows `Connection is closed` when run as part of the full suite (isolated runs always pass). This looks like the same Redis-connection teardown flakiness reported in #1374 — unrelated to this feature's logic.

## Open questions for review

- Is `ERRORS.FORBIDDEN` the right key name/place, or should it be scoped differently?
- Happy to extend `after` to also run on the `errorHandler` path if that's useful, currently it only wraps the normal `apiRoutes`.