### PR TITLE
fix(docker): wait for the whole release tree to be installable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,20 +34,23 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           IMAGE: ghcr.io/${{ github.repository }}
-          ATTEMPTS: ${{ inputs.wait_for_publish && 30 || 1 }}
+          ATTEMPTS: ${{ inputs.wait_for_publish && 40 || 1 }}
         run: |
+          mkdir -p "$RUNNER_TEMP/resolve"
           for attempt in $(seq 1 "$ATTEMPTS"); do
-            if npm view "@bull-board/cli@$VERSION" version > /dev/null 2>&1; then
+            if npm install "@bull-board/cli@$VERSION" --prefix "$RUNNER_TEMP/resolve" \
+                 --dry-run --omit=dev --no-audit --no-fund --prefer-online > /dev/null 2>&1 &&
+               npm view @bull-board/cli --json --prefer-online > "$RUNNER_TEMP/packument.json" &&
+               node -e 'process.exit(require(`${process.env.RUNNER_TEMP}/packument.json`).versions.includes(process.env.VERSION) ? 0 : 1)'; then
               break
             fi
             if [ "$attempt" = "$ATTEMPTS" ]; then
-              echo "@bull-board/cli@$VERSION is not on npm" >&2
+              echo "@bull-board/cli@$VERSION is not installable from npm" >&2
               exit 1
             fi
-            sleep 10
+            sleep 15
           done
 
-          npm view @bull-board/cli --json > "$RUNNER_TEMP/packument.json"
           node -e '
             const pkg = require(`${process.env.RUNNER_TEMP}/packument.json`);
             const { VERSION, IMAGE } = process.env;


### PR DESCRIPTION
The v9.6.0 image build failed, so there is no image on GHCR for it:

```
npm error notarget No matching version found for @bull-board/api@9.6.0.
```

The wait loop only asked npm whether `@bull-board/cli@9.6.0` existed. It did, so the build started, and then npm resolved the CLI's pinned `@bull-board/api@9.6.0` and got a 404, about 100 seconds after api had been published. `@bull-board/cli` is a new package, so its document was fetched from the origin. `@bull-board/api` is requested constantly, so a cached copy from before the publish was still being served. Checking the top level package says nothing about whether the versions it depends on are visible yet.

## What changed

The gate now runs a dry run of the install the Dockerfile performs:

```
npm install "@bull-board/cli@$VERSION" --prefix "$RUNNER_TEMP/resolve" \
  --dry-run --omit=dev --no-audit --no-fund --prefer-online
```

It resolves every dependency, so it fails the same way while any pinned `@bull-board/*` version is still missing, and the loop keeps waiting instead of starting a build that cannot pass.

Two smaller changes come with it. The packument used to pick the tags is fetched inside the loop and checked to contain the version, because a stale one would have produced an image tagged `9.6.0` only, dropping `:9` and `:latest` without failing. And the wait went from 30 attempts every 10 seconds to 40 every 15, since 100 seconds was not enough in this run.

Checked against the live registry: `9.6.0` gives `9.6.0,9,latest`, `9.5.0` gives `9.5.0` alone, and a version that does not exist exits 1 with no tags. Forcing `@bull-board/api` to an unpublished version through an npm override reproduces the original error in the dry run, which the old check passed.

## Next steps for you

1. Merge this.
2. Run the `Docker image` workflow manually with version `9.6.0` to build the image that the release missed. Since 9.6.0 is still the newest release, it will take `:9.6.0`, `:9` and `:latest`.
3. That run creates the GHCR package as private under the repo owner. It needs to be switched to public once in the package settings, which nothing in the workflow can do.

After that the release pipeline handles it on its own.
