### PR TITLE
fix(metrics): wait on the metrics row, not the completed count, in the postgres matrix test

### DIFF
--- a/packages/metrics/tests/bullmq-matrix/postgres.spec.ts
+++ b/packages/metrics/tests/bullmq-matrix/postgres.spec.ts
@@ -88,10 +88,13 @@ if (!POSTGRES_URL) {
           createPostgresBackend
         );
       const target = completed;
-      await waitFor(
-        async () => (await queue.getCompletedCount()) >= target,
-        'jobs did not complete on the PostgreSQL backend'
-      );
+      // The metrics row is written after the completing transaction, so it lags the completed count.
+      await waitFor(async () => {
+        const { rows } = await pool().query(
+          `SELECT count FROM metrics WHERE queue = '${queue.name}' AND kind = 'completed'`
+        );
+        return Number(rows[0]?.count ?? 0) >= target;
+      }, 'jobs did not complete on the PostgreSQL backend');
     }
 
     it('records nothing while the PostgreSQL backend reports no buffer anchor', async () => {


### PR DESCRIPTION
CI went red on master in [this job](https://github.com/felixmosh/bull-board/actions/runs/33743955747/job/100612061017): `packages/metrics/tests/bullmq-matrix/postgres.spec.ts` read `metrics.data.length` as 0. It is unrelated to the commit that was pushed, the test has a race.

BullMQ's PostgreSQL backend records metrics in a query of its own, issued after the transaction that completes the job has already committed (`collectMetrics` in `postgres-queue-backend`, "metrics are best-effort, so strict atomicity with the finish is not required"). The test waited on `queue.getCompletedCount()`, which that first transaction already satisfies, so a poll landing in the gap reads the metrics row before the last job is folded into it. It now waits on the metrics row itself, which is what `collect_metrics` writes.

Reproduced by dropping the sleep in `waitFor`: 3 of 5 runs failed with the same `Expected: > 0 / Received: 0`, and 8 of 8 pass with the fix. Full `@bull-board/metrics` suite green with `POSTGRES_URL` set.
