### PR TITLE
feat(api): widen the BullMQ peer range to ^5.56.0 and test the floor in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -74,9 +74,9 @@ jobs:
         env:
           CI: true
 
-      # Peer majors break types before they break runtime, so the `bullmq` peer range is
-      # checked against both supported majors as well as exercised by the runtime matrix.
-      - name: Typecheck against every supported BullMQ major
+      # Peer versions break types before they break runtime, so the `bullmq` peer range is
+      # checked at both ends as well as exercised by the runtime matrix.
+      - name: Typecheck against the BullMQ peer floor and every supported major
         run: yarn workspace @bull-board/api typecheck:bullmq
 
       - name: Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,20 +45,34 @@ All adapter tests require Redis. `testTimeout` is set to 30 000 ms in each jest 
 
 ## BullMQ version matrix
 
-`@bull-board/api` declares `bullmq` as `^5.79.2 || ^6.0.0`, and both majors are tested on every
-run. `packages/api/jest.config.js` is a `projects` aggregate over three configs:
+`@bull-board/api` declares `bullmq` as `^5.56.0 || ^6.0.0`. Both majors and the exact lower bound
+are tested on every run. `yarn workspace @bull-board/api test` is two `jest` invocations:
+`jest.config.js`, a `projects` aggregate over three configs, followed by
+`jest.config.bullmq-floor.js` on its own.
 
-| Project | Specs | `bullmq` resolves to |
+| Config | Specs | `bullmq` resolves to |
 |---|---|---|
-| `@bull-board/api` | everything except `tests/bullmq-matrix/` | the plain `bullmq` devDependency |
-| `bullmq@5` | `tests/bullmq-matrix/` only | `bullmq-v5` (npm alias) |
-| `bullmq@6` | `tests/bullmq-matrix/` only | `bullmq-v6` (npm alias) |
+| `jest.config.default.js` | everything except `tests/bullmq-matrix/` | the plain `bullmq` devDependency |
+| `jest.config.bullmq-v5.js` | `tests/bullmq-matrix/` only | `bullmq-v5` (npm alias, latest 5.x) |
+| `jest.config.bullmq-v6.js` | `tests/bullmq-matrix/` only | `bullmq-v6` (npm alias, latest 6.x) |
+| `jest.config.bullmq-floor.js` | everything except `tests/bullmq-matrix/` | `bullmq-v5-floor` (npm alias, pinned to 5.56.0) |
 
-The two version projects remap the bare `bullmq` specifier with `moduleNameMapper`, the same
-trick the Express adapter uses for its express@4/express@5 matrix. Subpaths are remapped too, so
+The version configs remap the bare `bullmq` specifier with `moduleNameMapper`, the same trick the
+Express adapter uses for its express@4/express@5 matrix. Subpaths are remapped too, so
 `helpers.ts` can read the resolved major out of `bullmq/package.json`; `assertResolvedMajor()`
 fails the suite if a mapping ever stops applying, which is what stops the matrix from silently
 running one major twice.
+
+The floor config replays the default project's specs, so it cannot be a fourth entry in
+`projects`: two projects driving the same queue names against one Redis race each other. It also
+throws at load if `bullmq-v5-floor` and the first term of the peer range disagree, so the declared
+lower bound cannot drift away from the version that proves it.
+
+The floor is set by what CI can prove, not by whatever the devDependency happened to be. Moving it
+down means finding the lowest version the suite passes on and widening the peer range to match;
+moving it up is a breaking change. As of 5.56.0 the blockers below are BullMQ storing scheduler
+`every` as a string, `upsertJobScheduler` leaving a stale `every` behind when a schedule switches
+to a cron pattern, and `Queue#removeGlobalConcurrency` not existing before 5.41.
 
 v6 differs from v5 in three ways that matter here, all of them covered by the matrix:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ That's it! Now you can access the `/admin/queues` route, and you will be able to
 
 See the [docs](https://felixmosh.github.io/bull-board/) for queue adapter options (read-only, retries, formatters, visibility guard), BullMQ Pro setup, board UI config, and more.
 
-BullMQ v5 and v6 are both supported, including [v6 queues stored in PostgreSQL](https://felixmosh.github.io/bull-board/recipes/postgres-backend). The adapter detects which it has, so there is nothing to configure.
+BullMQ `>= 5.56.0` and all of v6 are supported, including [v6 queues stored in PostgreSQL](https://felixmosh.github.io/bull-board/recipes/postgres-backend). The adapter detects which it has, so there is nothing to configure. See [supported versions](https://felixmosh.github.io/bull-board/queue-adapters/bullmq#supported-versions) for what CI tests and when the floor moves.
 
 ## Historical metrics
 

--- a/packages/api/jest.config.bullmq-floor.js
+++ b/packages/api/jest.config.bullmq-floor.js
@@ -1,0 +1,22 @@
+const { devDependencies, peerDependencies } = require('./package.json');
+const base = require('./jest.base.js');
+
+// Pinned exactly, with no caret, so a dependency bump cannot quietly raise what "the floor"
+// means; the guard below fails the run if the pin and the declared peer range drift apart.
+const pinned = devDependencies['bullmq-v5-floor'].replace('npm:bullmq@', '');
+const declared = peerDependencies.bullmq.split('||')[0].trim().replace(/^\^/, '');
+
+if (pinned !== declared) {
+  throw new Error(
+    `bullmq-v5-floor is pinned to ${pinned} but the bullmq peer range starts at ${declared}. ` +
+      `Pin the alias to the declared floor, or this project tests a version nobody claims to support.`
+  );
+}
+
+module.exports = {
+  ...base,
+  displayName: `bullmq@${pinned} (peer floor)`,
+  testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  testPathIgnorePatterns: [...base.testPathIgnorePatterns, '<rootDir>/tests/bullmq-matrix/'],
+  moduleNameMapper: { '^bullmq$': 'bullmq-v5-floor', '^bullmq/(.*)$': 'bullmq-v5-floor/$1' },
+};

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,6 +1,10 @@
 // Three projects: the existing suite against the plain `bullmq` devDependency, plus the
 // version matrix run twice, once per supported BullMQ major. The matrix is what keeps the
-// `^5.79.2 || ^6.0.0` peer range honest.
+// `^5.56.0 || ^6.0.0` peer range honest.
+//
+// The peer floor runs as its own `jest` invocation from the `test` script rather than a fourth
+// project here: it replays the same spec files as the default project, and two projects driving
+// the same queue names against one Redis race each other.
 module.exports = {
   // Three projects at full width oversubscribe the machine, and BullMQ surfaces that as
   // "Connection is closed" unhandled errors while a suite is tearing down its Redis clients.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,9 +40,9 @@
   "scripts": {
     "build": "yarn clean && tsc",
     "clean": "rm -rf dist",
-    "test": "jest",
+    "test": "jest && jest --config jest.config.bullmq-floor.js",
     "test:coverage": "jest --config jest.config.coverage.js",
-    "typecheck:bullmq": "tsc -p tsconfig.bullmq-v5.json && tsc -p tsconfig.bullmq-v6.json"
+    "typecheck:bullmq": "tsc -p tsconfig.bullmq-floor.json && tsc -p tsconfig.bullmq-v5.json && tsc -p tsconfig.bullmq-v6.json"
   },
   "dependencies": {
     "redis-info": "^3.1.0"
@@ -55,6 +55,7 @@
     "bull": "^4.16.5",
     "bullmq": "^5.81.3",
     "bullmq-v5": "npm:bullmq@^5",
+    "bullmq-v5-floor": "npm:bullmq@5.56.0",
     "bullmq-v6": "npm:bullmq@^6",
     "ioredis": "^6.0.0",
     "jest": "^30.4.2",
@@ -65,7 +66,7 @@
   "peerDependencies": {
     "@bull-board/ui": "9.4.0",
     "bull": "^4.16.5",
-    "bullmq": "^5.79.2 || ^6.0.0"
+    "bullmq": "^5.56.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "bull": {

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -10,6 +10,7 @@ import {
   ObliterateOptions,
   QueueAdapterOptions,
   QueueDefaultJobOptions,
+  QueueJob,
   QueueJobOptions,
   QueueMetrics,
   QueueWorker,
@@ -177,6 +178,26 @@ export class BullMQAdapter extends BaseAdapter {
 
   public removeJobScheduler(id: string): Promise<boolean> {
     return this.queue.removeJobScheduler(id);
+  }
+
+  /**
+   * Worked out from the ids BullMQ derives rather than from the error `Job#remove` raises, whose
+   * numeric code only exists in newer BullMQ. Removing the run a scheduler is waiting on would
+   * leave the scheduler registered and unable to fire again; past runs of the same scheduler carry
+   * the same `repeatJobKey` and are ordinary jobs.
+   */
+  public override async getArmedJobSchedulerId(job: QueueJob): Promise<string | null> {
+    const { id, repeatJobKey } = job as Job;
+
+    if (!id || !repeatJobKey) {
+      return null;
+    }
+
+    const scheduler = await this.queue.getJobScheduler(repeatJobKey).catch(() => null);
+
+    return scheduler?.next && this.schedulerRunId(repeatJobKey, scheduler.next) === id
+      ? repeatJobKey
+      : null;
   }
 
   public async getJobSchedulers(): Promise<Omit<AppJobScheduler, 'queueName'>[]> {

--- a/packages/api/tests/types/adapter-accepts-queue.ts
+++ b/packages/api/tests/types/adapter-accepts-queue.ts
@@ -1,5 +1,5 @@
 /**
- * Compile-only gate for the `bullmq: ^5.79.2 || ^6.0.0` peer range, run once per major by
+ * Compile-only gate for the `bullmq: ^5.56.0 || ^6.0.0` peer range, run once per major by
  * `yarn typecheck:bullmq`. Nothing here executes, and it needs `yarn build` first because it
  * checks the built `dist/` typings, which is what an installing project compiles against.
  *

--- a/packages/api/tsconfig.bullmq-floor.json
+++ b/packages/api/tsconfig.bullmq-floor.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "sourceMap": false,
+    "rootDir": ".",
+    "paths": {
+      "bullmq": ["../../node_modules/bullmq-v5-floor"]
+    }
+  },
+  "include": ["./tests/types"]
+}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -9,6 +9,6 @@
     "@bull-board/api": "9.4.0"
   },
   "peerDependencies": {
-    "bullmq": "^5.79.2 || ^6.0.0"
+    "bullmq": "^5.56.0 || ^6.0.0"
   }
 }

--- a/website/docs/queue-adapters/bullmq.md
+++ b/website/docs/queue-adapters/bullmq.md
@@ -4,12 +4,30 @@ For the [BullMQ](https://docs.bullmq.io/) queue library.
 
 ## Supported versions
 
-BullMQ **v5 and v6** both work, and the adapter figures out which one it is holding. Nothing to configure.
+`@bull-board/api` declares its BullMQ peer as `^5.56.0 || ^6.0.0`, and the adapter figures out which one it is holding. Nothing to configure.
 
 Two v6 changes are visible in the dashboard:
 
 - **No Paused tab.** v6 removed the paused job state. A paused queue's jobs are stored as `waiting`, so that is where the dashboard shows them. The queue still displays its paused banner and the pause and resume buttons still work.
 - **PostgreSQL queues are supported.** v6 can run on Postgres instead of Redis. See [PostgreSQL backend](/recipes/postgres-backend).
+
+### Support policy
+
+Three BullMQ versions run the full `@bull-board/api` suite on every commit:
+
+| Tested version | Why |
+|---|---|
+| `5.56.0` | The exact lower bound of the peer range, pinned with no caret. |
+| latest `5.x` | The version most installs resolve to. |
+| latest `6.x` | The current major. |
+
+The lower bound is a tested claim rather than a guess: `packages/api/jest.config.bullmq-floor.js` refuses to run if the pinned alias and the declared peer range disagree, so the range cannot be widened without the suite following it down.
+
+Below `5.56.0` the dashboard still starts and still lists, inspects and retries jobs, but three things break, which is why the range stops where it does. Job schedulers report `every` as a string instead of a number, so the interval column is wrong and the previous run cannot be named. Rewriting a schedule from an interval to a cron pattern leaves the old interval behind in Redis, so the scheduler ends up storing both. Versions before 5.41 have no `Queue#removeGlobalConcurrency`, so clearing a global concurrency limit silently does nothing.
+
+Anything at or above `5.56.0` gets every feature. If you are pinned lower and something on that list matters to you, open an issue rather than assuming the floor is fixed: it is set by what CI can prove, and it moves down whenever a fix makes a lower version pass.
+
+Raising the floor is a breaking change and only happens in a major release of `@bull-board/api`.
 
 ## Import
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,7 @@ __metadata:
     bull: "npm:^4.16.5"
     bullmq: "npm:^5.81.3"
     bullmq-v5: "npm:bullmq@^5"
+    bullmq-v5-floor: "npm:bullmq@5.56.0"
     bullmq-v6: "npm:bullmq@^6"
     ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
@@ -485,7 +486,7 @@ __metadata:
   peerDependencies:
     "@bull-board/ui": 9.4.0
     bull: ^4.16.5
-    bullmq: ^5.79.2 || ^6.0.0
+    bullmq: ^5.56.0 || ^6.0.0
   peerDependenciesMeta:
     bull:
       optional: true
@@ -764,7 +765,7 @@ __metadata:
   dependencies:
     "@bull-board/api": "npm:9.4.0"
   peerDependencies:
-    bullmq: ^5.79.2 || ^6.0.0
+    bullmq: ^5.56.0 || ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -6106,6 +6107,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bullmq-v5-floor@npm:bullmq@5.56.0":
+  version: 5.56.0
+  resolution: "bullmq@npm:5.56.0"
+  dependencies:
+    cron-parser: "npm:^4.9.0"
+    ioredis: "npm:^5.4.1"
+    msgpackr: "npm:^1.11.2"
+    node-abort-controller: "npm:^3.1.1"
+    semver: "npm:^7.5.4"
+    tslib: "npm:^2.0.0"
+    uuid: "npm:^9.0.0"
+  checksum: 10c0/77cbe1170ec0bea2b305fd435f17c316b21d75414bf48ff1e06f997444b4f43461d6a388d8f331186b49c0ceafc5ab86f5109a33ee7825fef8a5a9cc7fa7c424
+  languageName: node
+  linkType: hard
+
 "bullmq-v5@npm:bullmq@^5, bullmq@npm:^5.81.3":
   version: 5.81.3
   resolution: "bullmq@npm:5.81.3"
@@ -9434,7 +9450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:5.11.1, ioredis@npm:^5.3.2":
+"ioredis@npm:5.11.1, ioredis@npm:^5.3.2, ioredis@npm:^5.4.1":
   version: 5.11.1
   resolution: "ioredis@npm:5.11.1"
   dependencies:
@@ -12241,7 +12257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-abort-controller@npm:3.1.1":
+"node-abort-controller@npm:3.1.1, node-abort-controller@npm:^3.1.1":
   version: 3.1.1
   resolution: "node-abort-controller@npm:3.1.1"
   checksum: 10c0/f7ad0e7a8e33809d4f3a0d1d65036a711c39e9d23e0319d80ebe076b9a3b4432b4d6b86a7fab65521de3f6872ffed36fc35d1327487c48eb88c517803403eda3
@@ -16106,6 +16122,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #1097.

The peer range was never chosen. #1266 declared it as `^5.79.2` by copying whatever the devDependency happened to be that afternoon, so the lower bound is a claim CI has never tested, which is what this issue was opened about. It is also far narrower than the truth: `^5.79.2 || ^6.0.0` accepts 33.5% of BullMQ installs, so two thirds of the ecosystem gets a peer warning for a version that works fine.

This widens it to `^5.56.0 || ^6.0.0`, which accepts 88.3%, and makes CI prove the new bound on every commit.

## Finding the real floor

I pinned an npm alias to a series of releases and ran the whole `packages/api` suite, 224 tests, against each one, twice per version with Redis flushed in between.

| bullmq | failures | `GET /api/queues` |
|---|---|---|
| 5.60.0 and up | 0 | 200 |
| 5.58.0, 5.56.0 | 1 | 200 |
| 5.52.0 | 3 | 200 |
| 5.44.0 | 4 | 200 |
| 5.36.0 | 13 | 200 |
| 5.29.0 | 35 | 500 |
| 4.18.3 | 55 | 500 |

The cliff at 5.30 is `Queue#getJobSchedulersCount`, which the queue listing calls on every poll. Below it the board does not degrade, it stops: the endpoint the whole UI is built on 500s, and the same is true of every v4 release. Above 5.36 the picture is genuinely partial instead, individual features misbehaving on a working board.

## The one fix

The single failure at 5.56.0 and 5.58.0 was ours rather than BullMQ's. `cleanJob` refuses to delete the run a scheduler is waiting on, because removing it leaves the schedule registered and unable to fire again. `BullAdapter` answers that through `getArmedJobSchedulerId`. `BullMQAdapter` never overrode it, so the handler fell back to sniffing BullMQ's numeric error code `-8` off the thrown error, and that code does not exist before 5.59. Without it the request 500s instead of returning the 400 that names the scheduler.

The override works it out the way the schedulers view already does, from the ids BullMQ derives:

```ts
const scheduler = await this.queue.getJobScheduler(repeatJobKey).catch(() => null);

return scheduler?.next && this.schedulerRunId(repeatJobKey, scheduler.next) === id
  ? repeatJobKey
  : null;
```

The armed run is `repeat:<schedulerId>:<scheduler.next>`. Past runs of the same scheduler carry the same `repeatJobKey` and are ordinary jobs that should still delete, which the id comparison gets right and the error code never distinguished. That is what moves the floor from 5.60.0 to 5.56.0, and it makes the guard deterministic on every version rather than dependent on an undocumented number.

## Why it stops at 5.56 and not lower

The table above suggests 5.52 is three small fixes away and 5.44 is four, so I built them and measured, and the gain turned out not to be real.

Two of those failures are BullMQ storing a scheduler's `every` as a string and leaving the old `every` behind when a schedule is rewritten as a cron pattern, both of which the adapter can normalise away. The third is `FlowProducer#getFlow` ignoring a custom `prefix` and answering with a childless root between 5.44 and 5.48, which is upstream and fixed in 5.50.

The one that matters is the fourth, which is not in the table because it only shows up under load. Below 5.55, BullMQ's scheduler skips a slot whenever a worker is late, so `scheduler.next - every` names a run that never existed and `findLastRunId` cannot name the previous run. Measured over 20 runs of an interval schedule with a real worker:

| bullmq | runs with no job at `next - every` |
|---|---|
| 5.50.0 | 3/20 |
| 5.53.0 | 3/20 |
| 5.54.0 | 4/30 |
| 5.55.0 | 0/20 |
| 5.56.0 | 0/20 |
| 5.81.3 | 0/20 |

So the lowest version where the board actually works is 5.55.0, worth 88.4% against 5.56.0's 88.3%. One tenth of a point, for a fix that only papers over versions where the previous-run link is genuinely unreliable. I dropped it and left the floor at 5.56.0.

Below that, 5.36 is 91.0% and costs a `supportsGlobalConcurrency` capability plus the UI work to hide a control that currently no-ops silently, and an existence check so a `PATCH` to a mistyped scheduler id answers 404 instead of creating a schedule. Below 5.30 it is a second scheduler backend on the repeatable API. Both are written into the docs so nobody has to rediscover them.

## Keeping the floor honest

`jest.config.bullmq-floor.js` replays the whole default suite against `bullmq-v5-floor`, an alias pinned to exactly `5.56.0` with no caret so a dependency bump cannot quietly redefine what the floor means. It throws at load if that pin and the first term of the peer range disagree, so the declared bound cannot drift from the version that proves it. `tsconfig.bullmq-floor.json` joins `typecheck:bullmq` for the same reason one level up.

It runs as its own `jest` invocation from the `test` script rather than a fourth entry in `projects`. My first attempt made it a fourth project and the suite went red: it replays the default project's spec files, and two projects driving the same queue names against one Redis obliterate each other's fixtures. Sequential costs about 13 seconds.

## Docs

`website/docs/queue-adapters/bullmq.md` gains a support policy under Supported versions: the three versions CI runs, what breaks below the floor, that the floor moves down whenever a fix makes a lower version pass, and that raising it is a breaking change. That is the half of #1097 asking for a stated policy with real ranges rather than "latest". README and `CLAUDE.md` follow.

## Tests

The floor project is its own positive control. Remove the `getArmedJobSchedulerId` override and it fails with exactly the one scheduler failure it was added for, while the default, `bullmq@5` and `bullmq@6` projects stay green, which is the point: this is a version the suite could not previously see.

`yarn build`, `yarn lint:check`, `yarn format:check`, `typecheck:bullmq`, the full `yarn test` across every workspace and `yarn test:ui` are green locally against Redis and PostgreSQL.

`packages/metrics` gets no floor project. It declares no `bullmq` peer of its own and inherits the range through `@bull-board/api`, and its suite is serial, so a second full pass there costs more than it would prove.
