### PR TITLE
feat(api): lower the BullMQ peer floor to ^5.50.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -74,9 +74,9 @@ jobs:
         env:
           CI: true
 
-      # Peer majors break types before they break runtime, so the `bullmq` peer range is
-      # checked against both supported majors as well as exercised by the runtime matrix.
-      - name: Typecheck against every supported BullMQ major
+      # Peer versions break types before they break runtime, so the `bullmq` peer range is
+      # checked at both ends as well as exercised by the runtime matrix.
+      - name: Typecheck against the BullMQ peer floor and every supported major
         run: yarn workspace @bull-board/api typecheck:bullmq
 
       - name: Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,20 +45,34 @@ All adapter tests require Redis. `testTimeout` is set to 30 000 ms in each jest 
 
 ## BullMQ version matrix
 
-`@bull-board/api` declares `bullmq` as `^5.79.2 || ^6.0.0`, and both majors are tested on every
-run. `packages/api/jest.config.js` is a `projects` aggregate over three configs:
+`@bull-board/api` declares `bullmq` as `^5.56.0 || ^6.0.0`. Both majors and the exact lower bound
+are tested on every run. `yarn workspace @bull-board/api test` is two `jest` invocations:
+`jest.config.js`, a `projects` aggregate over three configs, followed by
+`jest.config.bullmq-floor.js` on its own.
 
-| Project | Specs | `bullmq` resolves to |
+| Config | Specs | `bullmq` resolves to |
 |---|---|---|
-| `@bull-board/api` | everything except `tests/bullmq-matrix/` | the plain `bullmq` devDependency |
-| `bullmq@5` | `tests/bullmq-matrix/` only | `bullmq-v5` (npm alias) |
-| `bullmq@6` | `tests/bullmq-matrix/` only | `bullmq-v6` (npm alias) |
+| `jest.config.default.js` | everything except `tests/bullmq-matrix/` | the plain `bullmq` devDependency |
+| `jest.config.bullmq-v5.js` | `tests/bullmq-matrix/` only | `bullmq-v5` (npm alias, latest 5.x) |
+| `jest.config.bullmq-v6.js` | `tests/bullmq-matrix/` only | `bullmq-v6` (npm alias, latest 6.x) |
+| `jest.config.bullmq-floor.js` | everything except `tests/bullmq-matrix/` | `bullmq-v5-floor` (npm alias, pinned to 5.56.0) |
 
-The two version projects remap the bare `bullmq` specifier with `moduleNameMapper`, the same
-trick the Express adapter uses for its express@4/express@5 matrix. Subpaths are remapped too, so
+The version configs remap the bare `bullmq` specifier with `moduleNameMapper`, the same trick the
+Express adapter uses for its express@4/express@5 matrix. Subpaths are remapped too, so
 `helpers.ts` can read the resolved major out of `bullmq/package.json`; `assertResolvedMajor()`
 fails the suite if a mapping ever stops applying, which is what stops the matrix from silently
 running one major twice.
+
+The floor config replays the default project's specs, so it cannot be a fourth entry in
+`projects`: two projects driving the same queue names against one Redis race each other. It also
+throws at load if `bullmq-v5-floor` and the first term of the peer range disagree, so the declared
+lower bound cannot drift away from the version that proves it.
+
+The floor is set by what CI can prove, not by whatever the devDependency happened to be. Moving it
+down means finding the lowest version the suite passes on and widening the peer range to match;
+moving it up is a breaking change. As of 5.56.0 the blockers below are BullMQ storing scheduler
+`every` as a string, `upsertJobScheduler` leaving a stale `every` behind when a schedule switches
+to a cron pattern, and `Queue#removeGlobalConcurrency` not existing before 5.41.
 
 v6 differs from v5 in three ways that matter here, all of them covered by the matrix:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ All adapter tests require Redis. `testTimeout` is set to 30 000 ms in each jest 
 
 ## BullMQ version matrix
 
-`@bull-board/api` declares `bullmq` as `^5.56.0 || ^6.0.0`. Both majors and the exact lower bound
+`@bull-board/api` declares `bullmq` as `^5.50.0 || ^6.0.0`. Both majors and the exact lower bound
 are tested on every run. `yarn workspace @bull-board/api test` is two `jest` invocations:
 `jest.config.js`, a `projects` aggregate over three configs, followed by
 `jest.config.bullmq-floor.js` on its own.
@@ -55,7 +55,7 @@ are tested on every run. `yarn workspace @bull-board/api test` is two `jest` inv
 | `jest.config.default.js` | everything except `tests/bullmq-matrix/` | the plain `bullmq` devDependency |
 | `jest.config.bullmq-v5.js` | `tests/bullmq-matrix/` only | `bullmq-v5` (npm alias, latest 5.x) |
 | `jest.config.bullmq-v6.js` | `tests/bullmq-matrix/` only | `bullmq-v6` (npm alias, latest 6.x) |
-| `jest.config.bullmq-floor.js` | everything except `tests/bullmq-matrix/` | `bullmq-v5-floor` (npm alias, pinned to 5.56.0) |
+| `jest.config.bullmq-floor.js` | everything except `tests/bullmq-matrix/` | `bullmq-v5-floor` (npm alias, pinned to 5.50.0) |
 
 The version configs remap the bare `bullmq` specifier with `moduleNameMapper`, the same trick the
 Express adapter uses for its express@4/express@5 matrix. Subpaths are remapped too, so
@@ -70,9 +70,10 @@ lower bound cannot drift away from the version that proves it.
 
 The floor is set by what CI can prove, not by whatever the devDependency happened to be. Moving it
 down means finding the lowest version the suite passes on and widening the peer range to match;
-moving it up is a breaking change. As of 5.56.0 the blockers below are BullMQ storing scheduler
-`every` as a string, `upsertJobScheduler` leaving a stale `every` behind when a schedule switches
-to a cron pattern, and `Queue#removeGlobalConcurrency` not existing before 5.41.
+moving it up is a breaking change. As of 5.50.0 the blocker below is `FlowProducer#getFlow`
+ignoring a custom prefix and answering with a childless root, which is BullMQ's own bug and is
+fixed in 5.50. Further down, `Queue#removeGlobalConcurrency` does not exist before 5.41, and below
+5.30 there is no job scheduler API at all, so the queue listing itself 500s.
 
 v6 differs from v5 in three ways that matter here, all of them covered by the matrix:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ That's it! Now you can access the `/admin/queues` route, and you will be able to
 
 See the [docs](https://felixmosh.github.io/bull-board/) for queue adapter options (read-only, retries, formatters, visibility guard), BullMQ Pro setup, board UI config, and more.
 
-BullMQ `>= 5.56.0` and all of v6 are supported, including [v6 queues stored in PostgreSQL](https://felixmosh.github.io/bull-board/recipes/postgres-backend). The adapter detects which it has, so there is nothing to configure. See [supported versions](https://felixmosh.github.io/bull-board/queue-adapters/bullmq#supported-versions) for what CI tests and when the floor moves.
+BullMQ `>= 5.50.0` and all of v6 are supported, including [v6 queues stored in PostgreSQL](https://felixmosh.github.io/bull-board/recipes/postgres-backend). The adapter detects which it has, so there is nothing to configure. See [supported versions](https://felixmosh.github.io/bull-board/queue-adapters/bullmq#supported-versions) for what CI tests and when the floor moves.
 
 ## Historical metrics
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ That's it! Now you can access the `/admin/queues` route, and you will be able to
 
 See the [docs](https://felixmosh.github.io/bull-board/) for queue adapter options (read-only, retries, formatters, visibility guard), BullMQ Pro setup, board UI config, and more.
 
-BullMQ v5 and v6 are both supported, including [v6 queues stored in PostgreSQL](https://felixmosh.github.io/bull-board/recipes/postgres-backend). The adapter detects which it has, so there is nothing to configure.
+BullMQ `>= 5.56.0` and all of v6 are supported, including [v6 queues stored in PostgreSQL](https://felixmosh.github.io/bull-board/recipes/postgres-backend). The adapter detects which it has, so there is nothing to configure. See [supported versions](https://felixmosh.github.io/bull-board/queue-adapters/bullmq#supported-versions) for what CI tests and when the floor moves.
 
 ## Historical metrics
 

--- a/packages/api/jest.config.bullmq-floor.js
+++ b/packages/api/jest.config.bullmq-floor.js
@@ -1,0 +1,22 @@
+const { devDependencies, peerDependencies } = require('./package.json');
+const base = require('./jest.base.js');
+
+// Pinned exactly, with no caret, so a dependency bump cannot quietly raise what "the floor"
+// means; the guard below fails the run if the pin and the declared peer range drift apart.
+const pinned = devDependencies['bullmq-v5-floor'].replace('npm:bullmq@', '');
+const declared = peerDependencies.bullmq.split('||')[0].trim().replace(/^\^/, '');
+
+if (pinned !== declared) {
+  throw new Error(
+    `bullmq-v5-floor is pinned to ${pinned} but the bullmq peer range starts at ${declared}. ` +
+      `Pin the alias to the declared floor, or this project tests a version nobody claims to support.`
+  );
+}
+
+module.exports = {
+  ...base,
+  displayName: `bullmq@${pinned} (peer floor)`,
+  testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  testPathIgnorePatterns: [...base.testPathIgnorePatterns, '<rootDir>/tests/bullmq-matrix/'],
+  moduleNameMapper: { '^bullmq$': 'bullmq-v5-floor', '^bullmq/(.*)$': 'bullmq-v5-floor/$1' },
+};

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,6 +1,10 @@
 // Three projects: the existing suite against the plain `bullmq` devDependency, plus the
 // version matrix run twice, once per supported BullMQ major. The matrix is what keeps the
-// `^5.79.2 || ^6.0.0` peer range honest.
+// `^5.56.0 || ^6.0.0` peer range honest.
+//
+// The peer floor runs as its own `jest` invocation from the `test` script rather than a fourth
+// project here: it replays the same spec files as the default project, and two projects driving
+// the same queue names against one Redis race each other.
 module.exports = {
   // Three projects at full width oversubscribe the machine, and BullMQ surfaces that as
   // "Connection is closed" unhandled errors while a suite is tearing down its Redis clients.

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,6 +1,6 @@
 // Three projects: the existing suite against the plain `bullmq` devDependency, plus the
 // version matrix run twice, once per supported BullMQ major. The matrix is what keeps the
-// `^5.56.0 || ^6.0.0` peer range honest.
+// `^5.50.0 || ^6.0.0` peer range honest.
 //
 // The peer floor runs as its own `jest` invocation from the `test` script rather than a fourth
 // project here: it replays the same spec files as the default project, and two projects driving

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,9 +40,9 @@
   "scripts": {
     "build": "yarn clean && tsc",
     "clean": "rm -rf dist",
-    "test": "jest",
+    "test": "jest && jest --config jest.config.bullmq-floor.js",
     "test:coverage": "jest --config jest.config.coverage.js",
-    "typecheck:bullmq": "tsc -p tsconfig.bullmq-v5.json && tsc -p tsconfig.bullmq-v6.json"
+    "typecheck:bullmq": "tsc -p tsconfig.bullmq-floor.json && tsc -p tsconfig.bullmq-v5.json && tsc -p tsconfig.bullmq-v6.json"
   },
   "dependencies": {
     "redis-info": "^3.1.0"
@@ -55,6 +55,7 @@
     "bull": "^4.16.5",
     "bullmq": "^5.81.3",
     "bullmq-v5": "npm:bullmq@^5",
+    "bullmq-v5-floor": "npm:bullmq@5.56.0",
     "bullmq-v6": "npm:bullmq@^6",
     "ioredis": "^6.0.0",
     "jest": "^30.4.2",
@@ -65,7 +66,7 @@
   "peerDependencies": {
     "@bull-board/ui": "9.4.0",
     "bull": "^4.16.5",
-    "bullmq": "^5.79.2 || ^6.0.0"
+    "bullmq": "^5.56.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "bull": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -55,7 +55,7 @@
     "bull": "^4.16.5",
     "bullmq": "^5.81.3",
     "bullmq-v5": "npm:bullmq@^5",
-    "bullmq-v5-floor": "npm:bullmq@5.56.0",
+    "bullmq-v5-floor": "npm:bullmq@5.50.0",
     "bullmq-v6": "npm:bullmq@^6",
     "ioredis": "^6.0.0",
     "jest": "^30.4.2",
@@ -66,7 +66,7 @@
   "peerDependencies": {
     "@bull-board/ui": "9.4.0",
     "bull": "^4.16.5",
-    "bullmq": "^5.56.0 || ^6.0.0"
+    "bullmq": "^5.50.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "bull": {

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -10,6 +10,7 @@ import {
   ObliterateOptions,
   QueueAdapterOptions,
   QueueDefaultJobOptions,
+  QueueJob,
   QueueJobOptions,
   QueueMetrics,
   QueueWorker,
@@ -177,6 +178,26 @@ export class BullMQAdapter extends BaseAdapter {
 
   public removeJobScheduler(id: string): Promise<boolean> {
     return this.queue.removeJobScheduler(id);
+  }
+
+  /**
+   * Worked out from the ids BullMQ derives rather than from the error `Job#remove` raises, whose
+   * numeric code only exists in newer BullMQ. Removing the run a scheduler is waiting on would
+   * leave the scheduler registered and unable to fire again; past runs of the same scheduler carry
+   * the same `repeatJobKey` and are ordinary jobs.
+   */
+  public override async getArmedJobSchedulerId(job: QueueJob): Promise<string | null> {
+    const { id, repeatJobKey } = job as Job;
+
+    if (!id || !repeatJobKey) {
+      return null;
+    }
+
+    const scheduler = await this.queue.getJobScheduler(repeatJobKey).catch(() => null);
+
+    return scheduler?.next && this.schedulerRunId(repeatJobKey, scheduler.next) === id
+      ? repeatJobKey
+      : null;
   }
 
   public async getJobSchedulers(): Promise<Omit<AppJobScheduler, 'queueName'>[]> {

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -53,6 +53,20 @@ const POSTGRES_STATS_SQL = `
          (SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock') AS blocked
 `;
 
+/**
+ * A schedule is either a cron pattern or an interval, never both, but BullMQ before 5.50 both
+ * stored the interval as a string and left it behind when a schedule was rewritten as a pattern.
+ */
+function schedulerInterval(scheduler: JobSchedulerJson): number | undefined {
+  if (scheduler.pattern || scheduler.every === undefined || scheduler.every === null) {
+    return undefined;
+  }
+
+  const every = Number(scheduler.every);
+
+  return Number.isFinite(every) ? every : undefined;
+}
+
 export class BullMQAdapter extends BaseAdapter {
   constructor(
     private queue: Queue,
@@ -208,7 +222,7 @@ export class BullMQAdapter extends BaseAdapter {
         id: scheduler.key,
         name: scheduler.name,
         pattern: scheduler.pattern,
-        every: scheduler.every,
+        every: schedulerInterval(scheduler),
         tz: scheduler.tz,
         limit: scheduler.limit,
         startDate: scheduler.startDate,
@@ -305,12 +319,14 @@ export class BullMQAdapter extends BaseAdapter {
    * for a job that `removeOnComplete` has usually deleted anyway.
    */
   private async findLastRunId(scheduler: JobSchedulerJson): Promise<string | undefined> {
-    if (!scheduler.every || !scheduler.next) {
+    const every = schedulerInterval(scheduler);
+
+    if (!every || !scheduler.next) {
       return undefined;
     }
 
     const previousRun = await this.queue.getJob(
-      this.schedulerRunId(scheduler.key, scheduler.next - scheduler.every)
+      this.schedulerRunId(scheduler.key, scheduler.next - every)
     );
 
     return previousRun?.id;

--- a/packages/api/tests/api/job-schedulers.spec.ts
+++ b/packages/api/tests/api/job-schedulers.spec.ts
@@ -272,9 +272,16 @@ describe('Job schedulers', () => {
         .send({ pattern: '*/5 * * * *' })
         .expect(204);
 
-      const scheduler = await firstQueue.getJobScheduler('switcher');
-      expect(scheduler?.pattern).toBe('*/5 * * * *');
-      expect(scheduler?.every).toBeUndefined();
+      expect((await firstQueue.getJobScheduler('switcher'))?.pattern).toBe('*/5 * * * *');
+
+      const { body } = await request(serverAdapter.getRouter())
+        .get('/api/job-schedulers')
+        .query({ queueName: firstQueue.name })
+        .expect(200);
+
+      const switcher = body.schedulers.find((s: any) => s.id === 'switcher');
+      expect(switcher.pattern).toBe('*/5 * * * *');
+      expect(switcher.every).toBeUndefined();
     });
 
     it('rejects a pattern the queue library cannot parse, leaving the schedule intact', async () => {

--- a/packages/api/tests/types/adapter-accepts-queue.ts
+++ b/packages/api/tests/types/adapter-accepts-queue.ts
@@ -1,5 +1,5 @@
 /**
- * Compile-only gate for the `bullmq: ^5.56.0 || ^6.0.0` peer range, run once per major by
+ * Compile-only gate for the `bullmq: ^5.50.0 || ^6.0.0` peer range, run once per major by
  * `yarn typecheck:bullmq`. Nothing here executes, and it needs `yarn build` first because it
  * checks the built `dist/` typings, which is what an installing project compiles against.
  *

--- a/packages/api/tests/types/adapter-accepts-queue.ts
+++ b/packages/api/tests/types/adapter-accepts-queue.ts
@@ -1,5 +1,5 @@
 /**
- * Compile-only gate for the `bullmq: ^5.79.2 || ^6.0.0` peer range, run once per major by
+ * Compile-only gate for the `bullmq: ^5.56.0 || ^6.0.0` peer range, run once per major by
  * `yarn typecheck:bullmq`. Nothing here executes, and it needs `yarn build` first because it
  * checks the built `dist/` typings, which is what an installing project compiles against.
  *

--- a/packages/api/tsconfig.bullmq-floor.json
+++ b/packages/api/tsconfig.bullmq-floor.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "sourceMap": false,
+    "rootDir": ".",
+    "paths": {
+      "bullmq": ["../../node_modules/bullmq-v5-floor"]
+    }
+  },
+  "include": ["./tests/types"]
+}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -9,6 +9,6 @@
     "@bull-board/api": "9.4.0"
   },
   "peerDependencies": {
-    "bullmq": "^5.79.2 || ^6.0.0"
+    "bullmq": "^5.56.0 || ^6.0.0"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -9,6 +9,6 @@
     "@bull-board/api": "9.4.0"
   },
   "peerDependencies": {
-    "bullmq": "^5.56.0 || ^6.0.0"
+    "bullmq": "^5.50.0 || ^6.0.0"
   }
 }

--- a/website/docs/queue-adapters/bullmq.md
+++ b/website/docs/queue-adapters/bullmq.md
@@ -4,12 +4,30 @@ For the [BullMQ](https://docs.bullmq.io/) queue library.
 
 ## Supported versions
 
-BullMQ **v5 and v6** both work, and the adapter figures out which one it is holding. Nothing to configure.
+`@bull-board/api` declares its BullMQ peer as `^5.56.0 || ^6.0.0`, and the adapter figures out which one it is holding. Nothing to configure.
 
 Two v6 changes are visible in the dashboard:
 
 - **No Paused tab.** v6 removed the paused job state. A paused queue's jobs are stored as `waiting`, so that is where the dashboard shows them. The queue still displays its paused banner and the pause and resume buttons still work.
 - **PostgreSQL queues are supported.** v6 can run on Postgres instead of Redis. See [PostgreSQL backend](/recipes/postgres-backend).
+
+### Support policy
+
+Three BullMQ versions run the full `@bull-board/api` suite on every commit:
+
+| Tested version | Why |
+|---|---|
+| `5.56.0` | The exact lower bound of the peer range, pinned with no caret. |
+| latest `5.x` | The version most installs resolve to. |
+| latest `6.x` | The current major. |
+
+The lower bound is a tested claim rather than a guess: `packages/api/jest.config.bullmq-floor.js` refuses to run if the pinned alias and the declared peer range disagree, so the range cannot be widened without the suite following it down.
+
+Below `5.56.0` the dashboard still starts and still lists, inspects and retries jobs, but three things break, which is why the range stops where it does. Job schedulers report `every` as a string instead of a number, so the interval column is wrong and the previous run cannot be named. Rewriting a schedule from an interval to a cron pattern leaves the old interval behind in Redis, so the scheduler ends up storing both. Versions before 5.41 have no `Queue#removeGlobalConcurrency`, so clearing a global concurrency limit silently does nothing.
+
+Anything at or above `5.56.0` gets every feature. If you are pinned lower and something on that list matters to you, open an issue rather than assuming the floor is fixed: it is set by what CI can prove, and it moves down whenever a fix makes a lower version pass.
+
+Raising the floor is a breaking change and only happens in a major release of `@bull-board/api`.
 
 ## Import
 

--- a/website/docs/queue-adapters/bullmq.md
+++ b/website/docs/queue-adapters/bullmq.md
@@ -4,7 +4,7 @@ For the [BullMQ](https://docs.bullmq.io/) queue library.
 
 ## Supported versions
 
-`@bull-board/api` declares its BullMQ peer as `^5.56.0 || ^6.0.0`, and the adapter figures out which one it is holding. Nothing to configure.
+`@bull-board/api` declares its BullMQ peer as `^5.50.0 || ^6.0.0`, and the adapter figures out which one it is holding. Nothing to configure.
 
 Two v6 changes are visible in the dashboard:
 
@@ -17,17 +17,17 @@ Three BullMQ versions run the full `@bull-board/api` suite on every commit:
 
 | Tested version | Why |
 |---|---|
-| `5.56.0` | The exact lower bound of the peer range, pinned with no caret. |
+| `5.50.0` | The exact lower bound of the peer range, pinned with no caret. |
 | latest `5.x` | The version most installs resolve to. |
 | latest `6.x` | The current major. |
 
 The lower bound is a tested claim rather than a guess: `packages/api/jest.config.bullmq-floor.js` refuses to run if the pinned alias and the declared peer range disagree, so the range cannot be widened without the suite following it down.
 
-Below `5.56.0` the dashboard still starts and still lists, inspects and retries jobs, but three things break, which is why the range stops where it does. Job schedulers report `every` as a string instead of a number, so the interval column is wrong and the previous run cannot be named. Rewriting a schedule from an interval to a cron pattern leaves the old interval behind in Redis, so the scheduler ends up storing both. Versions before 5.41 have no `Queue#removeGlobalConcurrency`, so clearing a global concurrency limit silently does nothing.
+The floor sits at `5.50.0` because of BullMQ's own bugs rather than anything the adapter chooses not to support. Between 5.44 and 5.48, `FlowProducer#getFlow` ignores a custom prefix and answers with a root that has no children, so the flow tab is empty for any queue using a `prefix`. Before 5.41 there is no `Queue#removeGlobalConcurrency`, so clearing a global concurrency limit silently does nothing.
 
-Anything at or above `5.56.0` gets every feature. If you are pinned lower and something on that list matters to you, open an issue rather than assuming the floor is fixed: it is set by what CI can prove, and it moves down whenever a fix makes a lower version pass.
+Below `5.30` the board does not start at all. The queue listing calls `Queue#getJobSchedulersCount` on every poll, that method arrived in 5.30, and without it `GET /api/queues` returns 500. The same is true of every BullMQ v4 release. That is a hard cliff rather than a degraded experience, which is why the range does not reach down to it.
 
-Raising the floor is a breaking change and only happens in a major release of `@bull-board/api`.
+If you are pinned below the floor and something here matters to you, open an issue rather than assuming the floor is fixed. It is set by what CI can prove, and it moves down whenever a fix makes a lower version pass. Raising it is a breaking change and only happens in a major release of `@bull-board/api`.
 
 ## Import
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,7 +475,7 @@ __metadata:
     bull: "npm:^4.16.5"
     bullmq: "npm:^5.81.3"
     bullmq-v5: "npm:bullmq@^5"
-    bullmq-v5-floor: "npm:bullmq@5.56.0"
+    bullmq-v5-floor: "npm:bullmq@5.50.0"
     bullmq-v6: "npm:bullmq@^6"
     ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
@@ -486,7 +486,7 @@ __metadata:
   peerDependencies:
     "@bull-board/ui": 9.4.0
     bull: ^4.16.5
-    bullmq: ^5.56.0 || ^6.0.0
+    bullmq: ^5.50.0 || ^6.0.0
   peerDependenciesMeta:
     bull:
       optional: true
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@bull-board/api": "npm:9.4.0"
   peerDependencies:
-    bullmq: ^5.56.0 || ^6.0.0
+    bullmq: ^5.50.0 || ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -6107,9 +6107,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bullmq-v5-floor@npm:bullmq@5.56.0":
-  version: 5.56.0
-  resolution: "bullmq@npm:5.56.0"
+"bullmq-v5-floor@npm:bullmq@5.50.0":
+  version: 5.50.0
+  resolution: "bullmq@npm:5.50.0"
   dependencies:
     cron-parser: "npm:^4.9.0"
     ioredis: "npm:^5.4.1"
@@ -6118,7 +6118,7 @@ __metadata:
     semver: "npm:^7.5.4"
     tslib: "npm:^2.0.0"
     uuid: "npm:^9.0.0"
-  checksum: 10c0/77cbe1170ec0bea2b305fd435f17c316b21d75414bf48ff1e06f997444b4f43461d6a388d8f331186b49c0ceafc5ab86f5109a33ee7825fef8a5a9cc7fa7c424
+  checksum: 10c0/974b9c93646c6903ad4a08a6fe7527c71d8d23a1e8a9693d9c037a6f8cefb1dd186668a988806b583c9433362ccf6d3a93bfa7bf95d8a01d576d37f95b12a22e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,7 @@ __metadata:
     bull: "npm:^4.16.5"
     bullmq: "npm:^5.81.3"
     bullmq-v5: "npm:bullmq@^5"
+    bullmq-v5-floor: "npm:bullmq@5.56.0"
     bullmq-v6: "npm:bullmq@^6"
     ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
@@ -485,7 +486,7 @@ __metadata:
   peerDependencies:
     "@bull-board/ui": 9.4.0
     bull: ^4.16.5
-    bullmq: ^5.79.2 || ^6.0.0
+    bullmq: ^5.56.0 || ^6.0.0
   peerDependenciesMeta:
     bull:
       optional: true
@@ -764,7 +765,7 @@ __metadata:
   dependencies:
     "@bull-board/api": "npm:9.4.0"
   peerDependencies:
-    bullmq: ^5.79.2 || ^6.0.0
+    bullmq: ^5.56.0 || ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -6106,6 +6107,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bullmq-v5-floor@npm:bullmq@5.56.0":
+  version: 5.56.0
+  resolution: "bullmq@npm:5.56.0"
+  dependencies:
+    cron-parser: "npm:^4.9.0"
+    ioredis: "npm:^5.4.1"
+    msgpackr: "npm:^1.11.2"
+    node-abort-controller: "npm:^3.1.1"
+    semver: "npm:^7.5.4"
+    tslib: "npm:^2.0.0"
+    uuid: "npm:^9.0.0"
+  checksum: 10c0/77cbe1170ec0bea2b305fd435f17c316b21d75414bf48ff1e06f997444b4f43461d6a388d8f331186b49c0ceafc5ab86f5109a33ee7825fef8a5a9cc7fa7c424
+  languageName: node
+  linkType: hard
+
 "bullmq-v5@npm:bullmq@^5, bullmq@npm:^5.81.3":
   version: 5.81.3
   resolution: "bullmq@npm:5.81.3"
@@ -9434,7 +9450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:5.11.1, ioredis@npm:^5.11.1, ioredis@npm:^5.3.2":
+"ioredis@npm:5.11.1, ioredis@npm:^5.11.1, ioredis@npm:^5.3.2, ioredis@npm:^5.4.1":
   version: 5.11.1
   resolution: "ioredis@npm:5.11.1"
   dependencies:
@@ -12241,7 +12257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-abort-controller@npm:3.1.1":
+"node-abort-controller@npm:3.1.1, node-abort-controller@npm:^3.1.1":
   version: 3.1.1
   resolution: "node-abort-controller@npm:3.1.1"
   checksum: 10c0/f7ad0e7a8e33809d4f3a0d1d65036a711c39e9d23e0319d80ebe076b9a3b4432b4d6b86a7fab65521de3f6872ffed36fc35d1327487c48eb88c517803403eda3
@@ -16106,6 +16122,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stacked on #1383, which you have already approved. Merge that one first and this diff collapses to the two commits it actually adds. I kept it separate rather than pushing over an approved branch.

#1383 stops at `^5.56.0` because that is where the suite went green with one fix. I said in it that reaching 5.44 would cost three changes and return two percentage points, and that I would do it in a follow-up if you wanted. Having now done two of the three, the answer came out better than I estimated: the floor lands at `5.50.0`, and the third change turned out not to be ours to make.

## The two fixes

Both are in `getJobSchedulers`, and both are corrections at any version rather than compatibility shims.

BullMQ before 5.50 stores a scheduler's `every` as a string. The board passed it straight through, so the interval column rendered `"60000"` instead of a number, and `findLastRunId` computed `scheduler.next - scheduler.every` on a string and got `NaN`, which silently cost you the previous-run link on every interval schedule.

Separately, `upsertJobScheduler` on those versions leaves the old `every` in the hash when a schedule is rewritten as a cron pattern, so the scheduler ends up storing both. A schedule is one or the other, and BullMQ resolves the ambiguity in favour of the pattern, so the board now does the same:

```ts
function schedulerInterval(scheduler: JobSchedulerJson): number | undefined {
  if (scheduler.pattern || scheduler.every === undefined || scheduler.every === null) {
    return undefined;
  }

  const every = Number(scheduler.every);

  return Number.isFinite(every) ? every : undefined;
}
```

One existing assertion moved. `swaps an interval for a pattern` read `every` back out of BullMQ's own storage, which is asserting BullMQ's behaviour rather than ours, and on an affected version it fails for a reason the board has already handled. It now checks the pattern in storage, which is right on every version, and checks the board's own listing for the interval, which is what a user actually sees.

## The third change, which is not ours

The remaining failure between 5.44 and 5.48 is the flow tab going empty for queues with a custom `prefix`. I chased it and it is BullMQ's, not ours. `FlowProducer#getFlow` ignores the prefix and answers with a childless root:

```
bullmq 5.44.0   getFlow(prefix)   children=none
bullmq 5.81.3   getFlow(prefix)   children=1
```

Same script, same Redis, same flow written by a correctly prefixed `FlowProducer`. Working around it would mean walking the dependency keys by hand instead of using `getFlow`, for the 1.0 pp between 5.50 and 5.44, so the floor stops at 5.50 where the upstream fix lands.

## Where that leaves the range

| peer range | accepts |
|---|---|
| `^5.79.2 \|\| ^6.0.0`, before #1383 | 33.5% |
| `^5.56.0 \|\| ^6.0.0`, #1383 | 88.3% |
| `^5.50.0 \|\| ^6.0.0`, this PR | 89.3% |

I would stop here. Below 5.50 the next stop worth anything is 5.36 at 91.0%, and it costs a `supportsGlobalConcurrency` capability plus UI work to hide a control that currently no-ops silently, and a real existence check so a `PATCH` to a mistyped scheduler id answers 404 instead of creating a schedule. Below 5.30 there is no job scheduler API at all, `GET /api/queues` returns 500 because the listing calls `getJobSchedulersCount`, and supporting that band means a second scheduler backend on the repeatable API. Both are in the docs so the next person does not have to rediscover them.

## Tests

The floor project is the control for both fixes. Put `every: scheduler.every` back and `bullmq@5.50.0 (peer floor)` fails on exactly the two scheduler tests the normalization was added for, while the default, `bullmq@5` and `bullmq@6` projects stay green, which is the point: these are versions the suite could not previously see. 5.50.0 passed three consecutive full runs with Redis flushed between them.

`yarn build`, `yarn lint:check`, `yarn format:check`, `typecheck:bullmq`, the full `yarn test` across every workspace and `yarn test:ui` are green locally against Redis and PostgreSQL.

Docs, README and `CLAUDE.md` follow the new floor, and the supported-versions section now names the two upstream bugs that set it and the hard cliff at 5.30, rather than just stating a number.
