### PR TITLE
test: cover the queue tree helpers, the polling guard and the recorder lifecycle

### DIFF
--- a/packages/metrics/src/MetricsRecorder.ts
+++ b/packages/metrics/src/MetricsRecorder.ts
@@ -79,6 +79,7 @@ export class MetricsRecorder {
   private readonly lastMinute = new Map<string, number>();
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
+  private stopped = false;
   readonly latencyEnabled: boolean;
   private readonly latencySampler: LatencySampler | null;
 
@@ -132,9 +133,10 @@ export class MetricsRecorder {
       clearInterval(this.timer);
       this.timer = null;
     }
-    if (this.ownsRedis) {
+    if (this.ownsRedis && !this.stopped) {
       this.redis.disconnect();
     }
+    this.stopped = true;
   }
 
   async snapshot(): Promise<void> {

--- a/packages/metrics/tests/MetricsRecorder.spec.ts
+++ b/packages/metrics/tests/MetricsRecorder.spec.ts
@@ -57,6 +57,23 @@ async function waitForFailedCount(queue: Queue, min: number) {
   throw new Error('jobs did not fail');
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error('condition was not met in time');
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 /**
  * BullMQ only appends a finalized minute bucket to `getMetrics().data` when a job
  * completes in a LATER wall-clock minute than the previous completion (see bullmq's
@@ -601,6 +618,124 @@ describe('MetricsRecorder', () => {
         await latencyQueue.obliterate({ force: true }).catch(() => undefined);
         await latencyQueue.close();
       }
+    });
+  });
+
+  describe('timer lifecycle', () => {
+    const queueName = 'RecorderLifecycleQueue';
+    let queue: Queue;
+    let recorder: MetricsRecorder | undefined;
+
+    beforeEach(async () => {
+      recorder = undefined;
+      await resetHistory(redis, queueName);
+      queue = new Queue(queueName, { connection });
+    });
+
+    afterEach(async () => {
+      recorder?.stop();
+      await queue.obliterate({ force: true }).catch(() => undefined);
+      await queue.close();
+    });
+
+    const makeRecorder = (snapshotIntervalMs: number) =>
+      new MetricsRecorder({
+        queues: [new BullMQAdapter(queue)],
+        connection: redis,
+        snapshotIntervalMs,
+      });
+
+    it('snapshots once immediately and again on every interval', async () => {
+      recorder = makeRecorder(50);
+      const snapshot = jest.spyOn(recorder, 'snapshot');
+
+      recorder.start();
+      expect(snapshot).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => snapshot.mock.calls.length >= 3);
+    });
+
+    it('ignores a second start rather than scheduling a second timer', () => {
+      recorder = makeRecorder(10_000);
+      const snapshot = jest.spyOn(recorder, 'snapshot');
+
+      recorder.start();
+      const timer = (recorder as any).timer;
+      recorder.start();
+
+      expect(snapshot).toHaveBeenCalledTimes(1);
+      expect((recorder as any).timer).toBe(timer);
+    });
+
+    it('leaves its timer unreferenced, so it cannot hold the event loop open', () => {
+      recorder = makeRecorder(10_000);
+
+      recorder.start();
+
+      expect((recorder as any).timer.hasRef()).toBe(false);
+    });
+
+    it('stops snapshotting once stopped', async () => {
+      recorder = makeRecorder(50);
+      const snapshot = jest.spyOn(recorder, 'snapshot');
+
+      recorder.start();
+      await waitFor(() => snapshot.mock.calls.length >= 2);
+
+      recorder.stop();
+      const afterStop = snapshot.mock.calls.length;
+      await new Promise((r) => setTimeout(r, 250));
+
+      expect(snapshot).toHaveBeenCalledTimes(afterStop);
+      expect((recorder as any).timer).toBeNull();
+    });
+
+    it('disconnects the redis client it opened itself', async () => {
+      const owning = new MetricsRecorder({ queues: [new BullMQAdapter(queue)], connection });
+      const own: Redis = (owning as any).redis;
+      await own.ping();
+
+      owning.stop();
+
+      await waitFor(() => own.status === 'end');
+    });
+
+    it("leaves a caller's own redis client connected", async () => {
+      recorder = new MetricsRecorder({ queues: [new BullMQAdapter(queue)], connection: redis });
+
+      recorder.stop();
+
+      expect(await redis.ping()).toBe('PONG');
+    });
+
+    it('is safe to stop twice, leaving no reconnect timer behind', async () => {
+      const owning = new MetricsRecorder({ queues: [new BullMQAdapter(queue)], connection });
+      const own: Redis = (owning as any).redis;
+      await own.ping();
+      const disconnect = jest.spyOn(own, 'disconnect');
+
+      owning.stop();
+      owning.stop();
+
+      expect(disconnect).toHaveBeenCalledTimes(1);
+      await waitFor(() => own.status === 'end');
+    });
+
+    it('skips a snapshot while the previous one is still running', async () => {
+      const adapter = new BullMQAdapter(queue);
+      const inFlight = deferred<null>();
+      const getMetrics = jest
+        .spyOn(adapter, 'getMetrics')
+        .mockReturnValueOnce(inFlight.promise as any);
+      recorder = new MetricsRecorder({ queues: [adapter], connection: redis, latency: false });
+
+      const firstPass = recorder.snapshot();
+      await recorder.snapshot();
+
+      expect(getMetrics).toHaveBeenCalledTimes(1);
+
+      inFlight.resolve(null);
+      await firstPass;
     });
   });
 });

--- a/packages/ui/tests/hooks/useInterval.spec.tsx
+++ b/packages/ui/tests/hooks/useInterval.spec.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react';
+import { useInterval } from '../../src/hooks/useInterval';
+import { deferred } from '../testUtils';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+const tick = (ms: number) => act(async () => void jest.advanceTimersByTime(ms));
+
+it('runs the callback once on mount, before any tick', () => {
+  const callback = jest.fn();
+
+  renderHook(() => useInterval(callback, 1000));
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('runs it again on every tick', async () => {
+  const callback = jest.fn();
+  renderHook(() => useInterval(callback, 1000));
+
+  await tick(1000);
+  await tick(1000);
+  await tick(1000);
+
+  expect(callback).toHaveBeenCalledTimes(4);
+});
+
+it('runs once and never schedules when the delay is null', async () => {
+  const callback = jest.fn();
+  renderHook(() => useInterval(callback, null));
+
+  await tick(10_000);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('skips ticks while the previous call is still in flight', async () => {
+  const inFlight = deferred<void>();
+  const callback = jest
+    .fn()
+    .mockResolvedValueOnce(undefined)
+    .mockReturnValueOnce(inFlight.promise)
+    .mockResolvedValue(undefined);
+
+  renderHook(() => useInterval(callback, 1000));
+
+  await tick(1000);
+  expect(callback).toHaveBeenCalledTimes(2);
+
+  await tick(3000);
+  expect(callback).toHaveBeenCalledTimes(2);
+
+  await act(async () => {
+    inFlight.resolve();
+    await inFlight.promise;
+  });
+  await tick(1000);
+
+  expect(callback).toHaveBeenCalledTimes(3);
+});
+
+it('calls the latest callback without restarting the interval', async () => {
+  const first = jest.fn();
+  const second = jest.fn();
+  const { rerender } = renderHook(({ callback }) => useInterval(callback, 1000), {
+    initialProps: { callback: first },
+  });
+
+  await tick(500);
+  rerender({ callback: second });
+  await tick(500);
+
+  expect(first).toHaveBeenCalledTimes(1);
+  expect(second).toHaveBeenCalledTimes(1);
+});
+
+it('restarts the interval when the delay changes', async () => {
+  const callback = jest.fn();
+  const { rerender } = renderHook(({ delay }) => useInterval(callback, delay), {
+    initialProps: { delay: 1000 as number | null },
+  });
+
+  await tick(1000);
+  expect(callback).toHaveBeenCalledTimes(2);
+
+  rerender({ delay: 5000 });
+  expect(callback).toHaveBeenCalledTimes(3);
+
+  await tick(1000);
+  expect(callback).toHaveBeenCalledTimes(3);
+
+  await tick(4000);
+  expect(callback).toHaveBeenCalledTimes(4);
+});
+
+it('stops ticking once unmounted', async () => {
+  const callback = jest.fn();
+  const { unmount } = renderHook(() => useInterval(callback, 1000));
+
+  unmount();
+  await tick(5000);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});

--- a/packages/ui/tests/utils/queueTreeCounts.spec.ts
+++ b/packages/ui/tests/utils/queueTreeCounts.spec.ts
@@ -1,0 +1,168 @@
+import {
+  aggregateCounts,
+  areAllPaused,
+  collectQueueNames,
+  collectQueues,
+  countPausedQueues,
+  countQueues,
+} from '../../src/utils/queueTreeCounts';
+import { toTree } from '../../src/utils/toTree';
+import { makeQueue } from '../testUtils';
+
+const withCounts = (
+  name: string,
+  counts: Partial<Record<string, number>>,
+  overrides = {}
+): ReturnType<typeof makeQueue> => {
+  const queue = makeQueue(name, overrides);
+  return { ...queue, counts: { ...queue.counts, ...counts } };
+};
+
+describe('countQueues', () => {
+  it('counts the leaves of a nested tree, not the groups', () => {
+    const root = toTree([
+      makeQueue('billing.invoices'),
+      makeQueue('billing.refunds'),
+      makeQueue('shipping.labels'),
+    ]);
+
+    expect(countQueues(root)).toBe(3);
+  });
+
+  it('counts a single leaf node passed on its own', () => {
+    const root = toTree([makeQueue('solo', { delimiter: undefined })]);
+
+    expect(countQueues(root.children[0])).toBe(1);
+  });
+
+  it('is zero for an empty tree', () => {
+    expect(countQueues(toTree([]))).toBe(0);
+  });
+});
+
+describe('countPausedQueues', () => {
+  it('counts only the paused leaves', () => {
+    const root = toTree([
+      makeQueue('billing.invoices', { isPaused: true }),
+      makeQueue('billing.refunds'),
+      makeQueue('shipping.labels', { isPaused: true }),
+    ]);
+
+    expect(countPausedQueues(root)).toBe(2);
+  });
+});
+
+describe('aggregateCounts', () => {
+  it('sums each status across every leaf', () => {
+    const root = toTree([
+      withCounts('billing.invoices', { waiting: 2, failed: 1 }),
+      withCounts('billing.refunds', { waiting: 3, completed: 5 }),
+    ]);
+
+    expect(aggregateCounts(root).byStatus).toEqual({ waiting: 5, failed: 1, completed: 5 });
+  });
+
+  it('leaves out a status the queue does not advertise, even when a count is present', () => {
+    const root = toTree([
+      withCounts('billing.invoices', { waiting: 2, delayed: 9 }, { statuses: ['waiting'] }),
+    ]);
+
+    const { byStatus, statuses } = aggregateCounts(root);
+    expect(byStatus).toEqual({ waiting: 2 });
+    expect(statuses).toEqual(['waiting']);
+  });
+
+  it('drops a status whose total is zero', () => {
+    const root = toTree([withCounts('billing.invoices', { waiting: 0, failed: 4 })]);
+
+    expect(aggregateCounts(root).statuses).toEqual(['failed']);
+  });
+
+  it('orders statuses by pipeline position rather than by how the queues listed them', () => {
+    const root = toTree([
+      withCounts(
+        'billing.invoices',
+        { completed: 1, active: 1, delayed: 1, waiting: 1 },
+        { statuses: ['completed', 'delayed', 'waiting', 'active'] }
+      ),
+    ]);
+
+    expect(aggregateCounts(root).statuses).toEqual(['active', 'waiting', 'delayed', 'completed']);
+  });
+
+  it('totals only the statuses it kept', () => {
+    const root = toTree([
+      withCounts('billing.invoices', { waiting: 2, delayed: 9 }, { statuses: ['waiting'] }),
+      withCounts('billing.refunds', { waiting: 3 }, { statuses: ['waiting'] }),
+    ]);
+
+    expect(aggregateCounts(root).total).toBe(5);
+  });
+
+  it('is empty for a tree with no queues', () => {
+    expect(aggregateCounts(toTree([]))).toEqual({ total: 0, byStatus: {}, statuses: [] });
+  });
+});
+
+describe('collectQueues', () => {
+  it('flattens the leaves in tree order', () => {
+    const root = toTree([
+      makeQueue('billing.invoices'),
+      makeQueue('billing.refunds'),
+      makeQueue('shipping.labels'),
+    ]);
+
+    expect(collectQueues(root).map((queue) => queue.name)).toEqual([
+      'billing.invoices',
+      'billing.refunds',
+      'shipping.labels',
+    ]);
+  });
+});
+
+describe('collectQueueNames', () => {
+  const root = toTree([
+    makeQueue('billing.invoices'),
+    makeQueue('billing.archive', { readOnlyMode: true }),
+    makeQueue('shipping.labels'),
+  ]);
+
+  it('returns every name by default', () => {
+    expect(collectQueueNames(root)).toEqual([
+      'billing.invoices',
+      'billing.archive',
+      'shipping.labels',
+    ]);
+  });
+
+  it('leaves read only queues out of a bulk action target list', () => {
+    expect(collectQueueNames(root, { writableOnly: true })).toEqual([
+      'billing.invoices',
+      'shipping.labels',
+    ]);
+  });
+});
+
+describe('areAllPaused', () => {
+  it('is true only when every leaf is paused', () => {
+    const allPaused = toTree([
+      makeQueue('billing.invoices', { isPaused: true }),
+      makeQueue('billing.refunds', { isPaused: true }),
+    ]);
+
+    expect(areAllPaused(allPaused)).toBe(true);
+  });
+
+  it('is false when one leaf is still running', () => {
+    const mixed = toTree([
+      makeQueue('billing.invoices', { isPaused: true }),
+      makeQueue('billing.refunds'),
+    ]);
+
+    expect(areAllPaused(mixed)).toBe(false);
+  });
+
+  it('is false for a group holding no queues, rather than vacuously true', () => {
+    expect(areAllPaused(toTree([]))).toBe(false);
+  });
+});

--- a/packages/ui/tests/utils/toTree.spec.ts
+++ b/packages/ui/tests/utils/toTree.spec.ts
@@ -1,0 +1,75 @@
+import { collectGroupPaths, toTree } from '../../src/utils/toTree';
+import { makeQueue } from '../testUtils';
+
+describe('toTree', () => {
+  it('hangs a queue without a delimiter straight off the root', () => {
+    const root = toTree([makeQueue('flat', { delimiter: undefined })]);
+
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].name).toBe('flat');
+    expect(root.children[0].queue?.name).toBe('flat');
+    expect(root.children[0].children).toEqual([]);
+  });
+
+  it('splits a delimited name into nested nodes, carrying the queue on the leaf only', () => {
+    const root = toTree([makeQueue('billing.invoices.retry')]);
+
+    const [billing] = root.children;
+    expect(billing.name).toBe('billing');
+    expect(billing.queue).toBeUndefined();
+
+    const [invoices] = billing.children;
+    expect(invoices.name).toBe('invoices');
+    expect(invoices.queue).toBeUndefined();
+
+    const [retry] = invoices.children;
+    expect(retry.name).toBe('retry');
+    expect(retry.queue?.name).toBe('billing.invoices.retry');
+  });
+
+  it('merges queues that share a prefix into one branch', () => {
+    const root = toTree([makeQueue('billing.invoices'), makeQueue('billing.refunds')]);
+
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].children.map((node) => node.name)).toEqual(['invoices', 'refunds']);
+  });
+
+  it('splits inside a redis cluster hash tag rather than treating the braces as a name', () => {
+    const root = toTree([makeQueue('{billing.invoices}')]);
+
+    expect(root.children[0].name).toBe('billing');
+    expect(root.children[0].children[0].name).toBe('invoices');
+    expect(root.children[0].children[0].queue?.name).toBe('{billing.invoices}');
+  });
+
+  it('sorts groups before leaves and alphabetically within each, only when asked', () => {
+    const queues = [
+      makeQueue('zeta', { delimiter: undefined }),
+      makeQueue('beta.one'),
+      makeQueue('alpha', { delimiter: undefined }),
+    ];
+
+    expect(toTree(queues).children.map((node) => node.name)).toEqual(['zeta', 'beta', 'alpha']);
+    expect(toTree(queues, true).children.map((node) => node.name)).toEqual([
+      'beta',
+      'alpha',
+      'zeta',
+    ]);
+  });
+});
+
+describe('collectGroupPaths', () => {
+  it('returns every group path and no leaf', () => {
+    const root = toTree([
+      makeQueue('billing.invoices.retry'),
+      makeQueue('billing.refunds'),
+      makeQueue('standalone', { delimiter: undefined }),
+    ]);
+
+    expect(collectGroupPaths(root)).toEqual(['billing', 'billing/invoices']);
+  });
+
+  it('returns nothing for a flat tree', () => {
+    expect(collectGroupPaths(toTree([makeQueue('flat', { delimiter: undefined })]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Tests for four bits of logic that had none:

- `queueTreeCounts.ts`, no spec, 30% of statements. `collectQueueNames({ writableOnly })` and `areAllPaused` decide what a bulk action targets, and both fail quietly when wrong.
- `toTree.ts`, no spec, 68%. Delimiter splitting, prefix merging, and splitting inside a `{...}` cluster hash tag.
- `useInterval.ts`, 10%. The `isLastFinished` guard that stops slow polls stacking up on a 15s refresh.
- `MetricsRecorder` timer lifecycle, 66% of functions, since the existing specs call `snapshot()` directly. start/stop, the `unref()`, the `running` guard, and the rule that `stop()` leaves a caller's own Redis client alone.

That last one turned up a bug: `stop()` disconnected an owned Redis client again on a second call, leaving a pending ioredis reconnect timer that can hold a process open. One-line guard, with a test. Only source change here.

Each test was checked red against a deliberately broken copy of the code it covers.
