### PR TITLE
feat(cli): connect through Redis Sentinel

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,15 @@ Usage:
 
 Options:
   -r, --redis <url>       Redis connection URL          [redis://localhost:6379]
+      --sentinel <list>   Comma separated sentinel host:port list, port [26379]
+      --sentinel-name <n> Redis master group name, required with --sentinel
+      --sentinel-password <pass>
+                          Password for the sentinel nodes themselves
+      --redis-username <name>
+                          Username for the Redis nodes behind the sentinels
+      --redis-password <pass>
+                          Password for the Redis nodes behind the sentinels
+      --redis-db <n>      Database to select behind the sentinels
   -p, --port <port>       Port to listen on             [3000]
       --host <address>    Interface to bind             [127.0.0.1]
       --prefix <list>     Comma separated key prefixes  [bull]
@@ -63,6 +72,37 @@ module.exports = {
   },
   queues: {
     'payment-webhooks': { readOnlyMode: true },
+  },
+};
+```
+
+## Redis Sentinel
+
+`--sentinel` connects through Redis Sentinel rather than to one instance directly, for a deployment where the master address is not fixed:
+
+```sh
+npx @bull-board/cli --sentinel s1.internal:26379,s2.internal:26379 --sentinel-name mymaster
+```
+
+A port is optional per entry and defaults to 26379. `--sentinel-name` is the master group name from your sentinel configuration and is required. `--sentinel` and `--redis` are mutually exclusive, and passing both is an error rather than a silent preference for one.
+
+ioredis resolves the current master through the sentinels listed and follows a failover on its own, so the whole dashboard moves with it: queue reads, the Bull subscriber, and `--history` recording all share the one connection.
+
+Credentials in sentinel mode come from their own flags, since there is no URL to carry them. `--redis-username`, `--redis-password` and `--redis-db` apply to the Redis nodes behind the sentinels, while `--sentinel-password` authenticates to the sentinel nodes themselves, which commonly have a different password. Passing any of them alongside a Redis URL is an error, because ioredis would take the URL's own credentials and ignore them.
+
+For anything beyond that, including TLS to the sentinel nodes, the config file's `redis` key accepts a full [ioredis options object](https://github.com/redis/ioredis#connect-to-redis) and is passed through untouched:
+
+```js
+// bull-board.config.js
+module.exports = {
+  redis: {
+    sentinels: [
+      { host: 's1.internal', port: 26379 },
+      { host: 's2.internal', port: 26379 },
+    ],
+    name: 'mymaster',
+    sentinelPassword: process.env.SENTINEL_PASSWORD,
+    enableTLSForSentinelMode: true,
   },
 };
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,8 +49,10 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
+    "@types/redis-parser": "^3.0.3",
     "@types/supertest": "^7.2.1",
     "jest": "^30.4.2",
+    "redis-parser": "^3.0.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.12",
     "typescript": "^5.9.3"

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -32,18 +32,6 @@ async function main(): Promise<void> {
   });
   const config = resolveConfig({ flags, env: process.env, file });
 
-  if (!config.redisUrl.startsWith('/')) {
-    let parsed: URL;
-    try {
-      parsed = new URL(config.redisUrl);
-    } catch {
-      throw new Error(`Invalid Redis URL: ${config.redisUrl}`);
-    }
-    if (!['redis:', 'rediss:'].includes(parsed.protocol)) {
-      throw new Error(`Redis URL must use redis:// or rediss://, got "${parsed.protocol}//"`);
-    }
-  }
-
   const board = await run(config, console, {
     beforeReady: (close) => {
       for (const signal of ['SIGINT', 'SIGTERM'] as const) {

--- a/packages/cli/src/config/connection.ts
+++ b/packages/cli/src/config/connection.ts
@@ -1,0 +1,163 @@
+import type { RedisOptions } from 'ioredis';
+import type { FlagValues } from './flags';
+import type { FileConfig } from './types';
+
+export type ConnectionConfig =
+  | { mode: 'url'; url: string; options: RedisOptions }
+  | { mode: 'sentinel'; options: RedisOptions }
+  | { mode: 'options'; options: RedisOptions };
+
+const DEFAULT_REDIS_URL = 'redis://localhost:6379';
+const DEFAULT_SENTINEL_PORT = 26379;
+
+function firstDefined<T>(...values: Array<T | undefined>): T | undefined {
+  return values.find((value) => value !== undefined && value !== '');
+}
+
+function toPort(value: string, invalid: () => Error): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) throw invalid();
+
+  return port;
+}
+
+function parseSentinels(value: string): RedisOptions['sentinels'] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const invalid = () =>
+        new Error(`Invalid sentinel address "${entry}": expected host or host:port.`);
+
+      // A bare IPv6 literal is all colons, so only a bracketed one can carry a port.
+      if (entry.startsWith('[')) {
+        const close = entry.indexOf(']');
+        if (close === -1) throw invalid();
+        const host = entry.slice(1, close);
+        const rest = entry.slice(close + 1);
+        if (!host) throw invalid();
+
+        return { host, port: rest === '' ? DEFAULT_SENTINEL_PORT : toPort(rest.slice(1), invalid) };
+      }
+
+      const separator = entry.indexOf(':');
+      if (separator === -1 || separator !== entry.lastIndexOf(':')) {
+        return { host: entry, port: DEFAULT_SENTINEL_PORT };
+      }
+
+      const host = entry.slice(0, separator);
+      if (!host) throw invalid();
+
+      return { host, port: toPort(entry.slice(separator + 1), invalid) };
+    });
+}
+
+function assertUsableUrl(url: string): void {
+  if (url.startsWith('/')) return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid Redis URL: ${url}`);
+  }
+  if (!['redis:', 'rediss:'].includes(parsed.protocol)) {
+    throw new Error(`Redis URL must use redis:// or rediss://, got "${parsed.protocol}//"`);
+  }
+}
+
+function credentialOptions({ flags, env }: { flags: FlagValues; env: NodeJS.ProcessEnv }): {
+  options: RedisOptions;
+  names: string[];
+} {
+  const options: RedisOptions = {};
+  const names: string[] = [];
+
+  const add = <K extends keyof RedisOptions>(
+    name: string,
+    key: K,
+    value: RedisOptions[K] | undefined
+  ) => {
+    if (value === undefined) return;
+    options[key] = value;
+    names.push(name);
+  };
+
+  const db = firstDefined(flags['redis-db'], env.BULL_BOARD_REDIS_DB);
+  if (db !== undefined && (!Number.isInteger(Number(db)) || Number(db) < 0)) {
+    throw new Error(`Invalid --redis-db: ${db}`);
+  }
+
+  add(
+    '--sentinel-password',
+    'sentinelPassword',
+    firstDefined(flags['sentinel-password'], env.BULL_BOARD_SENTINEL_PASSWORD)
+  );
+  add(
+    '--redis-username',
+    'username',
+    firstDefined(flags['redis-username'], env.BULL_BOARD_REDIS_USERNAME)
+  );
+  add(
+    '--redis-password',
+    'password',
+    firstDefined(flags['redis-password'], env.BULL_BOARD_REDIS_PASSWORD)
+  );
+  add('--redis-db', 'db', db === undefined ? undefined : Number(db));
+
+  return { options, names };
+}
+
+export function resolveConnection({
+  flags,
+  env,
+  file,
+}: {
+  flags: FlagValues;
+  env: NodeJS.ProcessEnv;
+  file: FileConfig;
+}): ConnectionConfig {
+  const explicitUrl = firstDefined(flags.redis, env.BULL_BOARD_REDIS_URL);
+  const sentinelList = firstDefined(flags.sentinel, env.BULL_BOARD_SENTINELS);
+  const sentinelName = firstDefined(flags['sentinel-name'], env.BULL_BOARD_SENTINEL_NAME);
+  const credentials = credentialOptions({ flags, env });
+
+  if (sentinelList && explicitUrl) {
+    throw new Error('Use either a Redis URL or --sentinel, not both.');
+  }
+
+  if (sentinelList) {
+    if (!sentinelName) {
+      throw new Error('--sentinel needs --sentinel-name, the Redis master group name.');
+    }
+
+    return {
+      mode: 'sentinel',
+      options: {
+        sentinels: parseSentinels(sentinelList),
+        name: sentinelName,
+        ...credentials.options,
+      },
+    };
+  }
+
+  const fileRedis = file.redis;
+  if (!explicitUrl && typeof fileRedis === 'object') {
+    const options = { ...fileRedis, ...credentials.options };
+
+    return fileRedis.sentinels ? { mode: 'sentinel', options } : { mode: 'options', options };
+  }
+
+  const url =
+    explicitUrl ?? (typeof fileRedis === 'string' ? fileRedis : undefined) ?? DEFAULT_REDIS_URL;
+  assertUsableUrl(url);
+
+  if (credentials.names.length > 0) {
+    throw new Error(
+      `${credentials.names.join(', ')} cannot be combined with a Redis URL. Put credentials in the URL itself, or connect through --sentinel.`
+    );
+  }
+
+  return { mode: 'url', url, options: {} };
+}

--- a/packages/cli/src/config/connection.ts
+++ b/packages/cli/src/config/connection.ts
@@ -14,11 +14,24 @@ function firstDefined<T>(...values: Array<T | undefined>): T | undefined {
   return values.find((value) => value !== undefined && value !== '');
 }
 
-function toPort(value: string, invalid: () => Error): number {
-  const port = Number(value);
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) throw invalid();
+function parseSentinel(entry: string): { host: string; port: number } {
+  // A bare IPv6 literal is all colons, so bracket it before the URL parser sees a port.
+  const bracketed =
+    !entry.startsWith('[') && entry.indexOf(':') !== entry.lastIndexOf(':') ? `[${entry}]` : entry;
 
-  return port;
+  let parsed: URL;
+  try {
+    parsed = new URL(`redis://${bracketed}`);
+  } catch {
+    throw new Error(`Invalid sentinel address "${entry}": expected host or host:port.`);
+  }
+
+  const port = parsed.port === '' ? DEFAULT_SENTINEL_PORT : Number(parsed.port);
+  if (!parsed.hostname || parsed.pathname || parsed.search || port === 0) {
+    throw new Error(`Invalid sentinel address "${entry}": expected host or host:port.`);
+  }
+
+  return { host: parsed.hostname.replace(/^\[|\]$/g, ''), port };
 }
 
 function parseSentinels(value: string): RedisOptions['sentinels'] {
@@ -26,31 +39,7 @@ function parseSentinels(value: string): RedisOptions['sentinels'] {
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean)
-    .map((entry) => {
-      const invalid = () =>
-        new Error(`Invalid sentinel address "${entry}": expected host or host:port.`);
-
-      // A bare IPv6 literal is all colons, so only a bracketed one can carry a port.
-      if (entry.startsWith('[')) {
-        const close = entry.indexOf(']');
-        if (close === -1) throw invalid();
-        const host = entry.slice(1, close);
-        const rest = entry.slice(close + 1);
-        if (!host) throw invalid();
-
-        return { host, port: rest === '' ? DEFAULT_SENTINEL_PORT : toPort(rest.slice(1), invalid) };
-      }
-
-      const separator = entry.indexOf(':');
-      if (separator === -1 || separator !== entry.lastIndexOf(':')) {
-        return { host: entry, port: DEFAULT_SENTINEL_PORT };
-      }
-
-      const host = entry.slice(0, separator);
-      if (!host) throw invalid();
-
-      return { host, port: toPort(entry.slice(separator + 1), invalid) };
-    });
+    .map(parseSentinel);
 }
 
 function assertUsableUrl(url: string): void {

--- a/packages/cli/src/config/flags.ts
+++ b/packages/cli/src/config/flags.ts
@@ -2,6 +2,12 @@ import { parseArgs } from 'node:util';
 
 export const FLAG_OPTIONS = {
   redis: { type: 'string', short: 'r' },
+  sentinel: { type: 'string' },
+  'sentinel-name': { type: 'string' },
+  'sentinel-password': { type: 'string' },
+  'redis-username': { type: 'string' },
+  'redis-password': { type: 'string' },
+  'redis-db': { type: 'string' },
   port: { type: 'string', short: 'p' },
   host: { type: 'string' },
   prefix: { type: 'string' },

--- a/packages/cli/src/config/resolve.ts
+++ b/packages/cli/src/config/resolve.ts
@@ -1,9 +1,9 @@
 import type { QueueAdapterOptions } from '@bull-board/api/typings/app';
+import { resolveConnection } from './connection';
 import type { FlagValues } from './flags';
 import type { CliConfig, FileConfig, FileHistoryConfig, HistoryConfig } from './types';
 
 const DEFAULTS = {
-  redisUrl: 'redis://localhost:6379',
   port: 3000,
   host: '127.0.0.1',
   prefixes: ['bull'],
@@ -82,7 +82,7 @@ export function resolveConfig({
   }
 
   return {
-    redisUrl: firstDefined(flags.redis, env.BULL_BOARD_REDIS_URL, file.redis) ?? DEFAULTS.redisUrl,
+    connection: resolveConnection({ flags, env, file }),
     port:
       toNumber(flags.port, 'port') ??
       toNumber(env.BULL_BOARD_PORT, 'port') ??

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -1,5 +1,7 @@
 import type { QueueAdapterOptions, UIConfig } from '@bull-board/api/typings/app';
 import type { Retention } from '@bull-board/metrics';
+import type { RedisOptions } from 'ioredis';
+import type { ConnectionConfig } from './connection';
 
 export interface FileHistoryConfig {
   enabled?: boolean;
@@ -20,7 +22,7 @@ export interface HistoryConfig {
 }
 
 export interface FileConfig {
-  redis?: string;
+  redis?: string | RedisOptions;
   port?: number;
   host?: string;
   prefix?: string | string[];
@@ -38,7 +40,7 @@ export interface FileConfig {
 }
 
 export interface CliConfig {
-  redisUrl: string;
+  connection: ConnectionConfig;
   port: number;
   host: string;
   prefixes: string[];

--- a/packages/cli/src/connectionState.ts
+++ b/packages/cli/src/connectionState.ts
@@ -1,10 +1,31 @@
+import type { ConnectionConfig } from './config/connection';
+
 export const RETRY_INTERVAL_MS = 3000;
 
 export type ConnectionState =
-  | { status: 'connecting'; redisUrl: string; attempts: number }
-  | { status: 'connected'; redisUrl: string; attempts: number }
-  | { status: 'unavailable'; redisUrl: string; attempts: number; lastError: string }
-  | { status: 'degraded'; redisUrl: string; attempts: number; lastError: string };
+  | { status: 'connecting'; redis: string; attempts: number }
+  | { status: 'connected'; redis: string; attempts: number }
+  | { status: 'unavailable'; redis: string; attempts: number; lastError: string }
+  | { status: 'degraded'; redis: string; attempts: number; lastError: string };
+
+export function describeConnection(connection: ConnectionConfig): string {
+  if (connection.mode === 'url') return maskRedisUrl(connection.url);
+
+  const { name, sentinels, host, port, path } = connection.options;
+  if (sentinels) {
+    const addresses = sentinels
+      .map((sentinel) => {
+        const host = sentinel.host ?? 'localhost';
+
+        return `${host.includes(':') ? `[${host}]` : host}:${sentinel.port ?? 26379}`;
+      })
+      .join(',');
+
+    return `sentinel://${name}@${addresses}`;
+  }
+
+  return path ?? `redis://${host ?? 'localhost'}:${port ?? 6379}`;
+}
 
 export function maskRedisUrl(redisUrl: string): string {
   if (redisUrl.startsWith('/')) return redisUrl;

--- a/packages/cli/src/diagnosticPage.ts
+++ b/packages/cli/src/diagnosticPage.ts
@@ -130,7 +130,7 @@ export function renderDiagnosticPage(state: ConnectionState): string {
   <h1>bull-board is waiting for Redis</h1>
   <p class="status">${headline}</p>
   <dl>
-    <dt>Redis URL</dt><dd><code>${escapeHtml(state.redisUrl)}</code></dd>
+    <dt>Redis</dt><dd><code>${escapeHtml(state.redis)}</code></dd>
     <dt>Error</dt><dd><code>${escapeHtml(error)}</code></dd>
     ${attemptsRow}
   </dl>

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -7,6 +7,15 @@ Usage:
 
 Options:
   -r, --redis <url>       Redis connection URL          [redis://localhost:6379]
+      --sentinel <list>   Comma separated sentinel host:port list, port [26379]
+      --sentinel-name <n> Redis master group name, required with --sentinel
+      --sentinel-password <pass>
+                          Password for the sentinel nodes themselves
+      --redis-username <name>
+                          Username for the Redis nodes behind the sentinels
+      --redis-password <pass>
+                          Password for the Redis nodes behind the sentinels
+      --redis-db <n>      Database to select behind the sentinels
   -p, --port <port>       Port to listen on             [3000]
       --host <address>    Interface to bind             [127.0.0.1]
       --prefix <list>     Comma separated key prefixes  [bull]
@@ -42,12 +51,20 @@ throughput, latency and queue age into Redis under the bull-board:metrics:
 namespace once a minute. --read-only stops the recording but keeps serving
 whatever another process has recorded.
 
+--sentinel connects through Redis Sentinel instead of a URL, and the two are
+mutually exclusive. ioredis resolves the current master through the sentinels
+listed and follows a failover on its own, so queue reads, the Bull subscriber
+and --history recording all move with it. The credential flags above apply to
+sentinel mode only; with a Redis URL, put credentials in the URL itself.
+
 Environment variables mirror every flag, for example BULL_BOARD_REDIS_URL,
-BULL_BOARD_PORT, BULL_BOARD_READ_ONLY.
+BULL_BOARD_SENTINELS, BULL_BOARD_SENTINEL_NAME, BULL_BOARD_PORT,
+BULL_BOARD_READ_ONLY.
 
 Examples:
   bull-board
   bull-board -r redis://localhost:6379 -p 4000
   bull-board --prefix tenant-a,tenant-b --read-only
   bull-board --user admin --password secret --host 0.0.0.0
+  bull-board --sentinel s1:26379,s2:26379 --sentinel-name mymaster
 `;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { createBullBoard } from '@bull-board/api';
 import { ExpressAdapter } from '@bull-board/express';
 import { Redis } from 'ioredis';
 import type { CliConfig } from './config/types';
-import { maskRedisUrl, RETRY_INTERVAL_MS, type ConnectionState } from './connectionState';
+import { describeConnection, RETRY_INTERVAL_MS, type ConnectionState } from './connectionState';
 import { describeError } from './describeError';
 import { discoverQueues, probeQueues } from './discovery';
 import { createHistory, warnIfCountersUnavailable } from './history';
@@ -61,15 +61,30 @@ export async function run(
     beforeReady?: (close: () => Promise<void>) => void;
   } = {}
 ): Promise<RunningBoard> {
-  const client = new Redis(config.redisUrl, {
+  const redisOptions = {
     maxRetriesPerRequest: null,
     lazyConnect: true,
-    ...(config.noRetry ? {} : { retryStrategy: () => RETRY_INTERVAL_MS }),
-  });
+    // ioredis retries unreachable sentinels forever, so connect() never rejects and --no-retry
+    // would hang. The retrying path keeps ioredis's own backoff, which re-resolves a promoted
+    // master faster than a flat interval would.
+    ...(config.noRetry
+      ? { sentinelRetryStrategy: () => null }
+      : { retryStrategy: () => RETRY_INTERVAL_MS }),
+    ...config.connection.options,
+  };
+  const client =
+    config.connection.mode === 'url'
+      ? new Redis(config.connection.url, redisOptions)
+      : new Redis(redisOptions);
+  const redisLabel = describeConnection(config.connection);
   let attemptError: Error | undefined;
   client.on('error', (error: Error) => {
     attemptError ??= error;
   });
+  // For the same reason, the first error rather than connect() is what releases startup onto
+  // the diagnostic page.
+  const firstError = new Promise<never>((_, reject) => client.once('error', reject));
+  firstError.catch(() => undefined);
 
   if (!isLoopbackHost(config.host) && !config.auth) {
     log.warn(
@@ -159,7 +174,7 @@ export async function run(
       await client.connect();
     } catch (error) {
       throw new Error(
-        `Could not connect to Redis at ${maskRedisUrl(config.redisUrl)}: ${describeError(attemptError ?? (error as Error))}`
+        `Could not connect to Redis at ${redisLabel}: ${describeError(attemptError ?? (error as Error))}`
       );
     }
 
@@ -193,7 +208,7 @@ export async function run(
     beforeReady?.(close);
 
     log.log(`bull-board listening on ${server.url}`);
-    log.log(`Redis:  ${maskRedisUrl(config.redisUrl)}`);
+    log.log(`Redis:  ${redisLabel}`);
     log.log(`Prefix: ${config.prefixes.join(', ')}`);
     logIfIdle(count);
 
@@ -204,7 +219,7 @@ export async function run(
 
   let state: ConnectionState = {
     status: 'connecting',
-    redisUrl: maskRedisUrl(config.redisUrl),
+    redis: redisLabel,
     attempts: 0,
   };
   const getState = () => state;
@@ -250,13 +265,13 @@ export async function run(
     }
     state = {
       status: 'unavailable',
-      redisUrl: maskRedisUrl(config.redisUrl),
+      redis: redisLabel,
       attempts: state.attempts + 1,
       lastError: message,
     };
     if (!everFailed) {
       everFailed = true;
-      log.warn(`Could not connect to Redis at ${maskRedisUrl(config.redisUrl)}: ${message}`);
+      log.warn(`Could not connect to Redis at ${redisLabel}: ${message}`);
       log.warn(
         `Serving a diagnostic page at ${server.url} and retrying every ` +
           `${RETRY_INTERVAL_MS / 1000}s. Pass --no-retry to exit instead of waiting.`
@@ -278,7 +293,7 @@ export async function run(
         if (closing) return;
         state = {
           status: 'connected',
-          redisUrl: maskRedisUrl(config.redisUrl),
+          redis: redisLabel,
           attempts: state.attempts,
         };
         scheduleRescan();
@@ -294,7 +309,7 @@ export async function run(
         const message = (error as Error).message;
         state = {
           status: 'degraded',
-          redisUrl: maskRedisUrl(config.redisUrl),
+          redis: redisLabel,
           attempts: state.attempts,
           lastError: message,
         };
@@ -308,7 +323,9 @@ export async function run(
   };
 
   try {
-    await client.connect();
+    const connecting = client.connect();
+    connecting.catch(() => undefined);
+    await Promise.race([connecting, firstError]);
   } catch (error) {
     markUnavailable(describeError(attemptError ?? (error as Error)));
   }
@@ -317,7 +334,7 @@ export async function run(
   }
 
   log.log(`bull-board listening on ${server.url}`);
-  log.log(`Redis:  ${maskRedisUrl(config.redisUrl)}`);
+  log.log(`Redis:  ${redisLabel}`);
   log.log(`Prefix: ${config.prefixes.join(', ')}`);
   if (deferredIdleCount !== undefined) logIfIdle(deferredIdleCount);
 

--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -626,6 +626,47 @@ describe('cli', () => {
       expect(stderr).toMatch(/redis:\/\/ or rediss:\/\//);
     });
 
+    it('--no-retry exits non-zero naming the master group when no sentinel answers', async () => {
+      const port = await unusedPort();
+
+      const { code, stdout, stderr } = await runToExit([
+        '--sentinel',
+        `127.0.0.1:${port}`,
+        '--sentinel-name',
+        'mymaster',
+        '--port',
+        '0',
+        '--no-retry',
+      ]);
+
+      expect(code).not.toBe(0);
+      expect(stderr).toContain(`sentinel://mymaster@127.0.0.1:${port}`);
+      expect(stdout).not.toMatch(/listening on/);
+    });
+
+    it('exits non-zero naming --sentinel-name when sentinels are given without a master group', async () => {
+      const { code, stderr } = await runToExit(['--sentinel', 'localhost:26379', '--port', '0']);
+
+      expect(code).not.toBe(0);
+      expect(stderr).toMatch(/--sentinel-name/);
+    });
+
+    it('exits non-zero when a Redis URL and sentinels are both set', async () => {
+      const { code, stderr } = await runToExit([
+        '--redis',
+        'redis://localhost:6379',
+        '--sentinel',
+        'localhost:26379',
+        '--sentinel-name',
+        'mymaster',
+        '--port',
+        '0',
+      ]);
+
+      expect(code).not.toBe(0);
+      expect(stderr).toMatch(/not both/);
+    });
+
     it('exits non-zero and points at --help for an unknown flag', async () => {
       const { code, stderr } = await runToExit(['--this-flag-does-not-exist']);
 
@@ -705,14 +746,36 @@ describe('cli', () => {
         const response = await fetch(`${cli.url}/__bull-board-cli/status`);
         const body = (await response.json()) as {
           status: string;
-          redisUrl: string;
+          redis: string;
           attempts: number;
         };
 
         expect(response.status).toBe(200);
         expect(body.status).not.toBe('connected');
-        expect(body.redisUrl).toBe(url);
+        expect(body.redis).toBe(url);
         expect(body.attempts).toBeGreaterThan(0);
+      } finally {
+        await cli.stop();
+      }
+    });
+
+    it('connects through sentinels and reports the master group on the status endpoint', async () => {
+      const port = await unusedPort();
+      const cli = await startCli([
+        '--sentinel',
+        `127.0.0.1:${port}`,
+        '--sentinel-name',
+        'mymaster',
+        '--port',
+        '0',
+      ]);
+
+      try {
+        const response = await fetch(`${cli.url}/__bull-board-cli/status`);
+        const body = (await response.json()) as { status: string; redis: string };
+
+        expect(response.status).toBe(200);
+        expect(body.redis).toBe(`sentinel://mymaster@127.0.0.1:${port}`);
       } finally {
         await cli.stop();
       }

--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -7,6 +7,7 @@ import type { Readable } from 'node:stream';
 import BullQueue from 'bull';
 import { Queue as BullMQQueue } from 'bullmq';
 import { Redis } from 'ioredis';
+import { startFakeSentinel } from './fakeSentinel';
 
 const REDIS_HOST = process.env.REDIS_HOST || 'localhost';
 const REDIS_PORT = process.env.REDIS_PORT || '6379';
@@ -246,6 +247,48 @@ describe('cli', () => {
 
   afterAll(async () => {
     await client.quit();
+  });
+
+  it('resolves the master through sentinels and serves the queues it finds there', async () => {
+    const queueName = unique('sentinel-disc');
+    const queue = new BullMQQueue(queueName, { connection: redisOptions });
+    await queue.add('seed', {});
+    const sentinel = await startFakeSentinel({
+      host: REDIS_HOST,
+      port: +REDIS_PORT,
+      name: 'mymaster',
+    });
+
+    try {
+      const cli = await startCli([
+        '--sentinel',
+        `127.0.0.1:${sentinel.port}`,
+        '--sentinel-name',
+        'mymaster',
+        '--scan-interval',
+        '0',
+        '--port',
+        '0',
+      ]);
+
+      try {
+        const response = await fetch(`${cli.url}/api/queues`);
+        const body = (await response.json()) as {
+          queues: Array<{ name: string; counts: Record<string, number> }>;
+        };
+
+        expect(response.status).toBe(200);
+        const served = body.queues.find((entry) => entry.name === queueName);
+        expect(served?.counts.waiting).toBe(1);
+        expect(sentinel.commands).toContain('SENTINEL get-master-addr-by-name');
+      } finally {
+        await cli.stop();
+      }
+    } finally {
+      await queue.obliterate({ force: true });
+      await queue.close();
+      await sentinel.close();
+    }
   });
 
   it('discovers a BullMQ queue and a Bull queue through the real binary', async () => {

--- a/packages/cli/tests/config.spec.ts
+++ b/packages/cli/tests/config.spec.ts
@@ -34,7 +34,7 @@ describe('resolveConfig', () => {
     const config = resolveConfig({ flags: parseFlags([]), env: noEnv, file: noFile });
 
     expect(config).toMatchObject({
-      redisUrl: 'redis://localhost:6379',
+      connection: { mode: 'url', url: 'redis://localhost:6379', options: {} },
       port: 3000,
       host: '127.0.0.1',
       prefixes: ['bull'],

--- a/packages/cli/tests/connection.spec.ts
+++ b/packages/cli/tests/connection.spec.ts
@@ -1,0 +1,175 @@
+import { resolveConnection } from '../src/config/connection';
+import { parseFlags } from '../src/config/flags';
+
+const noEnv = {} as NodeJS.ProcessEnv;
+const noFile = {};
+
+const resolve = (
+  argv: string[],
+  env: NodeJS.ProcessEnv = noEnv,
+  file: Parameters<typeof resolveConnection>[0]['file'] = noFile
+) => resolveConnection({ flags: parseFlags(argv), env, file });
+
+describe('resolveConnection', () => {
+  it('defaults to the localhost URL', () => {
+    expect(resolve([])).toEqual({
+      mode: 'url',
+      url: 'redis://localhost:6379',
+      options: {},
+    });
+  });
+
+  it('keeps a URL untouched, so URL mode behaves exactly as it did', () => {
+    expect(resolve(['--redis', 'rediss://user:pass@example.com:6380/3?family=6'])).toEqual({
+      mode: 'url',
+      url: 'rediss://user:pass@example.com:6380/3?family=6',
+      options: {},
+    });
+  });
+
+  it('accepts a unix socket path', () => {
+    expect(resolve(['--redis', '/tmp/redis.sock'])).toEqual({
+      mode: 'url',
+      url: '/tmp/redis.sock',
+      options: {},
+    });
+  });
+
+  it('rejects a URL that is not redis:// or rediss://', () => {
+    expect(() => resolve(['--redis', 'http://localhost:6379'])).toThrow(
+      'Redis URL must use redis:// or rediss://, got "http://"'
+    );
+  });
+
+  it('rejects a URL that does not parse', () => {
+    expect(() => resolve(['--redis', 'not a url'])).toThrow('Invalid Redis URL: not a url');
+  });
+
+  it('builds sentinel options from a host list, defaulting the port to 26379', () => {
+    expect(
+      resolve(['--sentinel', 'a.example:26380, b.example', '--sentinel-name', 'mymaster'])
+    ).toEqual({
+      mode: 'sentinel',
+      options: {
+        sentinels: [
+          { host: 'a.example', port: 26380 },
+          { host: 'b.example', port: 26379 },
+        ],
+        name: 'mymaster',
+      },
+    });
+  });
+
+  it('reads sentinels from the environment', () => {
+    const connection = resolve([], {
+      BULL_BOARD_SENTINELS: 'a.example',
+      BULL_BOARD_SENTINEL_NAME: 'mymaster',
+    } as NodeJS.ProcessEnv);
+
+    expect(connection).toMatchObject({ mode: 'sentinel' });
+  });
+
+  it('passes sentinel and data node credentials through', () => {
+    const connection = resolve([
+      '--sentinel',
+      'a.example',
+      '--sentinel-name',
+      'mymaster',
+      '--sentinel-password',
+      'watcher',
+      '--redis-username',
+      'board',
+      '--redis-password',
+      'hunter2',
+      '--redis-db',
+      '3',
+    ]);
+
+    expect(connection.options).toMatchObject({
+      sentinelPassword: 'watcher',
+      username: 'board',
+      password: 'hunter2',
+      db: 3,
+    });
+  });
+
+  it('rejects sentinels without a master group name', () => {
+    expect(() => resolve(['--sentinel', 'a.example'])).toThrow('--sentinel needs --sentinel-name');
+  });
+
+  it('rejects an unparseable sentinel entry', () => {
+    expect(() => resolve(['--sentinel', 'a.example:nope', '--sentinel-name', 'mymaster'])).toThrow(
+      'Invalid sentinel address "a.example:nope"'
+    );
+  });
+
+  it('rejects an explicit Redis URL alongside sentinels', () => {
+    expect(() =>
+      resolve([
+        '--redis',
+        'redis://localhost:6379',
+        '--sentinel',
+        'a.example',
+        '--sentinel-name',
+        'm',
+      ])
+    ).toThrow('Use either a Redis URL or --sentinel, not both.');
+  });
+
+  it('rejects credential flags alongside a Redis URL, which would silently ignore them', () => {
+    expect(() =>
+      resolve(['--redis', 'redis://localhost:6379', '--redis-password', 'hunter2'])
+    ).toThrow('--redis-password cannot be combined with a Redis URL');
+  });
+
+  it('takes a full ioredis options object from the config file', () => {
+    const connection = resolve([], noEnv, {
+      redis: { host: 'example.com', port: 6380, tls: {} },
+    });
+
+    expect(connection).toEqual({
+      mode: 'options',
+      options: { host: 'example.com', port: 6380, tls: {} },
+    });
+  });
+
+  it('treats a config file object carrying sentinels as sentinel mode', () => {
+    const connection = resolve([], noEnv, {
+      redis: { sentinels: [{ host: 'a.example', port: 26379 }], name: 'mymaster', tls: {} },
+    });
+
+    expect(connection.mode).toBe('sentinel');
+  });
+
+  it('prefers an explicit Redis URL over a config file options object', () => {
+    const connection = resolve(['--redis', 'redis://flag.example:6379'], noEnv, {
+      redis: { host: 'file.example', port: 6380 },
+    });
+
+    expect(connection).toEqual({
+      mode: 'url',
+      url: 'redis://flag.example:6379',
+      options: {},
+    });
+  });
+
+  it('keeps a bracketed IPv6 sentinel address together with its port', () => {
+    const connection = resolve(['--sentinel', '[::1]:26380', '--sentinel-name', 'mymaster']);
+
+    expect(connection.options.sentinels).toEqual([{ host: '::1', port: 26380 }]);
+  });
+
+  it('reads a bare IPv6 sentinel address as a host, not as host plus port', () => {
+    const connection = resolve(['--sentinel', '2001:db8::1', '--sentinel-name', 'mymaster']);
+
+    expect(connection.options.sentinels).toEqual([{ host: '2001:db8::1', port: 26379 }]);
+  });
+
+  it('lets credential flags override a config file options object', () => {
+    const connection = resolve(['--redis-password', 'hunter2'], noEnv, {
+      redis: { host: 'example.com', password: 'stale' },
+    });
+
+    expect(connection.options).toMatchObject({ host: 'example.com', password: 'hunter2' });
+  });
+});

--- a/packages/cli/tests/connection.spec.ts
+++ b/packages/cli/tests/connection.spec.ts
@@ -103,6 +103,15 @@ describe('resolveConnection', () => {
     );
   });
 
+  it.each(['a.example:0', 'a.example:99999', 'a.example/path', ':26379'])(
+    'rejects the unusable sentinel address %p',
+    (entry) => {
+      expect(() => resolve(['--sentinel', entry, '--sentinel-name', 'mymaster'])).toThrow(
+        `Invalid sentinel address "${entry}"`
+      );
+    }
+  );
+
   it('rejects an explicit Redis URL alongside sentinels', () => {
     expect(() =>
       resolve([

--- a/packages/cli/tests/connectionState.spec.ts
+++ b/packages/cli/tests/connectionState.spec.ts
@@ -1,4 +1,4 @@
-import { maskRedisUrl } from '../src/connectionState';
+import { describeConnection, maskRedisUrl } from '../src/connectionState';
 
 describe('maskRedisUrl', () => {
   it('masks a userinfo password', () => {
@@ -37,5 +37,47 @@ describe('maskRedisUrl', () => {
 
   it('returns an unparseable URL unchanged rather than throwing', () => {
     expect(maskRedisUrl('not a url')).toBe('not a url');
+  });
+});
+
+describe('describeConnection', () => {
+  it('masks the password of a URL connection', () => {
+    expect(
+      describeConnection({ mode: 'url', url: 'redis://user:hunter2@host:6379', options: {} })
+    ).toBe('redis://user:***@host:6379');
+  });
+
+  it('names the master group and every sentinel', () => {
+    expect(
+      describeConnection({
+        mode: 'sentinel',
+        options: {
+          name: 'mymaster',
+          sentinels: [
+            { host: 'a.example', port: 26379 },
+            { host: 'b.example', port: 26380 },
+          ],
+        },
+      })
+    ).toBe('sentinel://mymaster@a.example:26379,b.example:26380');
+  });
+
+  it('brackets an IPv6 sentinel host so its port stays readable', () => {
+    expect(
+      describeConnection({
+        mode: 'sentinel',
+        options: { name: 'mymaster', sentinels: [{ host: '::1', port: 26379 }] },
+      })
+    ).toBe('sentinel://mymaster@[::1]:26379');
+  });
+
+  it('never leaks a password from an options connection', () => {
+    const described = describeConnection({
+      mode: 'options',
+      options: { host: 'example.com', port: 6380, password: 'hunter2' },
+    });
+
+    expect(described).toBe('redis://example.com:6380');
+    expect(described).not.toContain('hunter2');
   });
 });

--- a/packages/cli/tests/fakeSentinel.ts
+++ b/packages/cli/tests/fakeSentinel.ts
@@ -1,0 +1,107 @@
+import { createServer, type Server } from 'node:net';
+
+export interface FakeSentinel {
+  port: number;
+  commands: string[];
+  close(): Promise<void>;
+}
+
+function bulkArray(values: string[]): string {
+  return (
+    `*${values.length}\r\n` +
+    values.map((value) => `$${Buffer.byteLength(value)}\r\n${value}\r\n`).join('')
+  );
+}
+
+function readCommands(buffer: Buffer): { commands: string[][]; rest: Buffer<ArrayBuffer> } {
+  const commands: string[][] = [];
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    if (buffer[offset] !== 0x2a) return { commands, rest: Buffer.from(buffer.subarray(offset)) };
+
+    const headerEnd = buffer.indexOf('\r\n', offset);
+    if (headerEnd === -1) return { commands, rest: Buffer.from(buffer.subarray(offset)) };
+
+    const argc = Number(buffer.subarray(offset + 1, headerEnd).toString());
+    const parts: string[] = [];
+    let cursor = headerEnd + 2;
+    let complete = true;
+
+    for (let i = 0; i < argc; i++) {
+      const lengthEnd = buffer.indexOf('\r\n', cursor);
+      if (lengthEnd === -1) {
+        complete = false;
+        break;
+      }
+      const length = Number(buffer.subarray(cursor + 1, lengthEnd).toString());
+      const start = lengthEnd + 2;
+      if (buffer.length < start + length + 2) {
+        complete = false;
+        break;
+      }
+      parts.push(buffer.subarray(start, start + length).toString());
+      cursor = start + length + 2;
+    }
+
+    if (!complete) return { commands, rest: Buffer.from(buffer.subarray(offset)) };
+
+    commands.push(parts);
+    offset = cursor;
+  }
+
+  return { commands, rest: Buffer.alloc(0) };
+}
+
+export async function startFakeSentinel(master: {
+  host: string;
+  port: number;
+  name: string;
+}): Promise<FakeSentinel> {
+  const commands: string[] = [];
+
+  const server: Server = createServer((socket) => {
+    let buffered = Buffer.alloc(0);
+
+    socket.on('data', (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      const { commands: received, rest } = readCommands(buffered);
+      buffered = rest;
+
+      for (const parts of received) {
+        const command = parts[0]?.toUpperCase();
+        const subcommand = parts[1]?.toLowerCase();
+        commands.push([command, subcommand].filter(Boolean).join(' '));
+
+        if (command === 'SENTINEL' && subcommand === 'get-master-addr-by-name') {
+          socket.write(
+            parts[2] === master.name ? bulkArray([master.host, String(master.port)]) : '$-1\r\n'
+          );
+        } else if (command === 'SENTINEL' && subcommand === 'sentinels') {
+          socket.write('*0\r\n');
+        } else if (command === 'QUIT') {
+          socket.write('+OK\r\n');
+          socket.end();
+        } else {
+          socket.write('+OK\r\n');
+        }
+      }
+    });
+
+    socket.on('error', () => undefined);
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve(typeof address === 'object' && address ? address.port : 0);
+    });
+  });
+
+  return {
+    port,
+    commands,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}

--- a/packages/cli/tests/fakeSentinel.ts
+++ b/packages/cli/tests/fakeSentinel.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from 'node:net';
+import RedisParser from 'redis-parser';
 
 export interface FakeSentinel {
   port: number;
@@ -13,46 +14,6 @@ function bulkArray(values: string[]): string {
   );
 }
 
-function readCommands(buffer: Buffer): { commands: string[][]; rest: Buffer<ArrayBuffer> } {
-  const commands: string[][] = [];
-  let offset = 0;
-
-  while (offset < buffer.length) {
-    if (buffer[offset] !== 0x2a) return { commands, rest: Buffer.from(buffer.subarray(offset)) };
-
-    const headerEnd = buffer.indexOf('\r\n', offset);
-    if (headerEnd === -1) return { commands, rest: Buffer.from(buffer.subarray(offset)) };
-
-    const argc = Number(buffer.subarray(offset + 1, headerEnd).toString());
-    const parts: string[] = [];
-    let cursor = headerEnd + 2;
-    let complete = true;
-
-    for (let i = 0; i < argc; i++) {
-      const lengthEnd = buffer.indexOf('\r\n', cursor);
-      if (lengthEnd === -1) {
-        complete = false;
-        break;
-      }
-      const length = Number(buffer.subarray(cursor + 1, lengthEnd).toString());
-      const start = lengthEnd + 2;
-      if (buffer.length < start + length + 2) {
-        complete = false;
-        break;
-      }
-      parts.push(buffer.subarray(start, start + length).toString());
-      cursor = start + length + 2;
-    }
-
-    if (!complete) return { commands, rest: Buffer.from(buffer.subarray(offset)) };
-
-    commands.push(parts);
-    offset = cursor;
-  }
-
-  return { commands, rest: Buffer.alloc(0) };
-}
-
 export async function startFakeSentinel(master: {
   host: string;
   port: number;
@@ -61,14 +22,8 @@ export async function startFakeSentinel(master: {
   const commands: string[] = [];
 
   const server: Server = createServer((socket) => {
-    let buffered = Buffer.alloc(0);
-
-    socket.on('data', (chunk: Buffer) => {
-      buffered = Buffer.concat([buffered, chunk]);
-      const { commands: received, rest } = readCommands(buffered);
-      buffered = rest;
-
-      for (const parts of received) {
+    const parser = new RedisParser({
+      returnReply: (parts: string[]) => {
         const command = parts[0]?.toUpperCase();
         const subcommand = parts[1]?.toLowerCase();
         commands.push([command, subcommand].filter(Boolean).join(' '));
@@ -85,9 +40,11 @@ export async function startFakeSentinel(master: {
         } else {
           socket.write('+OK\r\n');
         }
-      }
+      },
+      returnError: () => socket.destroy(),
     });
 
+    socket.on('data', (chunk: Buffer) => parser.execute(chunk));
     socket.on('error', () => undefined);
   });
 

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -37,6 +37,15 @@ Usage:
 
 Options:
   -r, --redis <url>       Redis connection URL          [redis://localhost:6379]
+      --sentinel <list>   Comma separated sentinel host:port list, port [26379]
+      --sentinel-name <n> Redis master group name, required with --sentinel
+      --sentinel-password <pass>
+                          Password for the sentinel nodes themselves
+      --redis-username <name>
+                          Username for the Redis nodes behind the sentinels
+      --redis-password <pass>
+                          Password for the Redis nodes behind the sentinels
+      --redis-db <n>      Database to select behind the sentinels
   -p, --port <port>       Port to listen on             [3000]
       --host <address>    Interface to bind             [127.0.0.1]
       --prefix <list>     Comma separated key prefixes  [bull]
@@ -65,6 +74,12 @@ Every flag has an environment variable equivalent, so you can configure the CLI 
 | Flag | Environment variable |
 |---|---|
 | `--redis` | `BULL_BOARD_REDIS_URL` |
+| `--sentinel` | `BULL_BOARD_SENTINELS` |
+| `--sentinel-name` | `BULL_BOARD_SENTINEL_NAME` |
+| `--sentinel-password` | `BULL_BOARD_SENTINEL_PASSWORD` |
+| `--redis-username` | `BULL_BOARD_REDIS_USERNAME` |
+| `--redis-password` | `BULL_BOARD_REDIS_PASSWORD` |
+| `--redis-db` | `BULL_BOARD_REDIS_DB` |
 | `--port` | `BULL_BOARD_PORT` |
 | `--host` | `BULL_BOARD_HOST` |
 | `--prefix` | `BULL_BOARD_PREFIX` |
@@ -114,9 +129,62 @@ module.exports = {
 };
 ```
 
+`redis` takes a connection URL as above, or a full [ioredis options object](https://github.com/redis/ioredis#connect-to-redis) when a URL can't express the connection, which is what [Redis Sentinel](#redis-sentinel) needs.
+
 `uiConfig` is the same object you'd pass to `createBullBoard({ options: { uiConfig } })` in code, see the [UIConfig reference](/configuration/ui-config) for the full set of fields. Board-wide title, logo, locale, and so on all live there, not at the top level of the config file.
 
 `queues` is dual purpose: an array (`queues: ['emails', 'webhooks']`) is equivalent to `--queues`, a comma-free explicit list that skips discovery. An object, as above, instead sets per-queue [`QueueAdapterOptions`](/queue-adapters/bullmq) overrides keyed by queue name, the same options you'd pass to `new BullMQAdapter(queue, options)` directly. A queue's own `readOnlyMode: true` always wins even when the board as a whole isn't read-only, but it can't turn read-only mode back off for a single queue once `--read-only` is set globally. A field can't do both jobs in the same file: pick the array form to restrict which queues are served, or the object form to configure the ones discovery finds.
+
+## Redis Sentinel
+
+A Sentinel deployment has no fixed master address, so there is no single URL to point `--redis` at. `--sentinel` takes the sentinel nodes instead and lets ioredis work out which Redis is currently the master:
+
+```sh
+npx @bull-board/cli --sentinel s1.internal:26379,s2.internal:26379 --sentinel-name mymaster
+```
+
+Each entry is a `host` or `host:port`, with the port defaulting to 26379. An IPv6 literal is all colons, so it needs brackets to carry a port: `[2001:db8::1]:26379`. Without them the whole entry is read as a host and gets the default port. `--sentinel-name` is the master group name from your sentinel configuration, the same string you would pass as `name` to ioredis, and it is required: sentinels can monitor more than one group, so there is nothing sensible to guess.
+
+`--sentinel` and `--redis` are mutually exclusive. Setting both is an error rather than a quiet precedence rule, so a leftover `BULL_BOARD_REDIS_URL` in a container's environment cannot silently send the dashboard to the wrong Redis.
+
+The CLI holds one ioredis connection and hands it to everything else it builds, so failover handling is not a separate feature: the queue instances, Bull's second subscriber connection, and the `--history` recorder all follow the master through a failover because they share that connection. During the failover window the dashboard's own API requests fail the way they do for any dropped connection, and recover once ioredis has re-resolved the master.
+
+### Credentials
+
+A Redis URL carries its own credentials. Sentinel mode has no URL, so they get their own flags:
+
+| Flag | Applies to |
+|---|---|
+| `--redis-username` | The Redis nodes behind the sentinels |
+| `--redis-password` | The Redis nodes behind the sentinels |
+| `--redis-db` | The Redis nodes behind the sentinels |
+| `--sentinel-password` | The sentinel nodes themselves |
+
+`--sentinel-password` is separate because sentinel nodes usually have a password of their own, distinct from the one guarding the data nodes.
+
+These four are rejected alongside a Redis URL rather than merged into it. ioredis treats an explicitly passed option as a default and lets the URL win, so a `--redis-password` next to a URL that already carries one would be silently discarded. Refusing the combination outright is clearer than a flag that sometimes takes effect. With a URL, put the credentials in the URL.
+
+### Everything else
+
+The flags cover the common deployment. For anything past it, the config file's `redis` key also accepts a full [ioredis options object](https://github.com/redis/ioredis#connect-to-redis), passed through to the client untouched:
+
+```js
+// bull-board.config.js
+module.exports = {
+  redis: {
+    sentinels: [
+      { host: 's1.internal', port: 26379 },
+      { host: 's2.internal', port: 26379 },
+    ],
+    name: 'mymaster',
+    sentinelPassword: process.env.SENTINEL_PASSWORD,
+    enableTLSForSentinelMode: true,
+    tls: {},
+  },
+};
+```
+
+That is the way to reach TLS to the sentinel nodes, `natMap` for a NAT-ed cluster, `preferredSlaves`, or a custom `sentinelRetryStrategy`. The object form is not limited to Sentinel: a plain `{ host, port, tls }` works too, wherever a URL is awkward. Credential flags still apply on top of an object, so a password can stay in the environment instead of the file.
 
 ## Basic auth
 

--- a/website/docs/guide/docker.md
+++ b/website/docs/guide/docker.md
@@ -94,6 +94,20 @@ For anything longer, mount a [config file](/guide/cli#config-file). The working 
 
 The container is a normal recorder, so it keeps writing for as long as it runs and stops when you stop it. Two of them against one Redis is safe, and `--read-only` keeps the charts while writing nothing. The [CLI guide](/guide/cli#historical-metrics) covers the config file keys and what leaves the charts empty.
 
+[Redis Sentinel](/guide/cli#redis-sentinel) needs no URL, which is the point: the master address is not fixed, so the container is given the sentinel nodes and the master group name instead.
+
+```yaml
+  bull-board:
+    image: ghcr.io/felixmosh/bull-board:9
+    environment:
+      BULL_BOARD_SENTINELS: sentinel-1:26379,sentinel-2:26379,sentinel-3:26379
+      BULL_BOARD_SENTINEL_NAME: mymaster
+      BULL_BOARD_SENTINEL_PASSWORD: ${SENTINEL_PASSWORD}
+      BULL_BOARD_REDIS_PASSWORD: ${REDIS_PASSWORD}
+```
+
+Leave `BULL_BOARD_REDIS_URL` unset there. Setting both is an error, so an old URL left behind in a compose file or an env file stops the container rather than quietly winning.
+
 Serving the dashboard under a path prefix, which is what a reverse proxy routing on the path needs, is `--base-path`:
 
 ```sh

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,12 +520,14 @@ __metadata:
     "@bull-board/metrics": "npm:9.7.0"
     "@types/express": "npm:^5.0.6"
     "@types/jest": "npm:^30.0.0"
+    "@types/redis-parser": "npm:^3.0.3"
     "@types/supertest": "npm:^7.2.1"
     bull: "npm:^4.16.5"
     bullmq: "npm:^5.81.3"
     express: "npm:^5.2.1"
     ioredis: "npm:^6.0.0"
     jest: "npm:^30.4.2"
+    redis-parser: "npm:^3.0.0"
     supertest: "npm:^7.2.2"
     ts-jest: "npm:^29.4.12"
     typescript: "npm:^5.9.3"
@@ -5020,10 +5022,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/redis-errors@npm:*":
+  version: 1.2.3
+  resolution: "@types/redis-errors@npm:1.2.3"
+  checksum: 10c0/7327b7c37c8b4e48b01f1643dd0e4273e44955d5e18643dd8231cbfb49c9b95b45afd0f2a30665811d795ede8b326f590a327d380abd46559863d4447a8c020c
+  languageName: node
+  linkType: hard
+
 "@types/redis-info@npm:^3.0.3":
   version: 3.0.3
   resolution: "@types/redis-info@npm:3.0.3"
   checksum: 10c0/3ab82763e64c00c3b1d52feea0fcd46f9b932a38e6b044b45b09711b494526e93fc8e676268226a27229df323630ac6587da150c83f591face7e8b1b88348e81
+  languageName: node
+  linkType: hard
+
+"@types/redis-parser@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@types/redis-parser@npm:3.0.3"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/redis-errors": "npm:*"
+  checksum: 10c0/e70f1a0c81030a790755fe2177b8d4af891c3e9d4cf2aa8988f2ce0d29851a8aad2ec05559c953fc17683d866c8971e31bedb76e3d20295ac04866900368f5e7
   languageName: node
   linkType: hard
 
@@ -14056,7 +14075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redis-parser@npm:3.0.0":
+"redis-parser@npm:3.0.0, redis-parser@npm:^3.0.0":
   version: 3.0.0
   resolution: "redis-parser@npm:3.0.0"
   dependencies:


### PR DESCRIPTION
Closes #550.

A Sentinel deployment has no fixed master address, so there is nothing to point `--redis` at, and ioredis needs `{ sentinels, name }` to reach one. Library users were never blocked, since they build the connection themselves, but the CLI took a single URL end to end and had no way in.

```sh
bull-board --sentinel s1.internal:26379,s2.internal:26379 --sentinel-name mymaster
```

`CliConfig.redisUrl` becomes a small tagged union built by a new `src/config/connection.ts`. Six flags, each with a `BULL_BOARD_*` variable so the Docker image needs no change: `--sentinel`, `--sentinel-name`, `--sentinel-password`, and `--redis-username` / `--redis-password` / `--redis-db` for the nodes behind the sentinels. The config file's `redis` key also widens to `string | RedisOptions`, which covers TLS to the sentinel nodes and anything else exotic without a follow-up flag. URL mode is untouched, pinned by a test on its exact resolved options. The CLI still holds one client, so queues, Bull's subscriber and `--history` all follow a failover for free.

The real work was not the config. Left at its default, ioredis retries unreachable sentinels forever rather than rejecting `connect()`, which broke both startup paths: `--no-retry` hung instead of exiting 1, and the retrying path never reached the banner, so no diagnostic page appeared and the process sat silent. `--no-retry` now aborts the first sweep, and the retrying path races `connect()` against the client's first `error` event.

Sentinel addresses are parsed by handing each entry to `new URL()` rather than splitting on colons, so IPv6 literals and port ranges are the platform's problem rather than ours. `@bull-board/api` needs nothing here, since it only ever receives queues that callers have already connected, and `@bull-board/metrics` already accepts `Redis | RedisOptions`, so a Sentinel connection has always worked there.

Three combinations are refused rather than silently resolved: sentinels without a master group name, an explicit Redis URL alongside `--sentinel`, and the credential flags alongside a URL. The last one matters because ioredis lets a URL win over explicitly passed options, so `--redis-password` next to a URL that already has one would be discarded without a word.

`yarn workspace @bull-board/cli test` is 132 passing, up from 119, and the new end to end tests were confirmed red against a `dist/` built from master.

One of them actually connects. ioredis only sends five commands while resolving a master, so `tests/fakeSentinel.ts` answers those over a socket, decoding the wire with `redis-parser`, and points the CLI at an ordinary Redis through it: the binary runs with `--sentinel`, resolves the master, discovers a seeded BullMQ queue and serves its counts. That needs no sentinel deployment and no CI change, and it fails if the resolved options regress in ways ioredis accepts silently, such as `sentinels` arriving as a string. Separately I ran the real thing, a master, replica and sentinel in Docker, and across two forced failovers the board followed the promoted master with no gap at two second polling.
