### PR TITLE
test(api): de-flake the queue workers spec and cover the untested job endpoints

### DIFF
--- a/packages/api/tests/api/job-flow.spec.ts
+++ b/packages/api/tests/api/job-flow.spec.ts
@@ -1,6 +1,8 @@
 import { createBullBoard } from '@bull-board/api';
+import { BullAdapter } from '@bull-board/api/bullAdapter';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
+import Bull from 'bull';
 import { FlowProducer, Queue } from 'bullmq';
 import request from 'supertest';
 
@@ -131,5 +133,40 @@ describe('Job flow', () => {
     expect(res.body.isFlowNode).toBe(false);
     expect(res.body.flowRoot.id).toBe(job.id);
     expect(res.body.flowRoot.children).toHaveLength(0);
+  });
+
+  it('returns a non-flow response when the parent queue is not on the board', async () => {
+    const tree = await flowProducer.add({
+      name: 'root',
+      queueName: parentQueue.name,
+      children: [{ name: 'leaf', queueName: childQueue.name, data: {} }],
+    });
+    const childJobId = tree.children![0].job.id;
+
+    createBullBoard({ queues: [new BullMQAdapter(childQueue)], serverAdapter });
+    const agent = request(serverAdapter.getRouter());
+
+    const res = await agent.get(`/api/queues/${childQueue.name}/${childJobId}/flow`).expect(200);
+
+    expect(res.body).toEqual({ nodeId: childJobId, flowRoot: null, isFlowNode: false });
+  });
+
+  it('returns a non-flow response for a Bull queue, which has no flows', async () => {
+    const bullQueue = new Bull('FlowBull', { redis: connection });
+    bullQueue.on('error', () => {});
+
+    try {
+      const job = await bullQueue.add('solo', {});
+      createBullBoard({ queues: [new BullAdapter(bullQueue)], serverAdapter });
+
+      const res = await request(serverAdapter.getRouter())
+        .get(`/api/queues/FlowBull/${job.id}/flow`)
+        .expect(200);
+
+      expect(res.body).toEqual({ nodeId: String(job.id), flowRoot: null, isFlowNode: false });
+    } finally {
+      await bullQueue.obliterate({ force: true }).catch(() => {});
+      await bullQueue.close();
+    }
   });
 });

--- a/packages/api/tests/api/job-handlers.spec.ts
+++ b/packages/api/tests/api/job-handlers.spec.ts
@@ -73,6 +73,29 @@ describe('Job/queue handlers', () => {
     expect(updated?.data).toEqual({ value: 'after' });
   });
 
+  it('returns a single job with its state', async () => {
+    const job = await queue.add('inspectable', { value: 42 }, { delay: 60_000 });
+    const agent = setupBoard();
+
+    const res = await agent.get(`/api/queues/HandlersTest/${job.id}`).expect(200);
+
+    expect(res.body.status).toBe('delayed');
+    expect(res.body.job).toMatchObject({
+      id: job.id,
+      name: 'inspectable',
+      data: { value: 42 },
+      isFailed: false,
+    });
+  });
+
+  it('answers 404 for a job the queue does not hold', async () => {
+    const agent = setupBoard();
+
+    const res = await agent.get('/api/queues/HandlersTest/404').expect(404);
+
+    expect(res.body.error).toEqual({ key: 'ERRORS.JOB_NOT_FOUND' });
+  });
+
   it("returns a job's logs", async () => {
     const job = await queue.add('logged', {});
     await queue.addJobLog(job.id as string, 'first line');

--- a/packages/api/tests/api/job-schedulers.spec.ts
+++ b/packages/api/tests/api/job-schedulers.spec.ts
@@ -277,6 +277,22 @@ describe('Job schedulers', () => {
       expect(scheduler?.every).toBeUndefined();
     });
 
+    it('writes the timezone, run limit and end date onto the schedule', async () => {
+      await firstQueue.upsertJobScheduler('dated', { pattern: '0 3 * * *' }, { name: 'task' });
+      const endDate = Date.now() + 7 * 24 * 60 * 60 * 1000;
+
+      await request(serverAdapter.getRouter())
+        .patch(`/api/queues/${firstQueue.name}/job-schedulers/dated`)
+        .send({ pattern: '0 4 * * *', tz: 'Europe/Warsaw', limit: 5, endDate })
+        .expect(204);
+
+      const scheduler = await firstQueue.getJobScheduler('dated');
+      expect(scheduler?.pattern).toBe('0 4 * * *');
+      expect(scheduler?.tz).toBe('Europe/Warsaw');
+      expect(scheduler?.limit).toBe(5);
+      expect(scheduler?.endDate).toBe(endDate);
+    });
+
     it('rejects a pattern the queue library cannot parse, leaving the schedule intact', async () => {
       await firstQueue.upsertJobScheduler('keep-me', { pattern: '0 3 * * *' }, { name: 'task' });
 

--- a/packages/api/tests/api/metrics.spec.ts
+++ b/packages/api/tests/api/metrics.spec.ts
@@ -43,6 +43,28 @@ describe('metrics', () => {
       });
   });
 
+  it('reports the metric it could read when the other one fails', async () => {
+    const metricsQueue = new Queue('PartialMetricsQueue', { connection });
+    queueList.push(metricsQueue);
+
+    const adapter = new BullMQAdapter(metricsQueue);
+    jest
+      .spyOn(adapter, 'getMetrics')
+      .mockImplementation((type) =>
+        type === 'failed'
+          ? Promise.reject(new Error('metrics unavailable'))
+          : Promise.resolve({ meta: { count: 0, prevTS: 0, prevCount: 0 }, data: [], count: 0 })
+      );
+    createBullBoard({ queues: [adapter], serverAdapter });
+
+    const res = await request(serverAdapter.getRouter())
+      .get(`/api/queues/${metricsQueue.name}/metrics`)
+      .expect(200);
+
+    expect(res.body.failed).toBeNull();
+    expect(res.body.completed).toMatchObject({ data: [] });
+  });
+
   it('should return 404 for an unknown queue', async () => {
     const metricsQueue = new Queue('KnownQueue', { connection });
     queueList.push(metricsQueue);

--- a/packages/api/tests/api/queue-workers.spec.ts
+++ b/packages/api/tests/api/queue-workers.spec.ts
@@ -6,7 +6,7 @@ import type { AppQueue, QueueWorker } from '@bull-board/api/typings/app';
 import type { GetQueueWorkersResponse } from '@bull-board/api/typings/responses';
 import { ExpressAdapter } from '@bull-board/express';
 import Bull from 'bull';
-import { Queue, Worker } from 'bullmq';
+import { Queue, Worker, type WorkerOptions } from 'bullmq';
 import request from 'supertest';
 
 const connection = {
@@ -46,6 +46,21 @@ async function waitForWorkers(
   throw new Error(`No workers showed up for "${queueName}"`);
 }
 
+async function startQueue(name: string): Promise<Queue> {
+  const queue = new Queue(name, { connection });
+  await queue.waitUntilReady();
+  return queue;
+}
+
+async function startWorker(
+  name: string,
+  opts: Omit<WorkerOptions, 'connection'> = {}
+): Promise<Worker> {
+  const worker = new Worker(name, async () => 'ok', { connection, ...opts });
+  await worker.waitUntilReady();
+  return worker;
+}
+
 describe('Queue workers', () => {
   let serverAdapter: ExpressAdapter;
 
@@ -65,7 +80,7 @@ describe('Queue workers', () => {
     });
 
     it('reports an empty list when nothing is consuming the queue', async () => {
-      queue = new Queue('WorkerlessBullMQ', { connection });
+      queue = await startQueue('WorkerlessBullMQ');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
       const { workers } = await fetchWorkers(serverAdapter, 'WorkerlessBullMQ');
@@ -73,13 +88,10 @@ describe('Queue workers', () => {
     });
 
     it('reports a connected worker with its name, address and age', async () => {
-      queue = new Queue('WatchedBullMQ', { connection });
+      queue = await startQueue('WatchedBullMQ');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
-      worker = new Worker('WatchedBullMQ', async () => 'ok', {
-        connection,
-        name: 'crunch-1',
-      });
+      worker = await startWorker('WatchedBullMQ', { name: 'crunch-1' });
 
       const workers = await waitForWorkers(serverAdapter, 'WatchedBullMQ');
       expect(workers).toHaveLength(1);
@@ -92,17 +104,27 @@ describe('Queue workers', () => {
     });
 
     it('leaves the name empty for an unnamed worker', async () => {
-      queue = new Queue('AnonymousBullMQ', { connection });
+      queue = await startQueue('AnonymousBullMQ');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
-      worker = new Worker('AnonymousBullMQ', async () => 'ok', { connection });
+      worker = await startWorker('AnonymousBullMQ');
 
       const workers = await waitForWorkers(serverAdapter, 'AnonymousBullMQ');
       expect(workers[0].name).toBeNull();
     });
 
+    it('answers with a null list when the queue cannot be asked', async () => {
+      queue = await startQueue('UnreachableBullMQ');
+      const adapter = new BullMQAdapter(queue);
+      jest.spyOn(adapter, 'getWorkers').mockRejectedValue(new Error('Connection is closed'));
+      createBullBoard({ queues: [adapter], serverAdapter });
+
+      const { workers } = await fetchWorkers(serverAdapter, 'UnreachableBullMQ');
+      expect(workers).toBeNull();
+    });
+
     it('resolves a queue that carries a prefix', async () => {
-      queue = new Queue('PrefixedBullMQ', { connection });
+      queue = await startQueue('PrefixedBullMQ');
       createBullBoard({
         queues: [new BullMQAdapter(queue, { prefix: 'prefixed/' })],
         serverAdapter,
@@ -113,7 +135,7 @@ describe('Queue workers', () => {
     });
 
     it('answers 404 for a queue the board does not know', async () => {
-      queue = new Queue('KnownBullMQ', { connection });
+      queue = await startQueue('KnownBullMQ');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
       const res = await request(serverAdapter.getRouter())
@@ -124,7 +146,7 @@ describe('Queue workers', () => {
     });
 
     it('serves a read only queue, since the list changes nothing', async () => {
-      queue = new Queue('ReadOnlyBullMQ', { connection });
+      queue = await startQueue('ReadOnlyBullMQ');
       createBullBoard({
         queues: [new BullMQAdapter(queue, { readOnlyMode: true })],
         serverAdapter,
@@ -172,7 +194,7 @@ describe('Queue workers', () => {
     });
 
     it('is false while nothing is consuming the queue', async () => {
-      queue = new Queue('FlagWorkerless', { connection });
+      queue = await startQueue('FlagWorkerless');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
       const [appQueue] = await fetchQueues(serverAdapter);
@@ -180,10 +202,10 @@ describe('Queue workers', () => {
     });
 
     it('turns true once a worker connects', async () => {
-      queue = new Queue('FlagWatched', { connection });
+      queue = await startQueue('FlagWatched');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
-      worker = new Worker('FlagWatched', async () => 'ok', { connection });
+      worker = await startWorker('FlagWatched');
       await waitForWorkers(serverAdapter, 'FlagWatched');
 
       const [appQueue] = await fetchQueues(serverAdapter);
@@ -191,7 +213,7 @@ describe('Queue workers', () => {
     });
 
     it('is null when the board opted out, so nothing is asked of redis', async () => {
-      queue = new Queue('FlagOptedOut', { connection });
+      queue = await startQueue('FlagOptedOut');
       const adapter = new BullMQAdapter(queue);
       const getWorkers = jest.spyOn(adapter, 'getWorkers');
       createBullBoard({
@@ -206,7 +228,7 @@ describe('Queue workers', () => {
     });
 
     it('is null for a queue that cannot be reached, leaving the rest of the board alone', async () => {
-      queue = new Queue('FlagReachable', { connection });
+      queue = await startQueue('FlagReachable');
       const broken = new BullMQAdapter(queue);
       jest.spyOn(broken, 'getName').mockReturnValue('FlagBroken');
       jest.spyOn(broken, 'getWorkers').mockRejectedValue(new Error('Connection is closed'));
@@ -250,7 +272,7 @@ describe('Queue workers', () => {
     });
 
     it('hides a queue the request is not allowed to see', async () => {
-      queue = new Queue('HiddenBullMQ', { connection });
+      queue = await startQueue('HiddenBullMQ');
       const adapter = new BullMQAdapter(queue);
       adapter.setVisibilityGuard(() => false);
       createBullBoard({ queues: [adapter], serverAdapter });
@@ -273,7 +295,7 @@ describe('Queue workers', () => {
     });
 
     it('refuses the route when the board opted out', async () => {
-      queue = new Queue('OptedOutBullMQ', { connection });
+      queue = await startQueue('OptedOutBullMQ');
       createBullBoard({
         queues: [new BullMQAdapter(queue)],
         serverAdapter,
@@ -288,7 +310,7 @@ describe('Queue workers', () => {
     });
 
     it('serves the route when the setting is left alone', async () => {
-      queue = new Queue('DefaultBullMQ', { connection });
+      queue = await startQueue('DefaultBullMQ');
       createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
 
       const { workers } = await fetchWorkers(serverAdapter, 'DefaultBullMQ');


### PR DESCRIPTION
`queue-workers.spec.ts` builds queues and workers and closes them without ever waiting for either to be ready. BullMQ's `RedisConnection.close()` ends with `removeAllListeners()` in a `finally`, so an `init()` still in flight rejects into an emitter with no `error` listener and jest reports an unhandled rejection. That is what failed on master in run 32969427875. `waitUntilReady()` on both closes the window.

The rest is coverage for things that had no test at all: `GET /api/queues/:queueName/:jobId`, the flow endpoint's empty response (a Bull queue, and a child whose parent queue is not on the board), a scheduler update carrying valid `tz`/`limit`/`endDate`, and the null degradation on the workers and metrics endpoints.

No source changes. 90.86% to 91.73% of statements.
