### PR TITLE
fix(metrics): adopt an injected client from any copy of ioredis

### DIFF
--- a/packages/metrics/src/HistoryAdmin.ts
+++ b/packages/metrics/src/HistoryAdmin.ts
@@ -1,4 +1,5 @@
 import { Redis, type RedisOptions } from 'ioredis';
+import { isRedisClient } from './connection';
 import { GLOBAL_QUEUE, HOUR_TIER, NAMESPACE, dayHashKey, hourHashKey, totalsHashKey } from './keys';
 
 const SCAN_COUNT = 500;
@@ -150,7 +151,7 @@ export class MetricsHistoryAdmin {
   private readonly ownsRedis: boolean;
 
   constructor(opts: MetricsHistoryAdminOptions) {
-    if (opts.connection instanceof Redis) {
+    if (isRedisClient(opts.connection)) {
       this.redis = opts.connection;
       this.ownsRedis = false;
     } else {

--- a/packages/metrics/src/MetricsRecorder.ts
+++ b/packages/metrics/src/MetricsRecorder.ts
@@ -1,6 +1,7 @@
 import type { BaseAdapter } from '@bull-board/api/baseAdapter';
 import type { MetricsType } from '@bull-board/api/typings/app';
 import { Redis, type RedisOptions } from 'ioredis';
+import { isRedisClient } from './connection';
 import { metricsToMinutePoints } from './dataMapping';
 import { HistoryStore, type Retention } from './HistoryStore';
 import { LatencySampler } from './LatencySampler';
@@ -85,7 +86,7 @@ export class MetricsRecorder {
   constructor(opts: MetricsRecorderOptions) {
     this.queues = opts.queues;
     this.intervalMs = opts.snapshotIntervalMs ?? 60000;
-    if (opts.connection instanceof Redis) {
+    if (isRedisClient(opts.connection)) {
       this.redis = opts.connection;
       this.ownsRedis = false;
     } else {

--- a/packages/metrics/src/RedisMetricsHistoryProvider.ts
+++ b/packages/metrics/src/RedisMetricsHistoryProvider.ts
@@ -6,6 +6,7 @@ import type {
   MetricsLatencyQuery,
 } from '@bull-board/api/typings/app';
 import { Redis, type RedisOptions } from 'ioredis';
+import { isRedisClient } from './connection';
 import { emptyVector, mergeVectors, quantile, vectorTotal } from './histogram';
 import {
   MetricsHistoryAdmin,
@@ -36,7 +37,7 @@ export class RedisMetricsHistoryProvider implements MetricsHistoryProvider {
   private readonly retentionDays: number;
 
   constructor(opts: RedisMetricsHistoryProviderOptions) {
-    if (opts.connection instanceof Redis) {
+    if (isRedisClient(opts.connection)) {
       this.redis = opts.connection;
       this.ownsRedis = false;
     } else {

--- a/packages/metrics/src/connection.ts
+++ b/packages/metrics/src/connection.ts
@@ -1,0 +1,7 @@
+import type { Redis, RedisOptions } from 'ioredis';
+
+export type MetricsConnection = Redis | RedisOptions;
+
+export function isRedisClient(connection: MetricsConnection): connection is Redis {
+  return typeof (connection as Partial<Redis>)?.hgetall === 'function';
+}

--- a/packages/metrics/tests/connection.spec.ts
+++ b/packages/metrics/tests/connection.spec.ts
@@ -1,0 +1,71 @@
+import { Redis } from 'ioredis';
+import { isRedisClient } from '../src/connection';
+import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
+
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: +(process.env.REDIS_PORT || 6379),
+};
+
+function clientFromASecondIoredisCopy(): Redis {
+  return {
+    hgetall: async () => ({}),
+    pipeline: () => ({}),
+    scanStream: () => ({}),
+    disconnect: () => {},
+  } as unknown as Redis;
+}
+
+describe('telling a client from connection options', () => {
+  let real: Redis;
+
+  beforeEach(() => {
+    real = new Redis({ protocol: 2, ...connection, lazyConnect: true });
+  });
+
+  afterEach(() => {
+    real.disconnect();
+  });
+
+  it('recognises a client whose Redis class is a different copy of ioredis', () => {
+    const foreign = clientFromASecondIoredisCopy();
+
+    expect(foreign instanceof Redis).toBe(false);
+    expect(isRedisClient(foreign)).toBe(true);
+  });
+
+  it('recognises our own client', () => {
+    expect(isRedisClient(real)).toBe(true);
+  });
+
+  it.each([
+    ['host and port', connection],
+    ['an empty object', {}],
+    ['a url-less options bag', { db: 3, keyPrefix: 'x:' }],
+  ])('treats %s as options rather than a client', (_label, options) => {
+    expect(isRedisClient(options)).toBe(false);
+  });
+
+  it('adopts an injected client instead of opening a second connection to localhost', () => {
+    const foreign = clientFromASecondIoredisCopy();
+
+    const admin = new MetricsHistoryAdmin({ connection: foreign }) as unknown as {
+      redis: Redis;
+      ownsRedis: boolean;
+    };
+
+    expect(admin.redis).toBe(foreign);
+    expect(admin.ownsRedis).toBe(false);
+  });
+
+  it('still builds and owns a client when given plain options', () => {
+    const admin = new MetricsHistoryAdmin({
+      connection: { ...connection, lazyConnect: true },
+    }) as unknown as { redis: Redis; ownsRedis: boolean };
+
+    expect(admin.ownsRedis).toBe(true);
+    expect(admin.redis.options.port).toBe(connection.port);
+
+    admin.redis.disconnect();
+  });
+});


### PR DESCRIPTION
`MetricsHistoryAdmin`, `MetricsRecorder` and `RedisMetricsHistoryProvider` all decide whether they were handed a client or a bag of options with `opts.connection instanceof Redis`. When that check is wrong, it is wrong silently and in the worst direction: the client falls through to the options branch, `new Redis({ protocol: 2, ...client })` spreads a client object as connection options, and you get a fresh connection to `localhost:6379`. The caller's client is ignored, history is read from and written to the wrong server, and `ownsRedis` is set to true so `disconnect()` later closes a connection this package never opened.

I reproduced it against the built package before changing anything: pass any object that is not `instanceof` this copy of `Redis`, and the admin comes back holding a brand new client pointed at `localhost` with `ownsRedis` true. Nothing throws and nothing warns.

`instanceof` is the wrong test here because a dependency tree routinely holds more than one copy of ioredis. Bull 4.16.5 and BullMQ 5 both pin ioredis 5, this package accepts `^5.0.0 || ^6.0.0`, and BullMQ 6 takes ioredis as an optional peer, so a caller's client being a different `Redis` class than ours is ordinary rather than exotic. `packages/cli/src/queueFactory.ts` already carries a comment about exactly this, describing the same client as "two nominally distinct declarations".

So the three constructors now ask what the value can do rather than which class it came from. `isRedisClient` checks for a callable `hgetall`, which every ioredis client has and no options bag does, and the three call sites are otherwise untouched: the RESP2 default, the spread order, and the `ownsRedis` bookkeeping all behave as before.

## Tests

`connection.spec.ts` covers a client whose `Redis` class is not ours being recognised, our own client being recognised, three shapes of options not being mistaken for a client, an injected foreign client being adopted rather than replaced by a localhost connection, and plain options still producing an owned client on the right port.

Putting `instanceof Redis` back fails exactly two of the seven, the foreign-client recognition and the adoption, and leaves the other five green. That is the right split: the five are about options handling, which this does not change.

`yarn format:check`, oxlint, the full `packages/metrics` suite against Redis and PostgreSQL, and the full `packages/api` suite across all four projects including the 5.56 floor are green locally.

## What this does not change

The CLI needs nothing. It declares ioredis as a direct dependency and builds its own `new Redis(config.redisUrl)`, so it never touches the caller's client and works against any Redis server whatever the surrounding application uses. I checked it while looking into this and there is no equivalent problem there.

This also does not make `@bull-board/metrics` work without ioredis. It stores history in Redis by design and speaks ioredis commands, so ioredis stays a required peer dependency. What changes is that any ioredis-compatible client you hand it is now used, rather than quietly swapped for a guess.
