### PR TITLE
feat(h3): support h3 2.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,35 @@ const base = require('./jest.base.js');
 module.exports = { ...base, displayName: 'express@4', moduleNameMapper: { '^express$': 'express-v4' } };
 ```
 
+### h3 version matrix
+
+`@bull-board/h3` declares `h3` as `^1.15.11 || ^2.0.0`. `yarn workspace @bull-board/h3 test` is
+two `jest` invocations over one spec file: `jest.config.js` maps `h3` to the `h3-v1` alias,
+`jest.config.v2.js` maps it to `h3-v2`, pinned to `2.0.1-rc.29`. The RC is what h3 publishes as
+`latest`; 1.x sits on the `1x` tag. Because a prerelease does not satisfy `^2.0.0`, installs keep
+resolving 1.x until a stable 2.0.0 ships, at which point they move without another release here.
+
+Two things in `H3Adapter` are load-bearing for 2.x and easy to undo by accident:
+
+- Routes are registered as `router[method](path, handler)`, never `router.use(path, handler,
+  method)`. Both forms match on 1.x, but the `use` form yields an empty params object on 2.x, so
+  every `:queueName` and `:jobId` route silently resolves to nothing and the API answers
+  `ERRORS.QUEUE_NOT_FOUND` for real queues while `GET /api/queues` keeps working.
+- The entry route sets `content-type: text/html` explicitly. 1.x infers it from the leading `<`;
+  2.x does not, and serves the dashboard as `text/plain`, so the browser shows the raw source.
+
+Like NestJS 12, h3 2.x is ESM only, so `jest.config.v2.js` is an ESM project behind
+`NODE_OPTIONS=--experimental-vm-modules`.
+
+It also cannot drive the app through `toNodeListener` plus supertest. h3 2.x sends its response
+through srvx, which does `res instanceof Promise` (`srvx/dist/adapters/node.mjs`) to decide
+whether to await the handler. A promise created inside jest's VM realm fails that check, srvx
+treats the promise itself as the body, and every async handler dies on `TypeError:
+webRes.headers is not iterable`. This is a jest realm artifact, not an adapter bug: the same code
+works against a real `http.createServer`. `tests/contract.spec.ts` therefore probes for
+`app.fetch`, which 2.x exposes and 1.x does not, and drives the web-standard entry point when it
+is there, falling back to `toNodeListener` plus supertest on 1.x.
+
 ### Runtime notes (adapters that need special handling)
 
 - **`packages/bun`** runs under Bun's native runtime, so its suite runs via `bun test` (not Jest) and lives in a dedicated CI job. The contract kit is Jest-compatible under `bun test` (`describe`/`it`/`expect`), so the spec reuses it unchanged. Bun is excluded from the Node `yarn test` foreach because its `test` script invokes `bun test`, which the Node runner can't execute.

--- a/packages/h3/jest.base.js
+++ b/packages/h3/jest.base.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  testTimeout: 30000,
+};

--- a/packages/h3/jest.config.v2.js
+++ b/packages/h3/jest.config.v2.js
@@ -2,17 +2,20 @@ const base = require('./jest.base.js');
 
 module.exports = {
   ...base,
-  displayName: 'h3@1',
+  displayName: 'h3@2',
+  extensionsToTreatAsEsm: ['.ts'],
+  testEnvironmentOptions: { customExportConditions: ['node'] },
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
+        useESM: true,
         tsconfig: {
           esModuleInterop: true,
           lib: ['es2022', 'DOM'],
-          module: 'CommonJS',
+          module: 'esnext',
           strict: true,
-          target: 'es2019',
+          target: 'es2022',
           resolveJsonModule: true,
           skipLibCheck: true,
           types: ['node', 'jest'],
@@ -20,5 +23,5 @@ module.exports = {
       },
     ],
   },
-  moduleNameMapper: { '^h3$': 'h3-v1', '^h3/(.*)$': 'h3-v1/$1' },
+  moduleNameMapper: { '^h3$': 'h3-v2', '^h3/(.*)$': 'h3-v2/$1' },
 };

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -30,13 +30,13 @@
   "scripts": {
     "build": "yarn clean && tsc",
     "clean": "rm -rf dist",
-    "test": "jest"
+    "test": "jest && NODE_OPTIONS=--experimental-vm-modules jest -c jest.config.v2.js"
   },
   "dependencies": {
     "@bull-board/api": "9.6.1",
     "@bull-board/ui": "9.6.1",
     "ejs": "^6.0.1",
-    "h3": "^1.15.11"
+    "h3": "^1.15.11 || ^2.0.0"
   },
   "devDependencies": {
     "@bull-board/test-utils": "9.6.1",
@@ -44,6 +44,8 @@
     "@types/jest": "^30.0.0",
     "@types/supertest": "^7.2.1",
     "bullmq": "^5.81.3",
+    "h3-v1": "npm:h3@^1.15.11",
+    "h3-v2": "npm:h3@2.0.1-rc.29",
     "jest": "^30.4.2",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.12"

--- a/packages/h3/src/H3Adapter.ts
+++ b/packages/h3/src/H3Adapter.ts
@@ -19,6 +19,7 @@ import {
   readBody,
   serveStatic,
   getHeaders,
+  setResponseHeader,
   setResponseStatus,
 } from 'h3';
 import { getContentType } from './utils/getContentType';
@@ -125,17 +126,20 @@ export class H3Adapter implements IServerAdapter {
     const routes = Array.isArray(route) ? route : [route];
 
     routes.forEach((route) => {
-      this.uiHandler.use(
+      this.uiHandler[method](
         `${this.basePath}${route}`,
-        eventHandler(async () => {
+        eventHandler(async (event) => {
           const { name: filename, params } = handler({
             basePath: this.basePath,
             uiConfig: this.uiConfig,
           });
 
+          // h3@1 infers text/html from the leading '<'; h3@2 does not, and serves the
+          // dashboard as text/plain unless the type is set explicitly.
+          setResponseHeader(event, 'content-type', 'text/html; charset=utf-8');
+
           return ejs.renderFile(`${this.viewPath}/${filename}`, params);
-        }),
-        method
+        })
       );
     });
 
@@ -178,7 +182,7 @@ export class H3Adapter implements IServerAdapter {
     const routes = Array.isArray(routeOrRoutes) ? routeOrRoutes : [routeOrRoutes];
 
     routes.forEach((route) => {
-      this.uiHandler.use(
+      this.uiHandler[method](
         `${this.basePath}${route}`,
         eventHandler(async (event) => {
           try {
@@ -206,8 +210,7 @@ export class H3Adapter implements IServerAdapter {
               });
             }
           }
-        }),
-        method
+        })
       );
     });
   }

--- a/packages/h3/tests/contract.spec.ts
+++ b/packages/h3/tests/contract.spec.ts
@@ -9,6 +9,10 @@ import { createApp, toNodeListener } from 'h3';
 import request from 'supertest';
 import { H3Adapter } from '../src';
 
+type WebApp = { fetch: (request: Request) => Promise<Response> };
+
+const hasFetch = (app: unknown): app is WebApp => typeof (app as WebApp).fetch === 'function';
+
 runServerAdapterContract('H3', async ({ basePath, queue }) => {
   const serverAdapter = new H3Adapter();
   serverAdapter.setBasePath(basePath);
@@ -18,13 +22,32 @@ runServerAdapterContract('H3', async ({ basePath, queue }) => {
     options: { uiBasePath: uiFixtureBasePath },
   });
 
-  const router = serverAdapter.registerHandlers();
   const app = createApp();
-  app.use(router);
-  const listener = toNodeListener(app);
+  app.use(serverAdapter.registerHandlers());
 
-  const send = async (req: ContractRequest): Promise<NormalizedResponse> => {
-    const agent = request(listener);
+  // h3@2 apps are web-standard and expose `fetch`. Driving that directly rather than
+  // going through `toNodeListener` keeps the suite off h3's node response layer, which
+  // rejects a promise created in jest's VM realm (`res instanceof Promise` in srvx).
+  const sendWeb = async (req: ContractRequest): Promise<NormalizedResponse> => {
+    const hasBody = req.body !== undefined;
+    const res = await (app as unknown as WebApp).fetch(
+      new Request(`http://localhost${req.path}`, {
+        method: req.method.toUpperCase(),
+        headers: hasBody ? { 'content-type': 'application/json' } : undefined,
+        body: hasBody ? JSON.stringify(req.body) : undefined,
+      })
+    );
+
+    const headers: Record<string, string | string[]> = {};
+    res.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    return { status: res.status, headers, text: await res.text() };
+  };
+
+  const sendNode = async (req: ContractRequest): Promise<NormalizedResponse> => {
+    const agent = request(toNodeListener(app));
     const m = req.method.toLowerCase() as 'get' | 'post' | 'put' | 'delete';
     let r = agent[m](req.path);
     if (req.body !== undefined) r = r.send(req.body as object);
@@ -32,5 +55,8 @@ runServerAdapterContract('H3', async ({ basePath, queue }) => {
     return { status: res.status, headers: res.headers as any, text: res.text };
   };
 
-  return { request: send, teardown: async () => undefined };
+  return {
+    request: hasFetch(app) ? sendWeb : sendNode,
+    teardown: async () => undefined,
+  };
 });

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,7 +1,6 @@
-import path from 'path';
 export * from './serverAdapterContract';
 export * from './redisFixtures';
 // src/uiFixture/dist/ mirrors the real UI build layout so createBullBoard resolves
-// view templates and static files the same way a production adapter would.
-/** Absolute path to the fixture UI base dir (contains dist/index.ejs + dist/static). */
-export const uiFixtureBasePath = path.join(__dirname, 'uiFixture');
+// view templates and static files the same way a production adapter would. The path is
+// computed in a CommonJS sibling so this barrel stays loadable from an ESM jest project.
+export { uiFixtureBasePath } from './uiFixturePath';

--- a/packages/test-utils/src/uiFixturePath.d.ts
+++ b/packages/test-utils/src/uiFixturePath.d.ts
@@ -1,0 +1,1 @@
+export declare const uiFixtureBasePath: string;

--- a/packages/test-utils/src/uiFixturePath.js
+++ b/packages/test-utils/src/uiFixturePath.js
@@ -1,0 +1,3 @@
+const path = require('path');
+
+module.exports.uiFixtureBasePath = path.join(__dirname, 'uiFixture');

--- a/website/docs/server-adapters/h3.md
+++ b/website/docs/server-adapters/h3.md
@@ -36,6 +36,16 @@ app.use(serverAdapter.registerHandlers());
 
 `registerHandlers()` returns an H3 handler tree. Mount it alongside your router, the adapter handles its own sub-paths under the base path.
 
+## Supported h3 versions
+
+`@bull-board/h3` supports h3 1.x and 2.x, and the suite runs against both on every CI build.
+The 2.x side is tested against `2.0.1-rc.29`, because that is what h3 currently publishes under
+its `latest` tag; 1.x lives on the `1x` tag. The declared range picks up a stable 2.0.0 as soon
+as it ships.
+
+You do not need to configure anything. The adapter registers its routes and sets the content type
+of the dashboard HTML explicitly, which is what makes the same code work on both majors.
+
 ## Full runnable example
 
 - Simple setup: [`examples/with-h3`](https://github.com/felixmosh/bull-board/tree/master/examples/with-h3)

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,7 +620,9 @@ __metadata:
     "@types/supertest": "npm:^7.2.1"
     bullmq: "npm:^5.81.3"
     ejs: "npm:^6.0.1"
-    h3: "npm:^1.15.11"
+    h3: "npm:^1.15.11 || ^2.0.0"
+    h3-v1: "npm:h3@^1.15.11"
+    h3-v2: "npm:h3@2.0.1-rc.29"
     jest: "npm:^30.4.2"
     supertest: "npm:^7.2.2"
     ts-jest: "npm:^29.4.12"
@@ -8690,7 +8692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"h3@npm:^1.15.11":
+"h3-v1@npm:h3@^1.15.11, h3@npm:^1.15.11 || ^2.0.0":
   version: 1.15.11
   resolution: "h3@npm:1.15.11"
   dependencies:
@@ -8704,6 +8706,26 @@ __metadata:
     ufo: "npm:^1.6.3"
     uncrypto: "npm:^0.1.3"
   checksum: 10c0/6ccb421b9f92e02e6330c2b6697b18ef18e9550e4a1708f224ca517c40ecd201cd00967d0feb26e718595e86e985edec1755933cf8792d34fb8504f1c7cc261d
+  languageName: node
+  linkType: hard
+
+"h3-v2@npm:h3@2.0.1-rc.29":
+  version: 2.0.1-rc.29
+  resolution: "h3@npm:2.0.1-rc.29"
+  dependencies:
+    rou3: "npm:^0.9.2"
+    srvx: "npm:^0.12.7"
+  peerDependencies:
+    crossws: ^0.4.12
+    ocache: ">=0.3.0"
+  peerDependenciesMeta:
+    crossws:
+      optional: true
+    ocache:
+      optional: true
+  bin:
+    h3: bin/h3.mjs
+  checksum: 10c0/1c5801977ca6414f5f0c858477841e6a12434381dd5c3902b1c14b9e3193978030dfdcb0cde17bda23809bf49e8d04858d593280aa857bde9fa7219080c89a6d
   languageName: node
   linkType: hard
 
@@ -14194,6 +14216,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rou3@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "rou3@npm:0.9.2"
+  checksum: 10c0/4b0ab14fbd3a7c60ffee1af644f618a9e76dd218cd4fbb585b8fa3601a3f25857c2b1656a215389379a7aef1e1e1897fd55e835658e9c3a5d9683571b36b3bd6
+  languageName: node
+  linkType: hard
+
 "router@npm:^2.2.0":
   version: 2.2.0
   resolution: "router@npm:2.2.0"
@@ -14745,6 +14774,15 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
+  languageName: node
+  linkType: hard
+
+"srvx@npm:^0.12.7":
+  version: 0.12.8
+  resolution: "srvx@npm:0.12.8"
+  bin:
+    srvx: ./bin/srvx.mjs
+  checksum: 10c0/b582f89b440b39018fc37bed4f860ff4291d4302dc625e7eaab567d39894a217c71ae92b2766b93725aae2e2805367d21c9f97770548032d9abb8feb7f777799
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
h3 publishes `2.0.1-rc.29` under its `latest` tag, and `@bull-board/h3` had never been run against 2.x. Two things break there, both fixed here:

- Routes were registered as `router.use(path, handler, method)`, which loses its params on 2.x, so every `:queueName` and `:jobId` route answered `ERRORS.QUEUE_NOT_FOUND` for queues that exist. They are now registered as `router[method](path, handler)`.
- 2.x does not infer `text/html` from the response body, so the dashboard was served as `text/plain` and browsers showed the raw source. The entry route now sets the content type explicitly.

Neither changes behaviour on 1.x. The declared range becomes `^1.15.11 || ^2.0.0`, and `yarn workspace @bull-board/h3 test` now runs the contract suite against both majors.

`@bull-board/test-utils` computes its fixture path in a CommonJS sibling now, so the kit also loads from the ESM jest project that h3 2.x requires.
