### PR TITLE
feat(cli): historical metrics behind --history

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ BullMQ keeps only a short ring buffer of per-minute metrics, so the throughput c
 npm install @bull-board/metrics
 ```
 
+The CLI and the Docker image carry the package already, so `--history` turns the same thing on with nothing to install:
+
+```sh
+npx @bull-board/cli -r redis://localhost:6379 --history
+```
+
 See the [historical metrics recipe](https://felixmosh.github.io/bull-board/recipes/historical-metrics) for the recorder setup and storage sizing, or try it on the [live demo](https://felixmosh.github.io/bull-board/demo/).
 
 ## Packages

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,6 +38,9 @@ Options:
       --user <name>       Basic auth user (requires --password)
       --password <pass>   Basic auth password (requires --user)
       --board-title <s>   Dashboard title
+      --history           Record and serve long-retention metrics history
+      --history-retention-days <n>
+                          Days of history to keep            [90]
       --config <file>     Path to a config file
       --browser <command> Command to open the browser with     [$BROWSER]
       --no-open           Do not open a browser
@@ -63,6 +66,20 @@ module.exports = {
   },
 };
 ```
+
+## Historical metrics
+
+`--history` turns on the long-retention metrics that otherwise need `@bull-board/metrics` wired into an app of your own:
+
+```sh
+npx @bull-board/cli -r redis://localhost:6379 --history
+```
+
+Every queue chart gains a 60m / 7d / 30d / 90d range selector, and a cross-queue Metrics history page shows up in the sidebar. The CLI process does the recording itself, copying throughput, wait time, run time and queue age into Redis once a minute under the `bull-board:metrics:` namespace, never over a key Bull or BullMQ owns. Recording follows discovery, so a queue that appears between rescans is picked up on the next tick.
+
+`--history-retention-days` sets the window, 90 days by default. Per-tier retention, the snapshot interval and `latency: false` go in the config file under a `history` key. `--read-only` keeps the reading and stops the writing, for a board that only displays what another process records.
+
+Completed and failed history comes out of BullMQ's own metrics buffer, so it stays empty unless your workers were built with `metrics: { maxDataPoints: MetricsTime.ONE_WEEK }`; the CLI warns at startup when no discovered queue has any. Latency and queue age need nothing from your workers. See the [historical metrics recipe](https://felixmosh.github.io/bull-board/recipes/historical-metrics) for storage sizing and what the charts show.
 
 ## Docker
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@bull-board/api": "9.6.1",
     "@bull-board/express": "9.6.1",
+    "@bull-board/metrics": "9.6.1",
     "bull": "^4.16.5",
     "bullmq": "^5.81.3",
     "express": "^5.2.1",

--- a/packages/cli/src/config/flags.ts
+++ b/packages/cli/src/config/flags.ts
@@ -12,6 +12,8 @@ export const FLAG_OPTIONS = {
   user: { type: 'string' },
   password: { type: 'string' },
   'board-title': { type: 'string' },
+  history: { type: 'boolean' },
+  'history-retention-days': { type: 'string' },
   config: { type: 'string' },
   'no-open': { type: 'boolean' },
   'no-retry': { type: 'boolean' },

--- a/packages/cli/src/config/resolve.ts
+++ b/packages/cli/src/config/resolve.ts
@@ -1,6 +1,6 @@
 import type { QueueAdapterOptions } from '@bull-board/api/typings/app';
 import type { FlagValues } from './flags';
-import type { CliConfig, FileConfig } from './types';
+import type { CliConfig, FileConfig, FileHistoryConfig, HistoryConfig } from './types';
 
 const DEFAULTS = {
   redisUrl: 'redis://localhost:6379',
@@ -73,6 +73,14 @@ export function resolveConfig({
     uiConfig.boardTitle = boardTitle;
   }
 
+  const readOnly =
+    flags['read-only'] ?? toBoolean(env.BULL_BOARD_READ_ONLY) ?? file.readOnly ?? false;
+  const history = resolveHistory({ flags, env, file, readOnly });
+  if (history) {
+    // Without showMetrics the per-queue chart never renders, so nor does its range selector.
+    uiConfig.showMetrics = uiConfig.showMetrics ?? true;
+  }
+
   return {
     redisUrl: firstDefined(flags.redis, env.BULL_BOARD_REDIS_URL, file.redis) ?? DEFAULTS.redisUrl,
     port:
@@ -98,12 +106,43 @@ export function resolveConfig({
       normalizeBasePath(env.BULL_BOARD_BASE_PATH) ??
       normalizeBasePath(file.basePath) ??
       '',
-    readOnly: flags['read-only'] ?? toBoolean(env.BULL_BOARD_READ_ONLY) ?? file.readOnly ?? false,
+    readOnly,
     auth: user && password ? { user, password } : null,
     open: flags['no-open'] === true ? false : (toBoolean(env.BULL_BOARD_OPEN) ?? file.open ?? true),
     browser: firstDefined(flags.browser, env.BULL_BOARD_BROWSER, env.BROWSER, file.browser),
     uiConfig,
     queueOptions,
     noRetry: flags['no-retry'] ?? toBoolean(env.BULL_BOARD_NO_RETRY) ?? file.noRetry ?? false,
+    history,
+  };
+}
+
+function resolveHistory({
+  flags,
+  env,
+  file,
+  readOnly,
+}: {
+  flags: FlagValues;
+  env: NodeJS.ProcessEnv;
+  file: FileConfig;
+  readOnly: boolean;
+}): HistoryConfig | null {
+  const fileHistory: FileHistoryConfig =
+    typeof file.history === 'boolean' ? { enabled: file.history } : (file.history ?? {});
+  const enabled =
+    flags.history ?? toBoolean(env.BULL_BOARD_HISTORY) ?? fileHistory.enabled ?? false;
+  if (!enabled) return null;
+
+  return {
+    // Recording writes to Redis, which is what --read-only says not to do.
+    record: fileHistory.record ?? !readOnly,
+    retentionDays:
+      toNumber(flags['history-retention-days'], 'history-retention-days') ??
+      toNumber(env.BULL_BOARD_HISTORY_RETENTION_DAYS, 'history-retention-days') ??
+      toNumber(fileHistory.retentionDays, 'history-retention-days'),
+    retention: fileHistory.retention,
+    latency: fileHistory.latency ?? true,
+    snapshotIntervalMs: fileHistory.snapshotIntervalMs,
   };
 }

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -1,4 +1,23 @@
 import type { QueueAdapterOptions, UIConfig } from '@bull-board/api/typings/app';
+import type { Retention } from '@bull-board/metrics';
+
+export interface FileHistoryConfig {
+  enabled?: boolean;
+  /** Write snapshots from this process. Defaults to true unless the board is read-only. */
+  record?: boolean;
+  retentionDays?: number;
+  retention?: Partial<Retention>;
+  latency?: boolean;
+  snapshotIntervalMs?: number;
+}
+
+export interface HistoryConfig {
+  record: boolean;
+  retentionDays?: number;
+  retention?: Partial<Retention>;
+  latency: boolean;
+  snapshotIntervalMs?: number;
+}
 
 export interface FileConfig {
   redis?: string;
@@ -15,6 +34,7 @@ export interface FileConfig {
   browser?: string;
   uiConfig?: UIConfig;
   noRetry?: boolean;
+  history?: boolean | FileHistoryConfig;
 }
 
 export interface CliConfig {
@@ -32,4 +52,5 @@ export interface CliConfig {
   uiConfig: UIConfig;
   queueOptions: Record<string, Partial<QueueAdapterOptions>>;
   noRetry: boolean;
+  history: HistoryConfig | null;
 }

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -17,6 +17,9 @@ Options:
       --user <name>       Basic auth user (requires --password)
       --password <pass>   Basic auth password (requires --user)
       --board-title <s>   Dashboard title
+      --history           Record and serve long-retention metrics history
+      --history-retention-days <n>
+                          Days of history to keep            [90]
       --config <file>     Path to a config file
       --browser <command> Command to open the browser with     [$BROWSER]
       --no-open           Do not open a browser
@@ -32,6 +35,12 @@ later. The diagnostic page does not come back; API requests just stop
 returning until Redis is reachable again, and Ctrl-C still works.
 Pass --no-retry to get the old behaviour back instead: print the error and
 exit 1 immediately, without opening a port.
+
+--history turns on historical metrics: the dashboard gains a range selector
+per queue and a cross-queue Metrics history page, and this process records
+throughput, latency and queue age into Redis under the bull-board:metrics:
+namespace once a minute. --read-only stops the recording but keeps serving
+whatever another process has recorded.
 
 Environment variables mirror every flag, for example BULL_BOARD_REDIS_URL,
 BULL_BOARD_PORT, BULL_BOARD_READ_ONLY.

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -1,0 +1,70 @@
+import type { BaseAdapter } from '@bull-board/api/baseAdapter';
+import type { MetricsHistoryProvider } from '@bull-board/api/typings/app';
+import { MetricsRecorder, RedisMetricsHistoryProvider } from '@bull-board/metrics';
+import type { Redis } from 'ioredis';
+import type { HistoryConfig } from './config/types';
+import { describeError } from './describeError';
+
+export interface HistoryRuntime {
+  provider: MetricsHistoryProvider;
+  start(queues: () => BaseAdapter[]): void;
+  stop(): void;
+}
+
+export interface HistoryDeps {
+  client: Redis;
+  config: HistoryConfig;
+  onWarning(message: string): void;
+}
+
+export function createHistory({ client, config, onWarning }: HistoryDeps): HistoryRuntime {
+  const retentionWindow = { retentionDays: config.retentionDays, retention: config.retention };
+  const provider = new RedisMetricsHistoryProvider({ connection: client, ...retentionWindow });
+  let recorder: MetricsRecorder | null = null;
+
+  return {
+    provider,
+    start(queues) {
+      if (!config.record || recorder) return;
+
+      recorder = new MetricsRecorder({
+        queues,
+        connection: client,
+        ...retentionWindow,
+        latency: config.latency,
+        snapshotIntervalMs: config.snapshotIntervalMs,
+        onLatencyError: (error, queueName) =>
+          onWarning(`Latency sampling failed for "${queueName}": ${describeError(error as Error)}`),
+      });
+      recorder.start();
+    },
+    stop() {
+      recorder?.stop();
+      recorder = null;
+      provider.disconnect();
+    },
+  };
+}
+
+export async function warnIfCountersUnavailable(
+  queues: BaseAdapter[],
+  onWarning: (message: string) => void
+): Promise<void> {
+  if (queues.length === 0) return;
+
+  const populated = await Promise.all(
+    queues.map((queue) =>
+      queue
+        .getMetrics('completed')
+        .then((metrics) => (metrics?.data?.length ?? 0) > 0)
+        .catch(() => false)
+    )
+  );
+  if (populated.some(Boolean)) return;
+
+  onWarning(
+    'No BullMQ metrics data found on any queue. Completed and failed history stays empty ' +
+      'until your workers are created with metrics: { maxDataPoints: MetricsTime.ONE_WEEK }. ' +
+      'Latency and queue age are recorded either way.'
+  );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import type { CliConfig } from './config/types';
 import { maskRedisUrl, RETRY_INTERVAL_MS, type ConnectionState } from './connectionState';
 import { describeError } from './describeError';
 import { discoverQueues, probeQueues } from './discovery';
+import { createHistory, warnIfCountersUnavailable } from './history';
 import { createQueueFactory } from './queueFactory';
 import { QueueRegistry } from './registry';
 import { startServer } from './server';
@@ -78,15 +79,19 @@ export async function run(
     );
   }
 
+  const onWarning = (message: string) => log.warn(message);
+  const history = config.history
+    ? createHistory({ client, config: config.history, onWarning })
+    : null;
+
   const serverAdapter = new ExpressAdapter();
   serverAdapter.setBasePath(config.basePath);
   const board = createBullBoard({
     queues: [],
     serverAdapter,
-    options: { uiConfig: config.uiConfig },
+    options: { uiConfig: config.uiConfig, historyProvider: history?.provider },
   });
 
-  const onWarning = (message: string) => log.warn(message);
   const queues = createQueueFactory({
     client,
     readOnly: config.readOnly,
@@ -112,6 +117,20 @@ export async function run(
     await registry.sync(discovered);
 
     return discovered.length;
+  };
+
+  const startHistory = async () => {
+    if (!history) return;
+
+    history.start(() => registry.adapters());
+    if (config.history?.record) {
+      await warnIfCountersUnavailable(registry.adapters(), onWarning);
+    } else {
+      log.warn(
+        'Historical metrics are served read-only: this process records nothing, so the charts ' +
+          'show only what another process has already recorded.'
+      );
+    }
   };
 
   const logIfIdle = (count: number) => {
@@ -145,10 +164,12 @@ export async function run(
     }
 
     const count = await scan();
+    await startHistory();
     const server = await startServer(config, { serverAdapter });
 
     const close = async () => {
       closing = true;
+      history?.stop();
       if (rescanTimer) clearTimeout(rescanTimer);
       await closeWithGrace(server.close(), SHUTDOWN_GRACE_MS, () => {
         log.warn(
@@ -192,6 +213,7 @@ export async function run(
 
   const close = async () => {
     closing = true;
+    history?.stop();
     if (rescanTimer) clearTimeout(rescanTimer);
     await closeWithGrace(server.close(), SHUTDOWN_GRACE_MS, () => {
       log.warn(
@@ -260,6 +282,7 @@ export async function run(
           attempts: state.attempts,
         };
         scheduleRescan();
+        await startHistory();
         if (everFailed) log.log('Redis connected. The dashboard is live.');
         if (deferIdleLog) {
           deferredIdleCount = count;

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -24,6 +24,10 @@ export class QueueRegistry {
 
   constructor(private readonly deps: QueueRegistryDeps) {}
 
+  public adapters(): BaseAdapter[] {
+    return [...this.live.values()].map((handle) => handle.adapter);
+  }
+
   public async sync(discovered: DiscoveredQueue[]): Promise<void> {
     // The board keys queues by bare name, so the same name under two prefixes would displace
     // itself. First prefix wins.

--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -920,6 +920,140 @@ describe('cli', () => {
     }
   });
 
+  describe('--history', () => {
+    async function waitForKeys(pattern: string, timeoutMs = 10000): Promise<string[]> {
+      const deadline = Date.now() + timeoutMs;
+      let found: string[] = [];
+      while (Date.now() < deadline) {
+        found = await keysUnder(client, pattern);
+        if (found.length > 0) return found;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      return found;
+    }
+
+    it('serves the history API, advertises it to the UI, and records into Redis', async () => {
+      const name = unique('history-on');
+      const queue = new BullMQQueue(name, { connection: redisOptions });
+      await queue.waitUntilReady();
+
+      try {
+        const cli = await startCli([
+          '--redis',
+          REDIS_URL,
+          '--queues',
+          name,
+          '--scan-interval',
+          '0',
+          '--port',
+          '0',
+          '--history',
+        ]);
+        try {
+          const to = Date.now();
+          const response = await fetch(
+            `${cli.url}/api/metrics/history?from=${to - 86400000}&to=${to}`
+          );
+          const body = (await response.json()) as Record<string, unknown[]>;
+
+          expect(response.status).toBe(200);
+          expect(Array.isArray(body.completed)).toBe(true);
+          expect(Array.isArray(body.failed)).toBe(true);
+
+          const html = await (await fetch(cli.url)).text();
+          expect(html).toContain('"hasHistoryProvider":true');
+          expect(html).toContain('"showMetrics":true');
+
+          expect(await waitForKeys(`bull-board:metrics:${name}:*`)).not.toEqual([]);
+        } finally {
+          await cli.stop();
+        }
+      } finally {
+        await queue.obliterate({ force: true }).catch(() => {});
+        await queue.close().catch(() => {});
+        await deleteKeysUnder(client, `bull:${name}:*`).catch(() => {});
+        await deleteKeysUnder(client, `bull-board:metrics:${name}:*`).catch(() => {});
+      }
+    });
+
+    it('serves history read-only under --read-only, writing nothing', async () => {
+      const name = unique('history-ro');
+      const queue = new BullMQQueue(name, { connection: redisOptions });
+      await queue.waitUntilReady();
+
+      try {
+        const cli = await startCli([
+          '--redis',
+          REDIS_URL,
+          '--queues',
+          name,
+          '--scan-interval',
+          '0',
+          '--port',
+          '0',
+          '--history',
+          '--read-only',
+        ]);
+        try {
+          const to = Date.now();
+          const response = await fetch(
+            `${cli.url}/api/metrics/history?from=${to - 86400000}&to=${to}`
+          );
+          expect(response.status).toBe(200);
+
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          expect(await keysUnder(client, `bull-board:metrics:${name}:*`)).toEqual([]);
+          expect(cli.stdout() + cli.stderr()).toContain('read-only');
+        } finally {
+          await cli.stop();
+        }
+      } finally {
+        await queue.obliterate({ force: true }).catch(() => {});
+        await queue.close().catch(() => {});
+        await deleteKeysUnder(client, `bull:${name}:*`).catch(() => {});
+        await deleteKeysUnder(client, `bull-board:metrics:${name}:*`).catch(() => {});
+      }
+    });
+
+    it('registers no history provider without the flag', async () => {
+      const name = unique('history-off');
+      const queue = new BullMQQueue(name, { connection: redisOptions });
+      await queue.waitUntilReady();
+
+      try {
+        const cli = await startCli([
+          '--redis',
+          REDIS_URL,
+          '--queues',
+          name,
+          '--scan-interval',
+          '0',
+          '--port',
+          '0',
+        ]);
+        try {
+          const to = Date.now();
+          const response = await fetch(
+            `${cli.url}/api/metrics/history?from=${to - 86400000}&to=${to}`
+          );
+          expect(await response.text()).not.toContain('"completed"');
+
+          const html = await (await fetch(cli.url)).text();
+          expect(html).not.toContain('"hasHistoryProvider":true');
+
+          expect(await keysUnder(client, `bull-board:metrics:${name}:*`)).toEqual([]);
+        } finally {
+          await cli.stop();
+        }
+      } finally {
+        await queue.obliterate({ force: true }).catch(() => {});
+        await queue.close().catch(() => {});
+        await deleteKeysUnder(client, `bull:${name}:*`).catch(() => {});
+      }
+    });
+  });
+
   it('never mutates the Redis keys it observes', async () => {
     const prefix = unique('no-mutate');
     const mqName = unique('no-mutate-mq');

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -196,6 +196,74 @@ describe('resolveConfig', () => {
     expect(config.open).toBe(false);
   });
 
+  it('leaves history off until something asks for it', () => {
+    expect(resolveConfig({ flags: parseFlags([]), env: noEnv, file: noFile }).history).toBeNull();
+  });
+
+  it('turns history on from a flag, an env var or the config file, in that order', () => {
+    const fromFlag = resolveConfig({
+      flags: parseFlags(['--history', '--history-retention-days', '30']),
+      env: { BULL_BOARD_HISTORY_RETENTION_DAYS: '60' } as NodeJS.ProcessEnv,
+      file: { history: { retentionDays: 90 } },
+    });
+    expect(fromFlag.history).toMatchObject({ record: true, retentionDays: 30, latency: true });
+
+    const fromEnv = resolveConfig({
+      flags: parseFlags([]),
+      env: {
+        BULL_BOARD_HISTORY: 'true',
+        BULL_BOARD_HISTORY_RETENTION_DAYS: '60',
+      } as NodeJS.ProcessEnv,
+      file: { history: { retentionDays: 90 } },
+    });
+    expect(fromEnv.history).toMatchObject({ retentionDays: 60 });
+
+    const fromFile = resolveConfig({
+      flags: parseFlags([]),
+      env: noEnv,
+      file: { history: { enabled: true, retentionDays: 90, latency: false } },
+    });
+    expect(fromFile.history).toMatchObject({ retentionDays: 90, latency: false });
+
+    const fromShorthand = resolveConfig({
+      flags: parseFlags([]),
+      env: noEnv,
+      file: { history: true },
+    });
+    expect(fromShorthand.history).toMatchObject({ record: true });
+  });
+
+  it('stops recording under --read-only, unless the config file asks for it explicitly', () => {
+    const readOnly = resolveConfig({
+      flags: parseFlags(['--history', '--read-only']),
+      env: noEnv,
+      file: noFile,
+    });
+    expect(readOnly.history).toMatchObject({ record: false });
+
+    const explicit = resolveConfig({
+      flags: parseFlags(['--history', '--read-only']),
+      env: noEnv,
+      file: { history: { record: true } },
+    });
+    expect(explicit.history).toMatchObject({ record: true });
+  });
+
+  it('turns showMetrics on with history, without overriding an explicit false', () => {
+    const derived = resolveConfig({ flags: parseFlags(['--history']), env: noEnv, file: noFile });
+    expect(derived.uiConfig.showMetrics).toBe(true);
+
+    const explicit = resolveConfig({
+      flags: parseFlags(['--history']),
+      env: noEnv,
+      file: { uiConfig: { showMetrics: false } },
+    });
+    expect(explicit.uiConfig.showMetrics).toBe(false);
+
+    const off = resolveConfig({ flags: parseFlags([]), env: noEnv, file: noFile });
+    expect(off.uiConfig.showMetrics).toBeUndefined();
+  });
+
   it('carries uiConfig and per-queue options through from the config file', () => {
     const config = resolveConfig({
       flags: parseFlags(['--board-title', 'Flag wins']),

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -37,6 +37,10 @@ recorder downtime, for example:
       options: { historyProvider: new RedisMetricsHistoryProvider({ connection }) },
     });
 
+`queues` also accepts a function, resolved on every tick instead of once, which is what you want when the queue set changes while the recorder runs.
+
+Not embedding bull-board in an app of your own? This package ships inside [`@bull-board/cli`](https://www.npmjs.com/package/@bull-board/cli) and the `ghcr.io/felixmosh/bull-board` image, where `--history` registers the provider and starts a recorder in the same process. See the [CLI guide](https://felixmosh.github.io/bull-board/guide/cli#historical-metrics).
+
 On shutdown, call `recorder.stop()` and `provider.disconnect()`. Both only close the Redis connection if the recorder/provider opened it internally, so it's a safe no-op if you passed in your own `Redis` instance.
 
 `connection` may be ioredis options or a `Redis` instance you created. `ioredis` is a peer dependency (v5 or v6): resolve a single copy in your app, and if you reuse an existing client, pass one built from that same `ioredis` — a client from a different install (for example one created internally by a BullMQ pinned to a different ioredis major) is not recognized as a `Redis` instance and would be misread as options.

--- a/packages/metrics/src/LatencySampler.ts
+++ b/packages/metrics/src/LatencySampler.ts
@@ -171,9 +171,13 @@ export class LatencySampler {
 
   private async sampleDurations(adapter: AdapterWithKeys, name: string): Promise<void> {
     const watermarkRaw = await this.redis.get(this.watermarkKey(name));
-    // Cold start begins at the previous tick rather than backfilling, since a first run
-    // against a large completed set would be a surprise fetch storm.
-    const watermark = watermarkRaw ? Number(watermarkRaw) : Date.now() - this.tickMs;
+    // Cold start covers one tick ending at the safety bound rather than backfilling, since a
+    // first run against a large completed set would be a surprise fetch storm. Ending at the
+    // bound rather than at now is what keeps a tick shorter than the margin from producing a
+    // window that is empty on every tick, leaving the watermark stuck forever.
+    const watermark = watermarkRaw
+      ? Number(watermarkRaw)
+      : Date.now() - this.tickMs - this.safetyMarginMs;
 
     const upperBound = Date.now() - this.safetyMarginMs;
     if (upperBound <= watermark) {

--- a/packages/metrics/src/MetricsRecorder.ts
+++ b/packages/metrics/src/MetricsRecorder.ts
@@ -20,7 +20,11 @@ const MINUTES_PER_DAY = 1440;
 export const DEFAULT_RETENTION: Retention = { minutes: 7, hours: 90, days: 90 };
 
 export interface MetricsRecorderOptions {
-  queues: BaseAdapter[];
+  /**
+   * A function is resolved on every tick, for a board whose queue set changes while it
+   * runs. An array is read once, at construction.
+   */
+  queues: BaseAdapter[] | (() => BaseAdapter[]);
   connection: RedisOptions | Redis;
   /** Per-resolution retention in days. Unspecified tiers fall back to the defaults. */
   retention?: Partial<Retention>;
@@ -72,7 +76,7 @@ export function resolveRetention(opts: {
 }
 
 export class MetricsRecorder {
-  private readonly queues: BaseAdapter[];
+  private readonly resolveQueues: () => BaseAdapter[];
   private readonly store: HistoryStore;
   private readonly redis: Redis;
   private readonly ownsRedis: boolean;
@@ -85,7 +89,8 @@ export class MetricsRecorder {
   private readonly latencySampler: LatencySampler | null;
 
   constructor(opts: MetricsRecorderOptions) {
-    this.queues = opts.queues;
+    const { queues } = opts;
+    this.resolveQueues = typeof queues === 'function' ? queues : () => queues;
     this.intervalMs = opts.snapshotIntervalMs ?? 60000;
     if (isRedisClient(opts.connection)) {
       this.redis = opts.connection;
@@ -146,7 +151,7 @@ export class MetricsRecorder {
     }
     this.running = true;
     try {
-      for (const adapter of this.queues) {
+      for (const adapter of this.resolveQueues()) {
         const name = adapter.getName();
         for (const metric of METRICS) {
           await this.snapshotOne(adapter, name, metric);

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -8,6 +8,7 @@ export type {
 } from './HistoryAdmin';
 export { MetricsRecorder } from './MetricsRecorder';
 export type { MetricsRecorderOptions } from './MetricsRecorder';
+export type { Retention } from './HistoryStore';
 export { RedisMetricsHistoryProvider } from './RedisMetricsHistoryProvider';
 export type { RedisMetricsHistoryProviderOptions } from './RedisMetricsHistoryProvider';
 export { LatencySampler } from './LatencySampler';

--- a/packages/metrics/tests/LatencySampler.spec.ts
+++ b/packages/metrics/tests/LatencySampler.spec.ts
@@ -200,6 +200,17 @@ describe('LatencySampler', () => {
     expect(vectorTotal(after[day] ?? [])).toBe(3);
   });
 
+  it('still samples on a cold start when the tick is shorter than the safety margin', async () => {
+    const tight = new LatencySampler({ redis, store, tickMs: 1000, safetyMarginMs: 1000 });
+    await processJobs(3, 20);
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await tight.sample(adapter);
+
+    const day = minuteToDay(Date.now() / 60000);
+    const days = await store.readRange(adapter.getName(), 'runtime', 'day', [day]);
+    expect(vectorTotal(days[day] ?? [])).toBe(3);
+  });
+
   it('lets only one of two concurrent samplers write', async () => {
     await processJobs(4, 20);
     const other = new LatencySampler({ redis, store, tickMs: 60_000, safetyMarginMs: 0 });

--- a/packages/metrics/tests/MetricsRecorder.spec.ts
+++ b/packages/metrics/tests/MetricsRecorder.spec.ts
@@ -186,6 +186,35 @@ describe('MetricsRecorder', () => {
     expect(snapshot2).toEqual(snapshot1);
   });
 
+  it('resolves a queues function on every snapshot, so a queue registered later is recorded', async () => {
+    await resetHistory(redis, 'RecorderLateQueue');
+    queue = new Queue('RecorderLateQueue', { connection });
+    worker = new Worker('RecorderLateQueue', async () => 'ok', {
+      connection,
+      metrics: { maxDataPoints: MetricsTime.ONE_HOUR },
+    });
+
+    for (let i = 0; i < 5; i++) await queue.add('job', {});
+    await waitForCompletedCount(queue, 5);
+    await forceMetricsFlush(redis, queue);
+    await waitForMetrics(queue, 1);
+
+    const adapter = new BullMQAdapter(queue);
+    const registered: BullMQAdapter[] = [];
+    const recorder = new MetricsRecorder({ queues: () => registered, connection: redis });
+
+    await recorder.snapshot();
+    expect(await redis.hgetall(totalsHashKey(adapter.getName(), 'completed'))).toEqual({});
+
+    registered.push(adapter);
+    await recorder.snapshot();
+    recorder.stop();
+
+    const totals = await redis.hgetall(totalsHashKey(adapter.getName(), 'completed'));
+    const stored = Object.values(totals).reduce((sum, value) => sum + Number(value), 0);
+    expect(stored).toBeGreaterThan(0);
+  });
+
   it('records failed metrics into the history store', async () => {
     await resetHistory(redis, 'RecorderFailedQueue');
     queue = new Queue('RecorderFailedQueue', { connection });

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -47,6 +47,9 @@ Options:
       --user <name>       Basic auth user (requires --password)
       --password <pass>   Basic auth password (requires --user)
       --board-title <s>   Dashboard title
+      --history           Record and serve long-retention metrics history
+      --history-retention-days <n>
+                          Days of history to keep            [90]
       --config <file>     Path to a config file
       --browser <command> Command to open the browser with     [$BROWSER]
       --no-open           Do not open a browser
@@ -72,6 +75,8 @@ Every flag has an environment variable equivalent, so you can configure the CLI 
 | `--user` | `BULL_BOARD_USER` |
 | `--password` | `BULL_BOARD_PASSWORD` |
 | `--board-title` | `BULL_BOARD_BOARD_TITLE` |
+| `--history` | `BULL_BOARD_HISTORY` |
+| `--history-retention-days` | `BULL_BOARD_HISTORY_RETENTION_DAYS` |
 | `--no-open` | `BULL_BOARD_OPEN` (set to `false` to skip the browser; `--no-open` always wins) |
 | `--no-retry` | `BULL_BOARD_NO_RETRY` |
 | `--browser` | `BULL_BOARD_BROWSER`, then `BROWSER` |
@@ -122,6 +127,56 @@ npx @bull-board/cli -r redis://localhost:6379 --user admin --password secret --h
 ```
 
 This is enough for a queue you've tunnelled to or a small internal box. It is not the layered, session-aware auth described in [Add basic auth](/recipes/basic-auth), which covers login flows and framework-integrated auth for an app you're embedding the dashboard into.
+
+## Historical metrics
+
+BullMQ's own metrics are a per-minute ring buffer capped at `maxDataPoints`, so the throughput chart can't look back further than that buffer reaches. `--history` turns on the long-retention path from the [historical metrics recipe](/recipes/historical-metrics) without wiring `@bull-board/metrics` into an app of your own:
+
+```sh
+npx @bull-board/cli -r redis://localhost:6379 --history
+```
+
+That registers `RedisMetricsHistoryProvider` on the Redis connection the dashboard already holds, so every queue chart gains a 60m / 7d / 30d / 90d range selector and a cross-queue "Metrics history" page shows up in the sidebar. It flips `showMetrics` on too, because the range selector lives inside the per-queue chart and that chart doesn't render without it.
+
+It also writes. A `MetricsRecorder` runs in the CLI process and once a minute copies each queue's completed and failed counters into long-retention buckets, then samples wait time, run time and the age of the oldest waiting job. The recorder follows discovery rather than a fixed list: a queue that shows up between rescans starts recording on the next tick, and one that disappears stops. No restart either way.
+
+`--history-retention-days` sets how long history is kept, 90 days by default. It moves the hourly and daily windows only and leaves minute-level detail at 7 days, since that tier holds essentially all the bytes. Per-tier retention, the snapshot interval and turning latency sampling off go in the config file under a `history` key:
+
+```js
+// bull-board.config.js
+module.exports = {
+  redis: 'redis://localhost:6379',
+  history: {
+    enabled: true,
+    retention: { minutes: 7, hours: 90, days: 90 },
+    latency: false,
+    snapshotIntervalMs: 60000,
+  },
+};
+```
+
+### What it writes
+
+Recording writes to the same Redis your queues live in, under the `bull-board:metrics:` namespace, and never touches a key Bull or BullMQ owns. Redis TTLs enforce retention, so there's nothing to prune by hand. [Storage footprint](/recipes/historical-metrics#storage-footprint) has the measured numbers; the short version is roughly 1.1 MB per queue for the counters at the default retention plus about 250 KB for latency, and an idle queue costs nothing.
+
+`--read-only` stops the writing and keeps the reading, so the board serves whatever another process has recorded. That's what you want when your workers already run a `MetricsRecorder` of their own and the CLI is only there to look at the result. The config file can ask for the opposite with `history: { record: true }` alongside `--read-only`, for a board that mustn't touch your queues but does own its history.
+
+Running several instances with `--history` at once is safe. The minute upsert applies a delta against the value already stored rather than adding to it, so a minute recorded twice still counts once, and latency sampling takes a short per-queue lease, so only one process scans a given queue on a given tick.
+
+### When the charts stay empty
+
+Completed and failed history is copied out of BullMQ's own metrics buffer, which stays empty unless your workers were built with metrics enabled:
+
+```ts
+new Worker(name, processor, {
+  connection,
+  metrics: { maxDataPoints: MetricsTime.ONE_WEEK },
+});
+```
+
+The CLI warns about this at startup when no discovered queue has any metrics data, because otherwise a queue whose workers never enabled metrics looks exactly like an idle one. Latency and queue age need nothing from your workers, since they're read from sorted sets BullMQ maintains anyway. One exception there: a queue using `removeOnComplete: true` has its jobs deleted before the next tick can read them, so it never accumulates latency data.
+
+This is BullMQ only. Bull v3 has no native metrics to snapshot, and BullMQ v6 queues backed by PostgreSQL aren't discoverable from the CLI in the first place.
 
 ## Docker
 

--- a/website/docs/guide/docker.md
+++ b/website/docs/guide/docker.md
@@ -84,6 +84,16 @@ For anything longer, mount a [config file](/guide/cli#config-file). The working 
       - ./bull-board.config.js:/app/bull-board.config.js:ro
 ```
 
+[Historical metrics](/recipes/historical-metrics) work here too, since the image carries `@bull-board/metrics` as part of the CLI. `--history`, or `BULL_BOARD_HISTORY=true`, registers the history provider and starts recording throughput and latency into your Redis once a minute:
+
+```yaml
+  bull-board:
+    image: ghcr.io/felixmosh/bull-board:9
+    command: --redis redis://redis:6379 --history --history-retention-days 90
+```
+
+The container is a normal recorder, so it keeps writing for as long as it runs and stops when you stop it. Two of them against one Redis is safe, and `--read-only` keeps the charts while writing nothing. The [CLI guide](/guide/cli#historical-metrics) covers the config file keys and what leaves the charts empty.
+
 Serving the dashboard under a path prefix, which is what a reverse proxy routing on the path needs, is `--base-path`:
 
 ```sh

--- a/website/docs/recipes/historical-metrics.md
+++ b/website/docs/recipes/historical-metrics.md
@@ -16,6 +16,20 @@ Two pieces, living in two different places.
 
 `RedisMetricsHistoryProvider` runs wherever you build the board. You pass it to `createBullBoard({ options: { historyProvider } })`. The core itself only defines the `MetricsHistoryProvider` interface and stays stateless: registering a provider just turns on one additional read endpoint that delegates to it. `@bull-board/metrics` is the batteries-included Redis implementation, but if you already have a metrics store of your own, you can implement the interface directly instead of adopting this package. With no provider configured, nothing about the board changes.
 
+## Without an app: the CLI and the Docker image
+
+If you aren't embedding bull-board in an app at all, the [standalone CLI](/guide/cli) and the [Docker image](/guide/docker) do both halves for you. `@bull-board/metrics` ships as part of `@bull-board/cli`, and `--history` registers the provider and starts a recorder in the same process:
+
+```sh
+npx @bull-board/cli --redis redis://localhost:6379 --history
+docker run --rm -p 127.0.0.1:3000:3000 ghcr.io/felixmosh/bull-board \
+  --redis redis://redis:6379 --history
+```
+
+The flag turns on `showMetrics` as well, so the range selector appears on queue pages and not only on the Metrics history page. `--history-retention-days` sets the window; per-tier retention, the snapshot interval and `latency: false` go in the CLI's config file under a `history` key. `--read-only` keeps the provider and drops the recorder, which is what you want when your workers already record and the CLI is only there to read.
+
+Everything below still applies, from the precondition on your workers to the storage footprint and the Redis keys involved. The one difference is that the recorder follows the CLI's discovery instead of a fixed list, so a queue that shows up between rescans starts recording on the next tick.
+
 ## Precondition: native metrics must be on
 
 The recorder can only snapshot what BullMQ is already collecting, so your Workers need native metrics enabled with a window wide enough to survive any recorder downtime:
@@ -92,6 +106,15 @@ const recorder = new MetricsRecorder({
   snapshotIntervalMs: 60_000, // optional, default 60s
 });
 recorder.start();
+```
+
+`queues` also takes a function, resolved on every tick rather than once. Reach for it when the queue set changes at runtime, whether you're discovering queues the way the CLI does or adding them through `addQueue`:
+
+```ts
+const recorder = new MetricsRecorder({
+  queues: () => currentAdapters,
+  connection: redisOptions,
+});
 ```
 
 Retention is enforced by Redis itself, so old buckets expire on their own and there's nothing to prune by hand. Buckets are UTC-aligned, and every key the recorder writes is namespaced under `bull-board:metrics:`, so it can't collide with BullMQ's own keys.

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,6 +517,7 @@ __metadata:
   dependencies:
     "@bull-board/api": "npm:9.6.1"
     "@bull-board/express": "npm:9.6.1"
+    "@bull-board/metrics": "npm:9.6.1"
     "@types/express": "npm:^5.0.6"
     "@types/jest": "npm:^30.0.0"
     "@types/supertest": "npm:^7.2.1"
@@ -691,7 +692,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bull-board/metrics@workspace:packages/metrics":
+"@bull-board/metrics@npm:9.6.1, @bull-board/metrics@workspace:packages/metrics":
   version: 0.0.0-use.local
   resolution: "@bull-board/metrics@workspace:packages/metrics"
   dependencies:


### PR DESCRIPTION
Closes #1414.

The Docker image is just the published `@bull-board/cli`, which didn't depend on `@bull-board/metrics` and had no seam to pass a `historyProvider` through, so historical metrics were unreachable from both the image and `npx @bull-board/cli`.

This adds the package as a CLI dependency (its only dependency is `@bull-board/api`, already in the tree, so the image grows by a few tens of KB) and one flag:

```sh
bull-board --redis redis://redis:6379 --history
```

That registers `RedisMetricsHistoryProvider` on the Redis client the CLI already holds, starts a `MetricsRecorder` in the same process, and turns on `uiConfig.showMetrics` so the range selector actually appears on queue pages. `--history-retention-days` sets the window; the rest (`record`, `retention`, `latency`, `snapshotIntervalMs`) goes in the config file under a `history` key. Both flags have the usual `BULL_BOARD_*` equivalents.

Recording is gated on `--read-only` rather than a second flag: with it, the provider is still registered and the charts still show whatever another process recorded. Several instances at once stay correct, since minute upserts are deltas and latency sampling takes a per-queue lease. The CLI warns at startup when no queue has anything in BullMQ's metrics buffer, and when it is serving history without recording it.

Two changes outside the CLI:

- `MetricsRecorder`'s `queues` now also accepts `() => BaseAdapter[]`, resolved per tick, because the CLI rediscovers queues every 10 seconds. Arrays behave exactly as before.
- `LatencySampler` cold-started its watermark at `now - tickMs` while ending each scan at `now - safetyMarginMs`, so any tick at or below the 5 second margin left the window empty on every tick and duration sampling never produced anything. It now starts at `now - tickMs - safetyMarginMs`. The 60 second default was never affected; the CLI's config file exposing `snapshotIntervalMs` is what surfaced it.

Tests, `packages/cli` 101 and `packages/metrics` 166 passing against a real Redis: config resolution, three runs of the real binary (with the flag, read-only, without), the per-tick queue resolution, and the sampler cold start. Docs updated in the CLI and Docker guides, the historical metrics recipe, and the three READMEs.
