### PR TITLE
fix(cli): move to ioredis 6 alongside bull 4 and bullmq 5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "bull": "^4.16.5",
     "bullmq": "^5.81.3",
     "express": "^5.2.1",
-    "ioredis": "^5.11.1"
+    "ioredis": "^6.0.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/packages/cli/src/queueFactory.ts
+++ b/packages/cli/src/queueFactory.ts
@@ -8,6 +8,16 @@ import { describeError } from './describeError';
 import type { DiscoveredQueue } from './discovery';
 import type { QueueHandle } from './registry';
 
+type BullRedisClient = ReturnType<NonNullable<BullQueue.QueueOptions['createClient']>>;
+type BullMQConnection = NonNullable<ConstructorParameters<typeof BullMQQueue>[1]>['connection'];
+
+// Bull 4.16.5 is the last release on that major and pins ioredis 5, and BullMQ 5 pins it too, so
+// both declare their client against a different copy of ioredis than the one the CLI holds. Same
+// client at runtime, two nominally distinct declarations. BullMQ 6 takes ioredis as an optional
+// peer and needs no cast.
+const asBullClient = (redis: Redis) => redis as unknown as BullRedisClient;
+const asBullMQConnection = (redis: Redis) => redis as unknown as BullMQConnection;
+
 export interface QueueFactoryDeps {
   client: Redis;
   readOnly: boolean;
@@ -37,7 +47,7 @@ export function createQueueFactory({
 
     if (discovered.lib === 'bullmq') {
       const queue = new BullMQQueue(discovered.name, {
-        connection: client,
+        connection: asBullMQConnection(client),
         prefix: discovered.prefix,
         // The dashboard only reads the queues it discovers, so it must not write their meta hash.
         skipMetasUpdate: true,
@@ -55,7 +65,7 @@ export function createQueueFactory({
     const queue = new BullQueue(discovered.name, {
       prefix: discovered.prefix,
       createClient: (type) => {
-        if (type === 'client') return client;
+        if (type === 'client') return asBullClient(client);
         // Bull rejects a subscriber that has enableReadyCheck or maxRetriesPerRequest set.
         if (!bullSubscriber) {
           bullSubscriber = client.duplicate({
@@ -64,7 +74,7 @@ export function createQueueFactory({
           });
         }
 
-        return bullSubscriber;
+        return asBullClient(bullSubscriber);
       },
     });
     queue.on('error', (error: Error) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,7 +522,7 @@ __metadata:
     bull: "npm:^4.16.5"
     bullmq: "npm:^5.81.3"
     express: "npm:^5.2.1"
-    ioredis: "npm:^5.11.1"
+    ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
     supertest: "npm:^7.2.2"
     ts-jest: "npm:^29.4.12"
@@ -9433,7 +9433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:5.11.1, ioredis@npm:^5.11.1, ioredis@npm:^5.3.2":
+"ioredis@npm:5.11.1, ioredis@npm:^5.3.2":
   version: 5.11.1
   resolution: "ioredis@npm:5.11.1"
   dependencies:


### PR DESCRIPTION
Supersedes #1378, and unblocks #1381. They look like two problems and are one.

`packages/cli` is the last workspace on ioredis 5. It opens a single client from `--redis-url` and hands it to every queue it discovers, which is what lets one connection back the whole dashboard and one `error` handler drive the connecting, degraded and unavailable states. Bull 4.16.5 pins `ioredis@^5.3.2` and BullMQ 5 pins `5.11.1` exactly, so on ioredis 6 the tree holds two copies and each library declares its client against the other one. Ioredis 6 also made `Redis` generic, so the CLI holds a `Redis<"legacy">` and hands it to signatures written for a plain `Redis`, which is both of #1378's build errors.

Same object at runtime, two nominally distinct declarations, so this names that at the two boundaries rather than restructuring around it. `asBullClient` and `asBullMQConnection` derive their target types from the libraries instead of spelling them out, so if either changes its client type the derivation follows rather than going quietly stale. `asBullMQConnection` stops being needed once the BullMQ devDependency moves to 6, which takes ioredis as an optional peer and pins nothing; `asBullClient` stays as long as bull 4 is supported, since 4.16.5 is the last release there and its pin will never move.

#1381 is the same knot from the other side. It only bumps a devDependency, but the CLI fails on two `Queue` types that differ solely by path and are both 6.1.2. Yarn keeps two copies because BullMQ 6 declares `ioredis` as an optional peer, so each consumer gets a virtualised instance resolved against the ioredis it provides; `packages/api` was on 6 and `packages/cli` on 5, and the instance that lost the hoist nested under the CLI. Putting both on the same ioredis collapses it. I checked out #1381, applied this on top, and the nested copy is gone and the CLI builds, so that one should go green on a rebase with no change of its own.

## Tests

No new specs. What is under test is the CLI talking to Redis through two libraries that disagree about which ioredis they hold, and the existing suite already drives both queue libraries end to end against a real one; a test asserting a cast compiles would be testing the compiler. It ran twice with ioredis 6 in place, 94 of 94 both times, which covers bull's `createClient` path including the separate subscriber connection.

`yarn build`, `yarn lint:check`, `yarn format:check` and the full `yarn test` across every workspace are green locally against Redis and PostgreSQL. One unrelated flake appeared once in `packages/api`, `PostgreSQL backend on bullmq@6 › reports a job as not being part of a flow`, and passed on two immediate re-runs; nothing here touches that package.
