### PR TITLE
fix(metrics): give each jest worker its own redis database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,16 @@ runs everything outside `tests/bullmq-matrix/` against the plain `bullmq` devDep
 POSTGRES_URL=postgres://bullmq:bullmq@localhost:5432/bullmq yarn workspace @bull-board/metrics test
 ```
 
+Its specs share one Redis, and several of them assert on state that is global by design: the
+`__global__` rollup hash every recorder writes into, and the namespace-wide SCAN that
+`MetricsHistoryAdmin` purges with. Unique queue names cannot isolate either, so `tests/connection.ts`
+hands each Jest worker its own logical database, derived from `JEST_WORKER_ID` and counting down
+from 15 so database 0 stays free for a developer's dev board. Any new spec in this package must
+take its connection from that module rather than build its own. `maxWorkers` in `jest.base.js`
+caps the worker count to the number of databases available, and `jest.config.js` repeats the cap
+because Jest reads global options from the root config only, ignoring them inside a `projects`
+entry.
+
 Types are gated separately, because a peer major breaks types before it breaks runtime:
 
 ```bash

--- a/packages/metrics/jest.base.js
+++ b/packages/metrics/jest.base.js
@@ -8,4 +8,8 @@ module.exports = {
   },
   testPathIgnorePatterns: ['/node_modules/'],
   testTimeout: 30000,
+  // Every spec wipes the whole `bull-board:metrics:` namespace on one shared Redis, so two
+  // running at once delete each other's fixtures. `jest.config.js` repeats this because Jest
+  // reads `maxWorkers` from the root config only when running `projects`.
+  maxWorkers: 1,
 };

--- a/packages/metrics/jest.base.js
+++ b/packages/metrics/jest.base.js
@@ -8,8 +8,8 @@ module.exports = {
   },
   testPathIgnorePatterns: ['/node_modules/'],
   testTimeout: 30000,
-  // Every spec wipes the whole `bull-board:metrics:` namespace on one shared Redis, so two
-  // running at once delete each other's fixtures. `jest.config.js` repeats this because Jest
-  // reads `maxWorkers` from the root config only when running `projects`.
-  maxWorkers: 1,
+  // Bounds JEST_WORKER_ID to the logical databases `tests/connection.ts` maps it onto, which
+  // throws if the two ever disagree. `jest.config.js` repeats it because Jest reads global
+  // options from the root config only, ignoring them inside a `projects` entry.
+  maxWorkers: 15,
 };

--- a/packages/metrics/jest.config.js
+++ b/packages/metrics/jest.config.js
@@ -1,8 +1,6 @@
-// Suite runs against a shared real Redis, including the __global__ rollup hash that every
-// spec file writes into. Parallel Jest workers across spec files can collide on that shared
-// state. This is an integration suite bound by Redis I/O, so serial execution costs little
-// and removes cross-file races.
+// See jest.base.js: the cap keeps JEST_WORKER_ID inside the range of logical databases
+// `tests/connection.ts` hands out.
 module.exports = {
-  maxWorkers: 1,
+  maxWorkers: 15,
   projects: ['<rootDir>/jest.config.default.js', '<rootDir>/jest.config.bullmq-v6.js'],
 };

--- a/packages/metrics/tests/HistoryAdmin.spec.ts
+++ b/packages/metrics/tests/HistoryAdmin.spec.ts
@@ -2,15 +2,7 @@ import { Redis } from 'ioredis';
 import { MetricsHistoryAdmin, parseHistoryKey } from '../src/HistoryAdmin';
 import { HistoryStore } from '../src/HistoryStore';
 import { GLOBAL_QUEUE, NAMESPACE, dayHashKey, minuteToDay, totalsHashKey } from '../src/keys';
-
-// Pinned to a throwaway logical database. This spec clears and purges the whole
-// `bull-board:metrics:` namespace, which on the default db would delete a developer's
-// running dev-board history along with it.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 const DAY_ONE = Date.UTC(2021, 0, 1, 0, 5) / 60000;
 const minuteOn = (offsetDays: number, offsetMinutes = 0) =>

--- a/packages/metrics/tests/HistoryStore.spec.ts
+++ b/packages/metrics/tests/HistoryStore.spec.ts
@@ -9,15 +9,7 @@ import {
   minuteToHour,
   totalsHashKey,
 } from '../src/keys';
-
-// Pinned to a throwaway logical database. These specs write fixture data into the shared
-// `__global__` rollup and clean up by key pattern, which on the default db would both
-// pollute and delete a developer's running dev-board history.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 describe('HistoryStore', () => {
   let redis: Redis;

--- a/packages/metrics/tests/LatencySampler.spec.ts
+++ b/packages/metrics/tests/LatencySampler.spec.ts
@@ -6,12 +6,7 @@ import { vectorTotal } from '../src/histogram';
 import { NAMESPACE, minuteToDay } from '../src/keys';
 import { LatencySampler } from '../src/LatencySampler';
 import { LatencyStore } from '../src/LatencyStore';
-
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 const QUEUE = 'LatencySamplerQueue';
 

--- a/packages/metrics/tests/LatencyStore.spec.ts
+++ b/packages/metrics/tests/LatencyStore.spec.ts
@@ -2,12 +2,7 @@ import { Redis } from 'ioredis';
 import { emptyVector } from '../src/histogram';
 import { GLOBAL_QUEUE, NAMESPACE, minuteToDay, minuteToHour, totalsHashKey } from '../src/keys';
 import { LatencyStore } from '../src/LatencyStore';
-
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 const QUEUE = 'LatencyStoreQueue';
 // Own day, far from the other suites, because the global rollup is shared.

--- a/packages/metrics/tests/MetricsRecorder.spec.ts
+++ b/packages/metrics/tests/MetricsRecorder.spec.ts
@@ -6,15 +6,7 @@ import { vectorTotal } from '../src/histogram';
 import { GLOBAL_QUEUE, NAMESPACE, dayHashKey, minuteToDay, totalsHashKey } from '../src/keys';
 import { LatencyStore } from '../src/LatencyStore';
 import { DEFAULT_RETENTION, MetricsRecorder, resolveRetention } from '../src/MetricsRecorder';
-
-// Pinned to a throwaway logical database. These specs write fixture data into the shared
-// `__global__` rollup and clean up by key pattern, which on the default db would both
-// pollute and delete a developer's running dev-board history.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 /**
  * `queue.obliterate()` (afterEach) only clears BullMQ's own keyspace, never this
@@ -400,13 +392,11 @@ describe('MetricsRecorder', () => {
 
   describe('backfill window', () => {
     // These cases drive a synthetic adapter rather than a real BullMQ queue, and they
-    // write thousands of recent minutes into the shared `__global__` rollup. Pinned to a
-    // throwaway logical database so they can't distort or delete a developer's dev-board
-    // history on the default one.
+    // write thousands of recent minutes into the shared `__global__` rollup.
     let scratch: Redis;
 
     beforeEach(() => {
-      scratch = new Redis({ ...connection, db: +(process.env.REDIS_TEST_DB || 15) });
+      scratch = new Redis(connection);
     });
 
     afterEach(async () => {

--- a/packages/metrics/tests/RedisMetricsHistoryProvider.spec.ts
+++ b/packages/metrics/tests/RedisMetricsHistoryProvider.spec.ts
@@ -4,15 +4,7 @@ import { HistoryStore } from '../src/HistoryStore';
 import { GLOBAL_QUEUE, dayHashKey, hourHashKey, minuteToDay, totalsHashKey } from '../src/keys';
 import { LatencyStore, QUEUE_AGE_METRIC } from '../src/LatencyStore';
 import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
-
-// Pinned to a throwaway logical database. These specs write fixture data into the shared
-// `__global__` rollup and clean up by key pattern, which on the default db would both
-// pollute and delete a developer's running dev-board history.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 describe('RedisMetricsHistoryProvider', () => {
   let redis: Redis;

--- a/packages/metrics/tests/bullmq-matrix/helpers.ts
+++ b/packages/metrics/tests/bullmq-matrix/helpers.ts
@@ -1,13 +1,9 @@
 import { Redis } from 'ioredis';
 import { NAMESPACE } from '../../src/keys';
 
-export const EXPECTED_MAJOR: number = Number((globalThis as Record<string, any>).BULLMQ_MAJOR);
+export { connection } from '../connection';
 
-export const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+export const EXPECTED_MAJOR: number = Number((globalThis as Record<string, any>).BULLMQ_MAJOR);
 
 export function resolvedMajor(): number {
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/metrics/tests/connection.ts
+++ b/packages/metrics/tests/connection.ts
@@ -1,0 +1,19 @@
+// Each Jest worker owns one logical database, so the namespace-wide SCAN and the shared
+// `__global__` rollup that several specs assert on cannot be seen by another worker.
+// Database 0 is left alone: it is where a developer's dev board keeps its history.
+const TEST_DBS = 15;
+
+const worker = Number(process.env.JEST_WORKER_ID ?? 1);
+
+if (worker > TEST_DBS) {
+  throw new Error(
+    `JEST_WORKER_ID ${worker} exceeds the ${TEST_DBS} Redis databases this suite reserves. ` +
+      `Keep maxWorkers at or below ${TEST_DBS}.`
+  );
+}
+
+export const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: +(process.env.REDIS_PORT || 6379),
+  db: process.env.REDIS_TEST_DB ? +process.env.REDIS_TEST_DB : TEST_DBS + 1 - worker,
+};

--- a/packages/metrics/tests/e2e.spec.ts
+++ b/packages/metrics/tests/e2e.spec.ts
@@ -5,17 +5,9 @@ import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
 import { GLOBAL_QUEUE, NAMESPACE, minuteToDay, totalsHashKey } from '../src/keys';
 import { MetricsRecorder } from '../src/MetricsRecorder';
 import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
+import { connection } from './connection';
 
 const E2E_QUEUE = 'MetricsE2ELatencyQueue';
-
-// Pinned to a throwaway logical database. These specs write fixture data into the shared
-// `__global__` rollup and clean up by key pattern, which on the default db would both
-// pollute and delete a developer's running dev-board history.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
 
 /**
  * See MetricsRecorder.spec.ts: `queue.obliterate()` never touches this package's own

--- a/packages/metrics/tests/footprint.spec.ts
+++ b/packages/metrics/tests/footprint.spec.ts
@@ -4,15 +4,7 @@ import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
 import { HistoryStore } from '../src/HistoryStore';
 import { GLOBAL_QUEUE, NAMESPACE } from '../src/keys';
 import { LatencyStore } from '../src/LatencyStore';
-
-// Pinned to a throwaway logical database. This spec clears and purges the whole
-// `bull-board:metrics:` namespace, which on the default db would delete a developer's
-// running dev-board history along with it.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
+import { connection } from './connection';
 
 const MINUTES_PER_DAY = 1440;
 const KB = 1024;

--- a/packages/metrics/tests/protocolGuardrail.spec.ts
+++ b/packages/metrics/tests/protocolGuardrail.spec.ts
@@ -2,17 +2,13 @@ import { Redis } from 'ioredis';
 import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
 import { MetricsRecorder } from '../src/MetricsRecorder';
 import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
+import { connection } from './connection';
 
 // ioredis v6 enables RESP3 (`protocol: 3`) by default. The three classes that can open their
 // own connection force `protocol: 2` on the options-construction path for exact v5 wire parity
 // and Redis < 6 support, while letting an explicit caller `protocol` win. These assertions read
 // the constructed client's negotiated option -- no server round-trip is needed, so they don't
 // depend on the Redis version under test.
-const connection = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: +(process.env.REDIS_PORT || 6379),
-  db: +(process.env.REDIS_TEST_DB || 15),
-};
 
 // The `redis` field is private; the tests reach it to inspect the resolved options.
 const protocolOf = (owner: { redis: Redis }): number | undefined => owner.redis.options.protocol;


### PR DESCRIPTION
The metrics specs share one Redis and several of them assert on state that is global by design: the `__global__` rollup every recorder increments, and the namespace-wide SCAN that `MetricsHistoryAdmin` purges with, which `HistoryAdmin.spec` follows by asserting the namespace is empty. Parallel workers therefore delete each other's fixtures. It failed on every run here, three or four suites out of twelve.

Unique queue names cannot isolate either of those, and neither can an ioredis `keyPrefix`, which prefixes command keys but not the pattern arguments to KEYS and SCAN. The isolation has to be a separate keyspace, and a logical database is the cheapest one Redis offers.

`tests/connection.ts` now owns the connection for the package and derives the database from `JEST_WORKER_ID`, counting down from 15 so database 0 stays free for a developer's dev board. The eleven spec files import it instead of each declaring the same literal. `maxWorkers` caps the worker count at the number of databases available rather than at 1, and the helper throws if the two numbers ever drift apart.

`maxWorkers` still has to appear in both `jest.base.js` and `jest.config.js`, because Jest reads global options from the root config only and ignores them inside a `projects` entry. That is why `jest --config jest.config.default.js` was running parallel in the first place.
