### PR TITLE
fix(metrics): support Redis Cluster and a configurable key namespace

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -79,6 +79,24 @@ jobs:
       - name: Typecheck against the BullMQ peer floor and every supported major
         run: yarn workspace @bull-board/api typecheck:bullmq
 
+      # A cluster cannot be a `services:` entry: it needs three servers brought up and then
+      # joined, which that block has no way to express. Without REDIS_CLUSTER_NODES the
+      # metrics cluster spec skips itself.
+      - name: Start Redis Cluster
+        run: |
+          docker compose -f docker-compose.redis.yml up -d redis-cluster
+          for _ in $(seq 30); do
+            if docker compose -f docker-compose.redis.yml exec -T redis-cluster \
+              redis-cli -p 7101 cluster info 2>/dev/null | grep -q cluster_state:ok; then
+              echo 'Redis Cluster ready'
+              exit 0
+            fi
+            sleep 2
+          done
+          echo 'Redis Cluster did not become ready'
+          docker compose -f docker-compose.redis.yml logs redis-cluster
+          exit 1
+
       - name: Test
         run: yarn test
         env:
@@ -87,6 +105,7 @@ jobs:
           # The default Redis port
           REDIS_PORT: 6379
           POSTGRES_URL: postgres://bullmq:bullmq@localhost:5432/bullmq
+          REDIS_CLUSTER_NODES: 127.0.0.1:7101,127.0.0.1:7102,127.0.0.1:7103
 
       - name: Coverage (@bull-board/api)
         if: matrix.node == '24.x'

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -7,6 +7,33 @@ services:
       - 6379:6379
     volumes:
       - redis_data:/data
+  # Only the metrics package's cluster spec uses this, which skips when REDIS_CLUSTER_NODES is
+  # unset, so the service is optional for everything else. Three masters in one container:
+  # gossip stays inside the container's network namespace while the host reaches each node
+  # through its published port, which is what makes the announced 127.0.0.1 correct for both.
+  redis-cluster:
+    image: redis:7
+    hostname: redis-cluster
+    restart: unless-stopped
+    ports:
+      - 7101:7101
+      - 7102:7102
+      - 7103:7103
+    command:
+      - bash
+      - -c
+      - |
+        for port in 7101 7102 7103; do
+          redis-server --port $$port --cluster-enabled yes \
+            --cluster-config-file /tmp/nodes-$$port.conf --cluster-node-timeout 5000 \
+            --appendonly no --save '' \
+            --cluster-announce-ip 127.0.0.1 --cluster-announce-port $$port \
+            --cluster-announce-bus-port 1$$port --daemonize yes
+        done
+        sleep 2
+        redis-cli --cluster create 127.0.0.1:7101 127.0.0.1:7102 127.0.0.1:7103 \
+          --cluster-replicas 0 --cluster-yes
+        exec tail -f /dev/null
   # Only the BullMQ v6 half of the version matrix uses this, to cover the PostgreSQL backend.
   # Those tests skip when POSTGRES_URL is unset, so the service is optional for everything else.
   postgres:

--- a/packages/cli/src/config/resolve.ts
+++ b/packages/cli/src/config/resolve.ts
@@ -137,6 +137,7 @@ function resolveHistory({
   return {
     // Recording writes to Redis, which is what --read-only says not to do.
     record: fileHistory.record ?? !readOnly,
+    prefix: fileHistory.prefix,
     retentionDays:
       toNumber(flags['history-retention-days'], 'history-retention-days') ??
       toNumber(env.BULL_BOARD_HISTORY_RETENTION_DAYS, 'history-retention-days') ??

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -7,6 +7,8 @@ export interface FileHistoryConfig {
   enabled?: boolean;
   /** Write snapshots from this process. Defaults to true unless the board is read-only. */
   record?: boolean;
+  /** Redis key namespace for the recorded history. Defaults to `bull-board:metrics`. */
+  prefix?: string;
   retentionDays?: number;
   retention?: Partial<Retention>;
   latency?: boolean;
@@ -15,6 +17,7 @@ export interface FileHistoryConfig {
 
 export interface HistoryConfig {
   record: boolean;
+  prefix?: string;
   retentionDays?: number;
   retention?: Partial<Retention>;
   latency: boolean;

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -18,8 +18,12 @@ export interface HistoryDeps {
 }
 
 export function createHistory({ client, config, onWarning }: HistoryDeps): HistoryRuntime {
-  const retentionWindow = { retentionDays: config.retentionDays, retention: config.retention };
-  const provider = new RedisMetricsHistoryProvider({ connection: client, ...retentionWindow });
+  const shared = {
+    prefix: config.prefix,
+    retentionDays: config.retentionDays,
+    retention: config.retention,
+  };
+  const provider = new RedisMetricsHistoryProvider({ connection: client, ...shared });
   let recorder: MetricsRecorder | null = null;
 
   return {
@@ -30,7 +34,7 @@ export function createHistory({ client, config, onWarning }: HistoryDeps): Histo
       recorder = new MetricsRecorder({
         queues,
         connection: client,
-        ...retentionWindow,
+        ...shared,
         latency: config.latency,
         snapshotIntervalMs: config.snapshotIntervalMs,
         onLatencyError: (error, queueName) =>

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -43,9 +43,30 @@ Not embedding bull-board in an app of your own? This package ships inside [`@bul
 
 On shutdown, call `recorder.stop()` and `provider.disconnect()`. Both only close the Redis connection if the recorder/provider opened it internally, so it's a safe no-op if you passed in your own `Redis` instance.
 
-`connection` may be ioredis options or a `Redis` instance you created. `ioredis` is a peer dependency (v5 or v6): resolve a single copy in your app, and if you reuse an existing client, pass one built from that same `ioredis` — a client from a different install (for example one created internally by a BullMQ pinned to a different ioredis major) is not recognized as a `Redis` instance and would be misread as options.
+`connection` may be ioredis options, or a `Redis` or `Cluster` instance you created. `ioredis` is a peer dependency (v5 or v6): resolve a single copy in your app, and if you reuse an existing client, pass one built from that same `ioredis`. A client from a different install (for example one created internally by a BullMQ pinned to a different ioredis major) is not recognized as a client and would be misread as options.
 
 Timestamps and buckets are UTC.
+
+## Key namespace
+
+Every key the recorder writes lives under `bull-board:metrics:`. Pass `prefix` to move it, which is how two boards share one Redis without their histories running together:
+
+    const recorder = new MetricsRecorder({ queues, connection, prefix: 'staging:metrics' });
+    const provider = new RedisMetricsHistoryProvider({ connection, prefix: 'staging:metrics' });
+
+The provider, the recorder and any `MetricsHistoryAdmin` must all be given the same prefix. A provider reading a namespace nothing writes to reports empty history rather than an error, the same way a mismatched retention quietly shortens the window.
+
+## Redis Cluster
+
+Pass a `Cluster` as `connection` and it works, with one thing worth knowing about the key layout.
+
+Each snapshot writes a queue's three tiers and the three `__global__` rollup tiers in a single `EVAL`, which is what makes the write idempotent across all resolutions at once. Redis Cluster rejects a multi-key command whose keys land in different slots, so the whole namespace has to hash to one slot. It is given a [hash tag](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) for that: `bull-board:metrics` becomes `{bull-board:metrics}`, and a `prefix` of your own is wrapped the same way unless it already carries a `{...}` tag, in which case yours is used and you choose the slot.
+
+One slot means one master holds the history for the whole board. That is the trade for keeping the rollup consistent on write rather than recomputing it on read, and the volume is the same as the storage section below: roughly 50 MB at 200 busy queues, and one `EVAL` per queue per metric per minute.
+
+Standalone keys are untagged and unchanged, so nothing moves for an existing deployment. Nothing carries over from a standalone Redis to a cluster, since the key names differ.
+
+Latency sampling reads BullMQ's own keys through the same connection, so your queues need the hash-tagged prefix BullMQ already asks for in cluster mode (`new Queue(name, { prefix: '{bull}' })`). Without it the sampler's pipelines span slots; it swallows that error, so pass `onLatencyError` to see it.
 
 ## Job latency
 
@@ -63,7 +84,7 @@ A BullMQ 6 queue backed by PostgreSQL records no history. Its `getMetrics()` rep
 
 ## Storage
 
-Every key lives under `bull-board:metrics:`. Each snapshot is written at three resolutions at once, each with its own retention, because they cost very different amounts:
+Each snapshot is written at three resolutions at once, each with its own retention, because they cost very different amounts:
 
 | Tier | Default retention | Size per busy day, per queue and metric |
 | --- | --- | --- |
@@ -97,14 +118,14 @@ Retention is enforced by Redis. Day-scoped keys expire on their own TTL; the dai
 
     import { MetricsHistoryAdmin } from '@bull-board/metrics';
 
-    const admin = new MetricsHistoryAdmin({ connection });
+    const admin = new MetricsHistoryAdmin({ connection });        // add `prefix` if the recorder has one
 
     await admin.stats();                          // bytes per tier and per queue, day range
     await admin.purge();                          // delete everything
     await admin.purge({ queue: 'mailer' });       // delete one queue
     await admin.purge({ before: '2026-06-01' });  // delete anything older than a day
 
-Both are `SCAN`-driven and confined to this package's namespace, so they never block Redis and never touch BullMQ's own keys. Purging a single queue also subtracts it from the cross-queue rollup. Call `admin.disconnect()` when done.
+Both are `SCAN`-driven and confined to this package's namespace, so they never block Redis and never touch BullMQ's own keys. On a cluster they scan every master, since `SCAN` carries no key for the client to route by. Purging a single queue also subtracts it from the cross-queue rollup. Call `admin.disconnect()` when done.
 
 `RedisMetricsHistoryProvider` exposes the same two operations to the board, which turns them into a storage panel on the Metrics history page with a confirmation before anything is deleted.
 

--- a/packages/metrics/src/HistoryAdmin.ts
+++ b/packages/metrics/src/HistoryAdmin.ts
@@ -1,6 +1,11 @@
-import { Redis, type RedisOptions } from 'ioredis';
-import { isRedisClient } from './connection';
-import { GLOBAL_QUEUE, HOUR_TIER, NAMESPACE, dayHashKey, hourHashKey, totalsHashKey } from './keys';
+import {
+  isCluster,
+  resolveClient,
+  scanTargets,
+  type MetricsClient,
+  type MetricsConnection,
+} from './connection';
+import { GLOBAL_QUEUE, HOUR_TIER, metricsKeys, resolveNamespace, type MetricsKeys } from './keys';
 
 const SCAN_COUNT = 500;
 const BATCH = 256;
@@ -59,7 +64,9 @@ export interface PurgeResult {
 }
 
 export interface MetricsHistoryAdminOptions {
-  connection: RedisOptions | Redis;
+  connection: MetricsConnection;
+  /** Must match the recorder's. See `MetricsRecorderOptions.prefix`. */
+  prefix?: string;
 }
 
 export type HistoryTier = 'minute' | 'hour' | 'day';
@@ -84,8 +91,8 @@ interface ParsedKey {
  * ending in `:completed` still resolves correctly. Anything that doesn't fit returns null
  * and is then reported but never deleted, so a stray key can't be destroyed by accident.
  */
-export function parseHistoryKey(key: string): ParsedKey | null {
-  const prefix = `${NAMESPACE}:`;
+export function parseHistoryKey(key: string, namespace: string): ParsedKey | null {
+  const prefix = `${namespace}:`;
   if (!key.startsWith(prefix)) {
     return null;
   }
@@ -121,13 +128,13 @@ function emptyTiers(): Record<HistoryTier, TierStats> {
 }
 
 /** The global rollup key mirroring a per-queue key, same tier and same day. */
-function globalKeyFor(parsed: ParsedKey): string {
+function globalKeyFor(keys: MetricsKeys, parsed: ParsedKey): string {
   if (parsed.day === null) {
-    return totalsHashKey(GLOBAL_QUEUE, parsed.metric);
+    return keys.totals(GLOBAL_QUEUE, parsed.metric);
   }
   return parsed.tier === 'hour'
-    ? hourHashKey(GLOBAL_QUEUE, parsed.metric, parsed.day)
-    : dayHashKey(GLOBAL_QUEUE, parsed.metric, parsed.day);
+    ? keys.hour(GLOBAL_QUEUE, parsed.metric, parsed.day)
+    : keys.day(GLOBAL_QUEUE, parsed.metric, parsed.day);
 }
 
 function toDay(value: Date | string): string {
@@ -143,24 +150,19 @@ function toDay(value: Date | string): string {
 /**
  * Inspection and cleanup for the Redis keys written by `MetricsRecorder`.
  *
- * Every operation is confined to the `bull-board:metrics:` namespace and driven by SCAN,
- * so it never blocks Redis and never touches BullMQ's own keys. Deletes use UNLINK.
+ * Every operation is confined to the recorder's namespace and driven by SCAN, so it never
+ * blocks Redis and never touches BullMQ's own keys. Deletes use UNLINK.
  */
 export class MetricsHistoryAdmin {
-  private readonly redis: Redis;
+  private readonly redis: MetricsClient;
+  private readonly keys: MetricsKeys;
   private readonly ownsRedis: boolean;
 
   constructor(opts: MetricsHistoryAdminOptions) {
-    if (isRedisClient(opts.connection)) {
-      this.redis = opts.connection;
-      this.ownsRedis = false;
-    } else {
-      // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
-      // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
-      // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
-      this.redis = new Redis({ protocol: 2, ...opts.connection });
-      this.ownsRedis = true;
-    }
+    const { client, owned } = resolveClient(opts.connection);
+    this.redis = client;
+    this.ownsRedis = owned;
+    this.keys = metricsKeys(resolveNamespace(opts.prefix, isCluster(client)));
   }
 
   disconnect(): void {
@@ -189,7 +191,7 @@ export class MetricsHistoryAdmin {
 
     const found: { key: string; parsed: ParsedKey }[] = [];
     for await (const key of this.scan()) {
-      const parsed = parseHistoryKey(key);
+      const parsed = parseHistoryKey(key, this.keys.namespace);
       if (parsed) {
         found.push({ key, parsed });
       }
@@ -282,7 +284,7 @@ export class MetricsHistoryAdmin {
     const totalsKeys: { key: string; parsed: ParsedKey }[] = [];
 
     for await (const key of this.scan()) {
-      const parsed = parseHistoryKey(key);
+      const parsed = parseHistoryKey(key, this.keys.namespace);
       if (!parsed) {
         continue;
       }
@@ -345,7 +347,7 @@ export class MetricsHistoryAdmin {
       return 0;
     }
     const minutes = await this.redis.hgetall(key);
-    const globalDay = globalKeyFor(parsed);
+    const globalDay = globalKeyFor(this.keys, parsed);
     const pipeline = this.redis.multi();
     const touched: string[] = [];
     for (const field of Object.keys(minutes)) {
@@ -382,7 +384,7 @@ export class MetricsHistoryAdmin {
     if (!SUMMABLE_METRICS.includes(metric)) {
       return 0;
     }
-    const globalTotals = totalsHashKey(GLOBAL_QUEUE, metric);
+    const globalTotals = this.keys.totals(GLOBAL_QUEUE, metric);
     const pipeline = this.redis.multi();
     const touched: string[] = [];
     days.forEach((day, i) => {
@@ -406,28 +408,31 @@ export class MetricsHistoryAdmin {
   }
 
   /**
-   * SCAN over the namespace. SCAN may hand back the same key on more than one cursor
-   * iteration, which would double-count in `stats()`, so emissions are de-duped here.
-   * The set is bounded by queues x metrics x retention days.
+   * SCAN over the namespace, once per master: SCAN carries no key, so a cluster client has
+   * no slot to route by and would answer from one arbitrary node. SCAN may also hand back the
+   * same key on more than one cursor iteration, which would double-count in `stats()`, so
+   * emissions are de-duped here. The set is bounded by queues x metrics x retention days.
    */
   private async *scan(): AsyncGenerator<string> {
     const seen = new Set<string>();
-    let cursor = '0';
-    do {
-      const [next, batch] = await this.redis.scan(
-        cursor,
-        'MATCH',
-        `${NAMESPACE}:*`,
-        'COUNT',
-        SCAN_COUNT
-      );
-      cursor = next;
-      for (const key of batch) {
-        if (!seen.has(key)) {
-          seen.add(key);
-          yield key;
+    for (const target of scanTargets(this.redis)) {
+      let cursor = '0';
+      do {
+        const [next, batch] = await target.scan(
+          cursor,
+          'MATCH',
+          this.keys.scanPattern,
+          'COUNT',
+          SCAN_COUNT
+        );
+        cursor = next;
+        for (const key of batch) {
+          if (!seen.has(key)) {
+            seen.add(key);
+            yield key;
+          }
         }
-      }
-    } while (cursor !== '0');
+      } while (cursor !== '0');
+    }
   }
 }

--- a/packages/metrics/src/HistoryStore.ts
+++ b/packages/metrics/src/HistoryStore.ts
@@ -1,13 +1,5 @@
-import type { Redis } from 'ioredis';
-import {
-  GLOBAL_QUEUE,
-  dayHashKey,
-  hourHashKey,
-  minuteToDay,
-  minuteToHour,
-  shiftDay,
-  totalsHashKey,
-} from './keys';
+import type { MetricsClient } from './connection';
+import { GLOBAL_QUEUE, minuteToDay, minuteToHour, shiftDay, type MetricsKeys } from './keys';
 
 export interface Retention {
   /** Days of minute-level detail. Doubles as the recorder's catch-up window. */
@@ -93,11 +85,13 @@ function ttl(days: number): string {
 }
 
 export class HistoryStore {
-  private readonly redis: Redis;
+  private readonly redis: MetricsClient;
+  private readonly keys: MetricsKeys;
   readonly retention: Retention;
 
-  constructor(opts: { redis: Redis; retention: Retention }) {
+  constructor(opts: { redis: MetricsClient; keys: MetricsKeys; retention: Retention }) {
     this.redis = opts.redis;
+    this.keys = opts.keys;
     this.retention = {
       minutes: Math.max(1, Math.floor(opts.retention.minutes)),
       hours: Math.max(1, Math.floor(opts.retention.hours)),
@@ -110,12 +104,12 @@ export class HistoryStore {
     await this.redis.eval(
       UPSERT_MINUTE,
       6,
-      dayHashKey(queue, metric, day),
-      hourHashKey(queue, metric, day),
-      totalsHashKey(queue, metric),
-      dayHashKey(GLOBAL_QUEUE, metric, day),
-      hourHashKey(GLOBAL_QUEUE, metric, day),
-      totalsHashKey(GLOBAL_QUEUE, metric),
+      this.keys.day(queue, metric, day),
+      this.keys.hour(queue, metric, day),
+      this.keys.totals(queue, metric),
+      this.keys.day(GLOBAL_QUEUE, metric, day),
+      this.keys.hour(GLOBAL_QUEUE, metric, day),
+      this.keys.totals(GLOBAL_QUEUE, metric),
       String(minute),
       String(minuteToHour(minute)),
       day,
@@ -147,7 +141,7 @@ export class HistoryStore {
     const redis = this.redis as unknown as {
       hmget(key: string, fields: string[]): Promise<(string | null)[]>;
     };
-    return redis.hmget(totalsHashKey(queue, metric), days);
+    return redis.hmget(this.keys.totals(queue, metric), days);
   }
 
   async readDayMinutes(
@@ -155,7 +149,7 @@ export class HistoryStore {
     metric: string,
     day: string
   ): Promise<Record<string, number>> {
-    return this.readNumericHash(dayHashKey(queue, metric, day));
+    return this.readNumericHash(this.keys.day(queue, metric, day));
   }
 
   /**
@@ -166,7 +160,7 @@ export class HistoryStore {
    * they cover are already outside the minute window anyway.
    */
   async readDayHours(queue: string, metric: string, day: string): Promise<Record<string, number>> {
-    const hours = await this.readNumericHash(hourHashKey(queue, metric, day));
+    const hours = await this.readNumericHash(this.keys.hour(queue, metric, day));
     if (Object.keys(hours).length > 0) {
       return hours;
     }

--- a/packages/metrics/src/LatencySampler.ts
+++ b/packages/metrics/src/LatencySampler.ts
@@ -1,7 +1,7 @@
 import type { BaseAdapter } from '@bull-board/api/baseAdapter';
-import type { Redis } from 'ioredis';
+import type { MetricsClient } from './connection';
 import { bucketIndex, emptyVector } from './histogram';
-import { NAMESPACE } from './keys';
+import type { MetricsKeys } from './keys';
 import type { LatencyMetric, LatencyStore } from './LatencyStore';
 
 const MS_PER_HOUR = 3600000;
@@ -27,7 +27,8 @@ interface AdapterWithKeys extends BaseAdapter {
 }
 
 export interface LatencySamplerOptions {
-  redis: Redis;
+  redis: MetricsClient;
+  keys: MetricsKeys;
   store: LatencyStore;
   /** Recorder tick, used to size the lease and to bound a cold start. */
   tickMs: number;
@@ -59,7 +60,8 @@ export interface LatencySamplerOptions {
  * trims faster than the tick runs.
  */
 export class LatencySampler {
-  private readonly redis: Redis;
+  private readonly redis: MetricsClient;
+  private readonly keys: MetricsKeys;
   private readonly store: LatencyStore;
   private readonly tickMs: number;
   private readonly maxSamples: number;
@@ -70,6 +72,7 @@ export class LatencySampler {
 
   constructor(opts: LatencySamplerOptions) {
     this.redis = opts.redis;
+    this.keys = opts.keys;
     this.store = opts.store;
     this.tickMs = opts.tickMs;
     this.maxSamples = opts.maxSamplesPerTick ?? DEFAULT_MAX_SAMPLES;
@@ -126,10 +129,6 @@ export class LatencySampler {
     return backed;
   }
 
-  private leaseKey(name: string): string {
-    return `${NAMESPACE}:${name}:latency:lease`;
-  }
-
   /**
    * Increments are not idempotent the way the counter upsert is, so two recorders scanning
    * the same range would double every histogram. Only the lease holder scans.
@@ -139,7 +138,7 @@ export class LatencySampler {
    * outliving its scan would make the next tick no-op and halve the sampling rate.
    */
   private async acquireLease(name: string): Promise<boolean> {
-    const held = await this.redis.set(this.leaseKey(name), this.id, 'PX', this.tickMs * 2, 'NX');
+    const held = await this.redis.set(this.keys.lease(name), this.id, 'PX', this.tickMs * 2, 'NX');
     return held === 'OK';
   }
 
@@ -149,13 +148,9 @@ export class LatencySampler {
       `if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end
        return 0`,
       1,
-      this.leaseKey(name),
+      this.keys.lease(name),
       this.id
     );
-  }
-
-  private watermarkKey(name: string): string {
-    return `${NAMESPACE}:${name}:latency:watermark`;
   }
 
   /**
@@ -170,7 +165,7 @@ export class LatencySampler {
   }
 
   private async sampleDurations(adapter: AdapterWithKeys, name: string): Promise<void> {
-    const watermarkRaw = await this.redis.get(this.watermarkKey(name));
+    const watermarkRaw = await this.redis.get(this.keys.watermark(name));
     // Cold start covers one tick ending at the safety bound rather than backfilling, since a
     // first run against a large completed set would be a surprise fetch storm. Ending at the
     // bound rather than at now is what keeps a tick shorter than the margin from producing a
@@ -195,7 +190,7 @@ export class LatencySampler {
     }
     if (ids.length === 0) {
       await this.redis.set(
-        this.watermarkKey(name),
+        this.keys.watermark(name),
         String(upperBound),
         'EX',
         this.watermarkTtlSeconds()
@@ -260,7 +255,7 @@ export class LatencySampler {
     await this.flush(name, 'waittime', waitByHour);
     // The bound, not the highest score observed. See SAFETY_MARGIN_MS.
     await this.redis.set(
-      this.watermarkKey(name),
+      this.keys.watermark(name),
       String(upperBound),
       'EX',
       this.watermarkTtlSeconds()

--- a/packages/metrics/src/LatencyStore.ts
+++ b/packages/metrics/src/LatencyStore.ts
@@ -1,7 +1,7 @@
-import type { Redis } from 'ioredis';
+import type { MetricsClient } from './connection';
 import { BUCKET_COUNT, mergeVectors, packVector, unpackVector } from './histogram';
 import type { Retention } from './HistoryStore';
-import { GLOBAL_QUEUE, hourHashKey, minuteToDay, shiftDay, totalsHashKey } from './keys';
+import { GLOBAL_QUEUE, minuteToDay, shiftDay, type MetricsKeys } from './keys';
 
 export type LatencyMetric = 'runtime' | 'waittime';
 
@@ -160,11 +160,13 @@ return 1
 `;
 
 export class LatencyStore {
-  private readonly redis: Redis;
+  private readonly redis: MetricsClient;
+  private readonly keys: MetricsKeys;
   readonly retention: Retention;
 
-  constructor(opts: { redis: Redis; retention: Retention }) {
+  constructor(opts: { redis: MetricsClient; keys: MetricsKeys; retention: Retention }) {
     this.redis = opts.redis;
+    this.keys = opts.keys;
     this.retention = opts.retention;
   }
 
@@ -178,10 +180,10 @@ export class LatencyStore {
     await this.redis.eval(
       MERGE_VECTOR,
       4,
-      hourHashKey(queue, metric, day),
-      totalsHashKey(queue, metric),
-      hourHashKey(GLOBAL_QUEUE, metric, day),
-      totalsHashKey(GLOBAL_QUEUE, metric),
+      this.keys.hour(queue, metric, day),
+      this.keys.totals(queue, metric),
+      this.keys.hour(GLOBAL_QUEUE, metric, day),
+      this.keys.totals(GLOBAL_QUEUE, metric),
       String(hour),
       day,
       packVector(vector),
@@ -197,10 +199,10 @@ export class LatencyStore {
     await this.redis.eval(
       MAX_GAUGE,
       4,
-      hourHashKey(queue, QUEUE_AGE_METRIC, day),
-      totalsHashKey(queue, QUEUE_AGE_METRIC),
-      hourHashKey(GLOBAL_QUEUE, QUEUE_AGE_METRIC, day),
-      totalsHashKey(GLOBAL_QUEUE, QUEUE_AGE_METRIC),
+      this.keys.hour(queue, QUEUE_AGE_METRIC, day),
+      this.keys.totals(queue, QUEUE_AGE_METRIC),
+      this.keys.hour(GLOBAL_QUEUE, QUEUE_AGE_METRIC, day),
+      this.keys.totals(GLOBAL_QUEUE, QUEUE_AGE_METRIC),
       String(hour),
       day,
       String(Math.max(0, Math.round(ms))),
@@ -218,7 +220,7 @@ export class LatencyStore {
   ): Promise<Record<string, number[]>> {
     const out: Record<string, number[]> = {};
     if (granularity === 'day') {
-      const raw = await this.redis.hgetall(totalsHashKey(queue, metric));
+      const raw = await this.redis.hgetall(this.keys.totals(queue, metric));
       for (const day of days) {
         if (raw[day] !== undefined) {
           out[day] = unpackVector(raw[day]);
@@ -229,7 +231,7 @@ export class LatencyStore {
     // Up to one key per retention day, so these go out together rather than as a serial
     // chain of round trips, matching how the counter path reads its day hashes.
     const perDay = await Promise.all(
-      days.map((day) => this.redis.hgetall(hourHashKey(queue, metric, day)))
+      days.map((day) => this.redis.hgetall(this.keys.hour(queue, metric, day)))
     );
     for (const raw of perDay) {
       for (const field of Object.keys(raw)) {
@@ -248,7 +250,7 @@ export class LatencyStore {
   ): Promise<Record<string, number>> {
     const out: Record<string, number> = {};
     if (granularity === 'day') {
-      const raw = await this.redis.hgetall(totalsHashKey(queue, QUEUE_AGE_METRIC));
+      const raw = await this.redis.hgetall(this.keys.totals(queue, QUEUE_AGE_METRIC));
       for (const day of days) {
         if (raw[day] !== undefined) {
           out[day] = Number(raw[day]) || 0;
@@ -257,7 +259,7 @@ export class LatencyStore {
       return out;
     }
     const perDay = await Promise.all(
-      days.map((day) => this.redis.hgetall(hourHashKey(queue, QUEUE_AGE_METRIC, day)))
+      days.map((day) => this.redis.hgetall(this.keys.hour(queue, QUEUE_AGE_METRIC, day)))
     );
     for (const raw of perDay) {
       for (const field of Object.keys(raw)) {

--- a/packages/metrics/src/MetricsRecorder.ts
+++ b/packages/metrics/src/MetricsRecorder.ts
@@ -1,9 +1,9 @@
 import type { BaseAdapter } from '@bull-board/api/baseAdapter';
 import type { MetricsType } from '@bull-board/api/typings/app';
-import { Redis, type RedisOptions } from 'ioredis';
-import { isRedisClient } from './connection';
+import { isCluster, resolveClient, type MetricsClient, type MetricsConnection } from './connection';
 import { metricsToMinutePoints } from './dataMapping';
 import { HistoryStore, type Retention } from './HistoryStore';
+import { metricsKeys, resolveNamespace } from './keys';
 import { LatencySampler } from './LatencySampler';
 import { LatencyStore } from './LatencyStore';
 
@@ -25,7 +25,17 @@ export interface MetricsRecorderOptions {
    * runs. An array is read once, at construction.
    */
   queues: BaseAdapter[] | (() => BaseAdapter[]);
-  connection: RedisOptions | Redis;
+  connection: MetricsConnection;
+  /**
+   * Redis key namespace, defaulting to `bull-board:metrics`. Set it to separate two boards
+   * sharing one Redis, and give the reading `RedisMetricsHistoryProvider` the same value.
+   *
+   * On a Redis Cluster the namespace has to sit in one hash slot, since the rollup scripts
+   * write a queue's keys and the cross-queue keys in one EVAL. A prefix with no `{...}` hash
+   * tag is wrapped in one, so `staging:metrics` becomes `{staging:metrics}`; supply your own
+   * tag to choose the slot yourself.
+   */
+  prefix?: string;
   /** Per-resolution retention in days. Unspecified tiers fall back to the defaults. */
   retention?: Partial<Retention>;
   /**
@@ -78,7 +88,7 @@ export function resolveRetention(opts: {
 export class MetricsRecorder {
   private readonly resolveQueues: () => BaseAdapter[];
   private readonly store: HistoryStore;
-  private readonly redis: Redis;
+  private readonly redis: MetricsClient;
   private readonly ownsRedis: boolean;
   private readonly intervalMs: number;
   private readonly lastMinute = new Map<string, number>();
@@ -92,22 +102,17 @@ export class MetricsRecorder {
     const { queues } = opts;
     this.resolveQueues = typeof queues === 'function' ? queues : () => queues;
     this.intervalMs = opts.snapshotIntervalMs ?? 60000;
-    if (isRedisClient(opts.connection)) {
-      this.redis = opts.connection;
-      this.ownsRedis = false;
-    } else {
-      // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
-      // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
-      // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
-      this.redis = new Redis({ protocol: 2, ...opts.connection });
-      this.ownsRedis = true;
-    }
-    this.store = new HistoryStore({ redis: this.redis, retention: resolveRetention(opts) });
+    const { client, owned } = resolveClient(opts.connection);
+    this.redis = client;
+    this.ownsRedis = owned;
+    const keys = metricsKeys(resolveNamespace(opts.prefix, isCluster(client)));
+    this.store = new HistoryStore({ redis: this.redis, keys, retention: resolveRetention(opts) });
     this.latencyEnabled = opts.latency !== false;
     this.latencySampler = this.latencyEnabled
       ? new LatencySampler({
           redis: this.redis,
-          store: new LatencyStore({ redis: this.redis, retention: resolveRetention(opts) }),
+          keys,
+          store: new LatencyStore({ redis: this.redis, keys, retention: resolveRetention(opts) }),
           tickMs: this.intervalMs,
           maxSamplesPerTick: opts.maxLatencySamplesPerTick,
           safetyMarginMs: opts.latencySafetyMarginMs,

--- a/packages/metrics/src/RedisMetricsHistoryProvider.ts
+++ b/packages/metrics/src/RedisMetricsHistoryProvider.ts
@@ -5,8 +5,7 @@ import type {
   MetricsLatencyPoint,
   MetricsLatencyQuery,
 } from '@bull-board/api/typings/app';
-import { Redis, type RedisOptions } from 'ioredis';
-import { isRedisClient } from './connection';
+import { isCluster, resolveClient, type MetricsClient, type MetricsConnection } from './connection';
 import { emptyVector, mergeVectors, quantile, vectorTotal } from './histogram';
 import {
   MetricsHistoryAdmin,
@@ -15,14 +14,16 @@ import {
   type PurgeResult,
 } from './HistoryAdmin';
 import { HistoryStore, type Retention } from './HistoryStore';
-import { GLOBAL_QUEUE, dayRange, dayToStartMs } from './keys';
+import { GLOBAL_QUEUE, dayRange, dayToStartMs, metricsKeys, resolveNamespace } from './keys';
 import { LatencyStore } from './LatencyStore';
 import { resolveRetention } from './MetricsRecorder';
 
 const MS_PER_HOUR = 3600000;
 
 export interface RedisMetricsHistoryProviderOptions {
-  connection: RedisOptions | Redis;
+  connection: MetricsConnection;
+  /** Must match the recorder's. See `MetricsRecorderOptions.prefix`. */
+  prefix?: string;
   /** Should mirror the recorder's retention. Only used to bound the query span. */
   retention?: Partial<Retention>;
   retentionDays?: number;
@@ -32,26 +33,20 @@ export class RedisMetricsHistoryProvider implements MetricsHistoryProvider {
   private readonly store: HistoryStore;
   private readonly latencyStore: LatencyStore;
   private readonly admin: MetricsHistoryAdmin;
-  private readonly redis: Redis;
+  private readonly redis: MetricsClient;
   private readonly ownsRedis: boolean;
   private readonly retentionDays: number;
 
   constructor(opts: RedisMetricsHistoryProviderOptions) {
-    if (isRedisClient(opts.connection)) {
-      this.redis = opts.connection;
-      this.ownsRedis = false;
-    } else {
-      // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
-      // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
-      // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
-      this.redis = new Redis({ protocol: 2, ...opts.connection });
-      this.ownsRedis = true;
-    }
+    const { client, owned } = resolveClient(opts.connection);
+    this.redis = client;
+    this.ownsRedis = owned;
+    const keys = metricsKeys(resolveNamespace(opts.prefix, isCluster(client)));
     const retention = resolveRetention(opts);
     this.retentionDays = retention.days;
-    this.store = new HistoryStore({ redis: this.redis, retention });
-    this.latencyStore = new LatencyStore({ redis: this.redis, retention });
-    this.admin = new MetricsHistoryAdmin({ connection: this.redis });
+    this.store = new HistoryStore({ redis: this.redis, keys, retention });
+    this.latencyStore = new LatencyStore({ redis: this.redis, keys, retention });
+    this.admin = new MetricsHistoryAdmin({ connection: this.redis, prefix: opts.prefix });
   }
 
   disconnect(): void {

--- a/packages/metrics/src/connection.ts
+++ b/packages/metrics/src/connection.ts
@@ -1,7 +1,29 @@
-import type { Redis, RedisOptions } from 'ioredis';
+import { Redis, type Cluster, type RedisOptions } from 'ioredis';
 
-export type MetricsConnection = Redis | RedisOptions;
+export type MetricsClient = Redis | Cluster;
+export type MetricsConnection = MetricsClient | RedisOptions;
 
-export function isRedisClient(connection: MetricsConnection): connection is Redis {
+export function isClient(connection: MetricsConnection): connection is MetricsClient {
   return typeof (connection as Partial<Redis>)?.hgetall === 'function';
+}
+
+export function isCluster(connection: MetricsConnection): connection is Cluster {
+  return typeof (connection as Partial<Cluster>)?.nodes === 'function';
+}
+
+export function scanTargets(client: MetricsClient): MetricsClient[] {
+  return isCluster(client) ? client.nodes('master') : [client];
+}
+
+export function resolveClient(connection: MetricsConnection): {
+  client: MetricsClient;
+  owned: boolean;
+} {
+  if (isClient(connection)) {
+    return { client: connection, owned: false };
+  }
+  // Default to RESP2 (ioredis v6 enables RESP3 by default). Keeps exact v5 wire parity and
+  // support for Redis < 6.0, whose `HELLO 3` handshake fails. Spread order lets an explicit
+  // caller `protocol` win. Only on the options path -- an injected client's protocol is its own.
+  return { client: new Redis({ protocol: 2, ...connection }), owned: true };
 }

--- a/packages/metrics/src/keys.ts
+++ b/packages/metrics/src/keys.ts
@@ -1,4 +1,4 @@
-export const NAMESPACE = 'bull-board:metrics';
+export const DEFAULT_NAMESPACE = 'bull-board:metrics';
 export const GLOBAL_QUEUE = '__global__';
 /** Marks the hourly rollup key so it can't be mistaken for a minute-level day hash. */
 export const HOUR_TIER = 'hour';
@@ -25,18 +25,6 @@ export function minuteToHour(minute: number): number {
   return Math.floor(minute / MINUTES_PER_HOUR);
 }
 
-export function dayHashKey(queue: string, metric: string, day: string): string {
-  return `${NAMESPACE}:${queue}:${metric}:${day}`;
-}
-
-export function hourHashKey(queue: string, metric: string, day: string): string {
-  return `${NAMESPACE}:${queue}:${metric}:${HOUR_TIER}:${day}`;
-}
-
-export function totalsHashKey(queue: string, metric: string): string {
-  return `${NAMESPACE}:${queue}:${metric}:totals`;
-}
-
 export function shiftDay(day: string, offsetDays: number): string {
   return msToDay(dayToStartMs(day) + offsetDays * MS_PER_DAY);
 }
@@ -59,4 +47,45 @@ export function dayRange(fromMs: number, toMs: number): string[] {
     cursor += MS_PER_DAY;
   }
   return days;
+}
+
+function hasHashTag(value: string): boolean {
+  const open = value.indexOf('{');
+  return open !== -1 && value.indexOf('}', open + 1) > open + 1;
+}
+
+function trimTrailingColons(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === ':') {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+// The braces are a Redis hash tag: one EVAL writes queue and `__global__` keys together.
+export function resolveNamespace(prefix: string | undefined, clustered: boolean): string {
+  const base = trimTrailingColons(prefix ?? DEFAULT_NAMESPACE) || DEFAULT_NAMESPACE;
+  return clustered && !hasHashTag(base) ? `{${base}}` : base;
+}
+
+export interface MetricsKeys {
+  namespace: string;
+  day(queue: string, metric: string, day: string): string;
+  hour(queue: string, metric: string, day: string): string;
+  totals(queue: string, metric: string): string;
+  lease(queue: string): string;
+  watermark(queue: string): string;
+  scanPattern: string;
+}
+
+export function metricsKeys(namespace: string): MetricsKeys {
+  return {
+    namespace,
+    day: (queue, metric, day) => `${namespace}:${queue}:${metric}:${day}`,
+    hour: (queue, metric, day) => `${namespace}:${queue}:${metric}:${HOUR_TIER}:${day}`,
+    totals: (queue, metric) => `${namespace}:${queue}:${metric}:totals`,
+    lease: (queue) => `${namespace}:${queue}:latency:lease`,
+    watermark: (queue) => `${namespace}:${queue}:latency:watermark`,
+    scanPattern: `${namespace}:*`,
+  };
 }

--- a/packages/metrics/tests/HistoryAdmin.spec.ts
+++ b/packages/metrics/tests/HistoryAdmin.spec.ts
@@ -1,8 +1,11 @@
 import { Redis } from 'ioredis';
 import { MetricsHistoryAdmin, parseHistoryKey } from '../src/HistoryAdmin';
 import { HistoryStore } from '../src/HistoryStore';
-import { GLOBAL_QUEUE, NAMESPACE, dayHashKey, minuteToDay, totalsHashKey } from '../src/keys';
+import { DEFAULT_NAMESPACE, GLOBAL_QUEUE, metricsKeys, minuteToDay } from '../src/keys';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
+const parse = (key: string) => parseHistoryKey(key, DEFAULT_NAMESPACE);
 
 const DAY_ONE = Date.UTC(2021, 0, 1, 0, 5) / 60000;
 const minuteOn = (offsetDays: number, offsetMinutes = 0) =>
@@ -15,7 +18,7 @@ describe('MetricsHistoryAdmin', () => {
   let admin: MetricsHistoryAdmin;
 
   const clearNamespace = async () => {
-    const keys = await redis.keys(`${NAMESPACE}:*`);
+    const keys = await redis.keys(`${DEFAULT_NAMESPACE}:*`);
     if (keys.length > 0) {
       await redis.del(...keys);
     }
@@ -23,7 +26,11 @@ describe('MetricsHistoryAdmin', () => {
 
   beforeEach(async () => {
     redis = new Redis(connection);
-    store = new HistoryStore({ redis, retention: { minutes: 90, hours: 90, days: 90 } });
+    store = new HistoryStore({
+      redis,
+      keys: testKeys,
+      retention: { minutes: 90, hours: 90, days: 90 },
+    });
     admin = new MetricsHistoryAdmin({ connection: redis });
     await clearNamespace();
   });
@@ -35,19 +42,19 @@ describe('MetricsHistoryAdmin', () => {
 
   describe('parseHistoryKey', () => {
     it('parses each of the three tiers', () => {
-      expect(parseHistoryKey(`${NAMESPACE}:Q:completed:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:completed:2021-01-01`)).toEqual({
         queue: 'Q',
         metric: 'completed',
         tier: 'minute',
         day: '2021-01-01',
       });
-      expect(parseHistoryKey(`${NAMESPACE}:Q:completed:hour:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:completed:hour:2021-01-01`)).toEqual({
         queue: 'Q',
         metric: 'completed',
         tier: 'hour',
         day: '2021-01-01',
       });
-      expect(parseHistoryKey(`${NAMESPACE}:Q:completed:totals`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:completed:totals`)).toEqual({
         queue: 'Q',
         metric: 'completed',
         tier: 'day',
@@ -56,13 +63,13 @@ describe('MetricsHistoryAdmin', () => {
     });
 
     it('parses from the right so queue names may contain colons', () => {
-      expect(parseHistoryKey(`${NAMESPACE}:team:eu:mailer:failed:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:team:eu:mailer:failed:2021-01-01`)).toEqual({
         queue: 'team:eu:mailer',
         metric: 'failed',
         tier: 'minute',
         day: '2021-01-01',
       });
-      expect(parseHistoryKey(`${NAMESPACE}:team:eu:mailer:failed:hour:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:team:eu:mailer:failed:hour:2021-01-01`)).toEqual({
         queue: 'team:eu:mailer',
         metric: 'failed',
         tier: 'hour',
@@ -72,26 +79,26 @@ describe('MetricsHistoryAdmin', () => {
 
     it('is not fooled by a queue named after a tier marker or a metric', () => {
       // Queue literally called `hour`: the tier marker sits next to the metric, not here.
-      expect(parseHistoryKey(`${NAMESPACE}:hour:completed:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:hour:completed:2021-01-01`)).toEqual({
         queue: 'hour',
         metric: 'completed',
         tier: 'minute',
         day: '2021-01-01',
       });
-      expect(parseHistoryKey(`${NAMESPACE}:hour:completed:hour:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:hour:completed:hour:2021-01-01`)).toEqual({
         queue: 'hour',
         metric: 'completed',
         tier: 'hour',
         day: '2021-01-01',
       });
       // Queue name ending in something that looks like a metric segment.
-      expect(parseHistoryKey(`${NAMESPACE}:jobs:completed:failed:2021-01-01`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:jobs:completed:failed:2021-01-01`)).toEqual({
         queue: 'jobs:completed',
         metric: 'failed',
         tier: 'minute',
         day: '2021-01-01',
       });
-      expect(parseHistoryKey(`${NAMESPACE}:jobs:completed:totals`)).toEqual({
+      expect(parse(`${DEFAULT_NAMESPACE}:jobs:completed:totals`)).toEqual({
         queue: 'jobs',
         metric: 'completed',
         tier: 'day',
@@ -100,14 +107,14 @@ describe('MetricsHistoryAdmin', () => {
     });
 
     it('rejects keys outside the namespace or with an unexpected shape', () => {
-      expect(parseHistoryKey('bull:mailer:id')).toBeNull();
-      expect(parseHistoryKey(`${NAMESPACE}:Q:completed`)).toBeNull();
-      expect(parseHistoryKey(`${NAMESPACE}:Q:completed:not-a-day`)).toBeNull();
-      expect(parseHistoryKey(`${NAMESPACE}:Q:completed:2021-1-1`)).toBeNull();
-      expect(parseHistoryKey(`${NAMESPACE}foo:Q:completed:totals`)).toBeNull();
+      expect(parse('bull:mailer:id')).toBeNull();
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:completed`)).toBeNull();
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:completed:not-a-day`)).toBeNull();
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:completed:2021-1-1`)).toBeNull();
+      expect(parse(`${DEFAULT_NAMESPACE}foo:Q:completed:totals`)).toBeNull();
       // Unknown metric segment: not ours, so never a purge target.
-      expect(parseHistoryKey(`${NAMESPACE}:Q:latency:2021-01-01`)).toBeNull();
-      expect(parseHistoryKey(`${NAMESPACE}:Q:latency:totals`)).toBeNull();
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:latency:2021-01-01`)).toBeNull();
+      expect(parse(`${DEFAULT_NAMESPACE}:Q:latency:totals`)).toBeNull();
     });
   });
 
@@ -172,13 +179,13 @@ describe('MetricsHistoryAdmin', () => {
     });
 
     it('ignores foreign keys that happen to sit in the namespace', async () => {
-      await redis.set(`${NAMESPACE}:stray`, '1');
+      await redis.set(`${DEFAULT_NAMESPACE}:stray`, '1');
       await store.upsertMinute('Q', 'completed', minuteOn(0), 3);
 
       const stats = await admin.stats();
 
       expect(stats.queues.map((q) => q.queue).sort()).toEqual(['Q', GLOBAL_QUEUE]);
-      expect(await redis.get(`${NAMESPACE}:stray`)).toBe('1');
+      expect(await redis.get(`${DEFAULT_NAMESPACE}:stray`)).toBe('1');
     });
 
     it('sorts queues by footprint, largest first', async () => {
@@ -259,7 +266,7 @@ describe('MetricsHistoryAdmin', () => {
       const result = await admin.purge();
 
       expect(result.keysDeleted).toBeGreaterThan(0);
-      expect(await redis.keys(`${NAMESPACE}:*`)).toEqual([]);
+      expect(await redis.keys(`${DEFAULT_NAMESPACE}:*`)).toEqual([]);
       expect(await redis.get('bull:mailer:1')).toBe('job-payload');
       expect(await redis.get('unrelated')).toBe('keep-me');
 
@@ -277,7 +284,7 @@ describe('MetricsHistoryAdmin', () => {
         keysDeleted: 0,
         fieldsDeleted: 0,
       });
-      expect(await redis.hget(totalsHashKey('Q', 'completed'), dayOf(0))).toBe('3');
+      expect(await redis.hget(testKeys.totals('Q', 'completed'), dayOf(0))).toBe('3');
     });
 
     it('purging one queue leaves the other queues intact', async () => {
@@ -286,9 +293,9 @@ describe('MetricsHistoryAdmin', () => {
 
       await admin.purge({ queue: 'Q' });
 
-      expect(await redis.exists(dayHashKey('Q', 'completed', dayOf(0)))).toBe(0);
-      expect(await redis.exists(totalsHashKey('Q', 'completed'))).toBe(0);
-      expect(await redis.hget(totalsHashKey('Q2', 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.exists(testKeys.day('Q', 'completed', dayOf(0)))).toBe(0);
+      expect(await redis.exists(testKeys.totals('Q', 'completed'))).toBe(0);
+      expect(await redis.hget(testKeys.totals('Q2', 'completed'), dayOf(0))).toBe('5');
     });
 
     it('subtracts the purged queue from the global rollup', async () => {
@@ -298,9 +305,9 @@ describe('MetricsHistoryAdmin', () => {
       await admin.purge({ queue: 'Q' });
 
       expect(
-        await redis.hget(dayHashKey(GLOBAL_QUEUE, 'completed', dayOf(0)), String(minuteOn(0)))
+        await redis.hget(testKeys.day(GLOBAL_QUEUE, 'completed', dayOf(0)), String(minuteOn(0)))
       ).toBe('5');
-      expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
     });
 
     it('purging the last queue drains the global rollup instead of leaving zeros', async () => {
@@ -308,19 +315,19 @@ describe('MetricsHistoryAdmin', () => {
 
       await admin.purge({ queue: 'Q' });
 
-      expect(await redis.exists(dayHashKey(GLOBAL_QUEUE, 'completed', dayOf(0)))).toBe(0);
-      expect(await redis.hexists(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe(0);
+      expect(await redis.exists(testKeys.day(GLOBAL_QUEUE, 'completed', dayOf(0)))).toBe(0);
+      expect(await redis.hexists(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe(0);
     });
 
     it('corrects the global totals even when the queue day hash is already gone', async () => {
       await store.upsertMinute('Q', 'completed', minuteOn(0), 3);
       await store.upsertMinute('Q2', 'completed', minuteOn(0), 5);
       // Simulate the day hash having expired while the daily rollup is still in retention.
-      await redis.del(dayHashKey('Q', 'completed', dayOf(0)));
+      await redis.del(testKeys.day('Q', 'completed', dayOf(0)));
 
       await admin.purge({ queue: 'Q' });
 
-      expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
     });
 
     it('drops only days before the cutoff', async () => {
@@ -330,10 +337,10 @@ describe('MetricsHistoryAdmin', () => {
 
       const result = await admin.purge({ before: dayOf(2) });
 
-      expect(await redis.exists(dayHashKey('Q', 'completed', dayOf(0)))).toBe(0);
-      expect(await redis.exists(dayHashKey('Q', 'completed', dayOf(1)))).toBe(0);
-      expect(await redis.exists(dayHashKey('Q', 'completed', dayOf(2)))).toBe(1);
-      expect(await redis.hkeys(totalsHashKey('Q', 'completed'))).toEqual([dayOf(2)]);
+      expect(await redis.exists(testKeys.day('Q', 'completed', dayOf(0)))).toBe(0);
+      expect(await redis.exists(testKeys.day('Q', 'completed', dayOf(1)))).toBe(0);
+      expect(await redis.exists(testKeys.day('Q', 'completed', dayOf(2)))).toBe(1);
+      expect(await redis.hkeys(testKeys.totals('Q', 'completed'))).toEqual([dayOf(2)]);
       expect(result.keysDeleted).toBeGreaterThan(0);
       expect(result.fieldsDeleted).toBeGreaterThan(0);
     });
@@ -344,14 +351,14 @@ describe('MetricsHistoryAdmin', () => {
 
       await admin.purge({ before: new Date(minuteOn(5) * 60000) });
 
-      expect(await redis.hkeys(totalsHashKey('Q', 'completed'))).toEqual([dayOf(5)]);
+      expect(await redis.hkeys(testKeys.totals('Q', 'completed'))).toEqual([dayOf(5)]);
     });
 
     it('rejects a malformed day cutoff instead of purging the wrong range', async () => {
       await store.upsertMinute('Q', 'completed', minuteOn(0), 3);
 
       await expect(admin.purge({ before: '01/01/2021' })).rejects.toThrow(/YYYY-MM-DD/);
-      expect(await redis.exists(dayHashKey('Q', 'completed', dayOf(0)))).toBe(1);
+      expect(await redis.exists(testKeys.day('Q', 'completed', dayOf(0)))).toBe(1);
     });
 
     it('combines queue and cutoff, correcting the global rollup for the dropped days only', async () => {
@@ -361,10 +368,10 @@ describe('MetricsHistoryAdmin', () => {
 
       await admin.purge({ queue: 'Q', before: dayOf(1) });
 
-      expect(await redis.hkeys(totalsHashKey('Q', 'completed'))).toEqual([dayOf(1)]);
+      expect(await redis.hkeys(testKeys.totals('Q', 'completed'))).toEqual([dayOf(1)]);
       // Day 0 loses Q's 3 and keeps Q2's 5; day 1 is untouched.
-      expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
-      expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(1))).toBe('4');
+      expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(1))).toBe('4');
     });
 
     it('handles queue names containing colons', async () => {
@@ -373,9 +380,9 @@ describe('MetricsHistoryAdmin', () => {
 
       await admin.purge({ queue: 'team:eu:mailer' });
 
-      expect(await redis.exists(totalsHashKey('team:eu:mailer', 'completed'))).toBe(0);
-      expect(await redis.hget(totalsHashKey('other', 'completed'), dayOf(0))).toBe('5');
-      expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.exists(testKeys.totals('team:eu:mailer', 'completed'))).toBe(0);
+      expect(await redis.hget(testKeys.totals('other', 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('5');
     });
 
     it('treats a glob-looking queue name literally', async () => {
@@ -384,8 +391,8 @@ describe('MetricsHistoryAdmin', () => {
 
       await admin.purge({ queue: 'Q*' });
 
-      expect(await redis.exists(totalsHashKey('Q*', 'completed'))).toBe(0);
-      expect(await redis.hget(totalsHashKey('Q1', 'completed'), dayOf(0))).toBe('5');
+      expect(await redis.exists(testKeys.totals('Q*', 'completed'))).toBe(0);
+      expect(await redis.hget(testKeys.totals('Q1', 'completed'), dayOf(0))).toBe('5');
     });
 
     it('is idempotent: purging twice changes nothing the second time', async () => {
@@ -404,8 +411,8 @@ describe('MetricsHistoryAdmin', () => {
 
       await store.upsertMinute('Q', 'completed', minuteOn(0), 3);
 
-      expect(await redis.hget(totalsHashKey('Q', 'completed'), dayOf(0))).toBe('3');
-      expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('3');
+      expect(await redis.hget(testKeys.totals('Q', 'completed'), dayOf(0))).toBe('3');
+      expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), dayOf(0))).toBe('3');
     });
 
     it('purges a backlog spanning more than one HDEL batch', async () => {
@@ -413,12 +420,12 @@ describe('MetricsHistoryAdmin', () => {
       for (let i = 0; i < 400; i++) {
         backlog[dayOf(-500 + i)] = '1';
       }
-      await redis.hset(totalsHashKey('Q', 'completed'), backlog);
+      await redis.hset(testKeys.totals('Q', 'completed'), backlog);
 
       const result = await admin.purge({ before: dayOf(0) });
 
       expect(result.fieldsDeleted).toBe(400);
-      expect(await redis.exists(totalsHashKey('Q', 'completed'))).toBe(0);
+      expect(await redis.exists(testKeys.totals('Q', 'completed'))).toBe(0);
     });
   });
 

--- a/packages/metrics/tests/HistoryStore.spec.ts
+++ b/packages/metrics/tests/HistoryStore.spec.ts
@@ -1,15 +1,15 @@
 import { Redis } from 'ioredis';
 import { HistoryStore } from '../src/HistoryStore';
 import {
+  DEFAULT_NAMESPACE,
   GLOBAL_QUEUE,
-  NAMESPACE,
-  dayHashKey,
-  hourHashKey,
+  metricsKeys,
   minuteToDay,
   minuteToHour,
-  totalsHashKey,
 } from '../src/keys';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 describe('HistoryStore', () => {
   let redis: Redis;
@@ -19,17 +19,21 @@ describe('HistoryStore', () => {
 
   beforeEach(async () => {
     redis = new Redis(connection);
-    store = new HistoryStore({ redis, retention: { minutes: 90, hours: 90, days: 90 } });
+    store = new HistoryStore({
+      redis,
+      keys: testKeys,
+      retention: { minutes: 90, hours: 90, days: 90 },
+    });
     await redis.del(
-      dayHashKey('Q', 'completed', day),
-      totalsHashKey('Q', 'completed'),
-      dayHashKey(GLOBAL_QUEUE, 'completed', day),
-      totalsHashKey(GLOBAL_QUEUE, 'completed'),
-      dayHashKey('Q2', 'completed', day),
-      totalsHashKey('Q2', 'completed'),
-      hourHashKey('Q', 'completed', day),
-      hourHashKey(GLOBAL_QUEUE, 'completed', day),
-      hourHashKey('Q2', 'completed', day)
+      testKeys.day('Q', 'completed', day),
+      testKeys.totals('Q', 'completed'),
+      testKeys.day(GLOBAL_QUEUE, 'completed', day),
+      testKeys.totals(GLOBAL_QUEUE, 'completed'),
+      testKeys.day('Q2', 'completed', day),
+      testKeys.totals('Q2', 'completed'),
+      testKeys.hour('Q', 'completed', day),
+      testKeys.hour(GLOBAL_QUEUE, 'completed', day),
+      testKeys.hour('Q2', 'completed', day)
     );
   });
 
@@ -40,10 +44,12 @@ describe('HistoryStore', () => {
   it('writes the minute, queue total, global minute, and global total', async () => {
     await store.upsertMinute('Q', 'completed', minute, 4);
 
-    expect(await redis.hget(dayHashKey('Q', 'completed', day), String(minute))).toBe('4');
-    expect(await redis.hget(totalsHashKey('Q', 'completed'), day)).toBe('4');
-    expect(await redis.hget(dayHashKey(GLOBAL_QUEUE, 'completed', day), String(minute))).toBe('4');
-    expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)).toBe('4');
+    expect(await redis.hget(testKeys.day('Q', 'completed', day), String(minute))).toBe('4');
+    expect(await redis.hget(testKeys.totals('Q', 'completed'), day)).toBe('4');
+    expect(await redis.hget(testKeys.day(GLOBAL_QUEUE, 'completed', day), String(minute))).toBe(
+      '4'
+    );
+    expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)).toBe('4');
   });
 
   it('is idempotent: re-writing the same minute does not double count', async () => {
@@ -51,34 +57,36 @@ describe('HistoryStore', () => {
     await store.upsertMinute('Q', 'completed', minute, 4);
     await store.upsertMinute('Q', 'completed', minute, 4);
 
-    expect(await redis.hget(totalsHashKey('Q', 'completed'), day)).toBe('4');
-    expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)).toBe('4');
+    expect(await redis.hget(testKeys.totals('Q', 'completed'), day)).toBe('4');
+    expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)).toBe('4');
   });
 
   it('applies a delta when a minute value is corrected upward', async () => {
     await store.upsertMinute('Q', 'completed', minute, 4);
     await store.upsertMinute('Q', 'completed', minute, 7);
 
-    expect(await redis.hget(dayHashKey('Q', 'completed', day), String(minute))).toBe('7');
-    expect(await redis.hget(totalsHashKey('Q', 'completed'), day)).toBe('7');
+    expect(await redis.hget(testKeys.day('Q', 'completed', day), String(minute))).toBe('7');
+    expect(await redis.hget(testKeys.totals('Q', 'completed'), day)).toBe('7');
   });
 
   it('accumulates the global rollup across queues', async () => {
     await store.upsertMinute('Q', 'completed', minute, 4);
     await store.upsertMinute('Q2', 'completed', minute, 6);
 
-    expect(await redis.hget(dayHashKey(GLOBAL_QUEUE, 'completed', day), String(minute))).toBe('10');
-    expect(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)).toBe('10');
+    expect(await redis.hget(testKeys.day(GLOBAL_QUEUE, 'completed', day), String(minute))).toBe(
+      '10'
+    );
+    expect(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)).toBe('10');
   });
 
   it('sets a TTL on the day hash', async () => {
     await store.upsertMinute('Q', 'completed', minute, 4);
 
     const keys = [
-      dayHashKey('Q', 'completed', day),
-      totalsHashKey('Q', 'completed'),
-      dayHashKey(GLOBAL_QUEUE, 'completed', day),
-      totalsHashKey(GLOBAL_QUEUE, 'completed'),
+      testKeys.day('Q', 'completed', day),
+      testKeys.totals('Q', 'completed'),
+      testKeys.day(GLOBAL_QUEUE, 'completed', day),
+      testKeys.totals(GLOBAL_QUEUE, 'completed'),
     ];
 
     for (const key of keys) {
@@ -113,8 +121,8 @@ describe('HistoryStore', () => {
     await store.upsertMinute('Q', 'completed', minute, 7);
     await store.upsertMinute('Q', 'completed', minute, 4);
 
-    expect(await redis.hget(dayHashKey('Q', 'completed', day), String(minute))).toBe('4');
-    expect(await redis.hget(totalsHashKey('Q', 'completed'), day)).toBe('4');
+    expect(await redis.hget(testKeys.day('Q', 'completed', day), String(minute))).toBe('4');
+    expect(await redis.hget(testKeys.totals('Q', 'completed'), day)).toBe('4');
   });
 
   it('readDayMinutes on a never-written day returns {} without throwing', async () => {
@@ -129,8 +137,8 @@ describe('HistoryStore', () => {
       await store.upsertMinute('Q2', 'completed', hourStart + 10, 1);
 
       const hour = String(minuteToHour(minute));
-      expect(await redis.hget(hourHashKey('Q', 'completed', day), hour)).toBe('10');
-      expect(await redis.hget(hourHashKey(GLOBAL_QUEUE, 'completed', day), hour)).toBe('11');
+      expect(await redis.hget(testKeys.hour('Q', 'completed', day), hour)).toBe('10');
+      expect(await redis.hget(testKeys.hour(GLOBAL_QUEUE, 'completed', day), hour)).toBe('11');
     });
 
     it('separates distinct hours of the same day', async () => {
@@ -138,7 +146,7 @@ describe('HistoryStore', () => {
       await store.upsertMinute('Q', 'completed', hourStart, 4);
       await store.upsertMinute('Q', 'completed', hourStart + 60, 7);
 
-      expect(await redis.hgetall(hourHashKey('Q', 'completed', day))).toEqual({
+      expect(await redis.hgetall(testKeys.hour('Q', 'completed', day))).toEqual({
         [String(minuteToHour(hourStart))]: '4',
         [String(minuteToHour(hourStart + 60))]: '7',
       });
@@ -151,8 +159,8 @@ describe('HistoryStore', () => {
       await store.upsertMinute('Q', 'completed', minute, 2);
 
       const hour = String(minuteToHour(minute));
-      expect(await redis.hget(hourHashKey('Q', 'completed', day), hour)).toBe('2');
-      expect(await redis.hget(totalsHashKey('Q', 'completed'), day)).toBe('2');
+      expect(await redis.hget(testKeys.hour('Q', 'completed', day), hour)).toBe('2');
+      expect(await redis.hget(testKeys.totals('Q', 'completed'), day)).toBe('2');
     });
 
     it('readDayHours prefers the rollup and falls back to folding minutes', async () => {
@@ -162,7 +170,7 @@ describe('HistoryStore', () => {
       expect(await store.readDayHours('Q', 'completed', day)).toEqual({ [hour]: 4 });
 
       // Simulates a day recorded before the hourly tier existed: only minutes survive.
-      await redis.del(hourHashKey('Q', 'completed', day));
+      await redis.del(testKeys.hour('Q', 'completed', day));
 
       expect(await store.readDayHours('Q', 'completed', day)).toEqual({ [hour]: 4 });
     });
@@ -176,34 +184,35 @@ describe('HistoryStore', () => {
     it('gives each tier its own TTL', async () => {
       const tiered = new HistoryStore({
         redis,
+        keys: testKeys,
         retention: { minutes: 2, hours: 30, days: 90 },
       });
       await tiered.upsertMinute('Q', 'completed', minute, 4);
 
       const ttlOf = (key: string) => redis.ttl(key);
 
-      expect(await ttlOf(dayHashKey('Q', 'completed', day))).toBeLessThanOrEqual(2 * 86400);
-      expect(await ttlOf(hourHashKey('Q', 'completed', day))).toBeGreaterThan(2 * 86400);
-      expect(await ttlOf(hourHashKey('Q', 'completed', day))).toBeLessThanOrEqual(30 * 86400);
-      expect(await ttlOf(totalsHashKey('Q', 'completed'))).toBeGreaterThan(30 * 86400);
-      expect(await ttlOf(totalsHashKey('Q', 'completed'))).toBeLessThanOrEqual(90 * 86400);
+      expect(await ttlOf(testKeys.day('Q', 'completed', day))).toBeLessThanOrEqual(2 * 86400);
+      expect(await ttlOf(testKeys.hour('Q', 'completed', day))).toBeGreaterThan(2 * 86400);
+      expect(await ttlOf(testKeys.hour('Q', 'completed', day))).toBeLessThanOrEqual(30 * 86400);
+      expect(await ttlOf(testKeys.totals('Q', 'completed'))).toBeGreaterThan(30 * 86400);
+      expect(await ttlOf(testKeys.totals('Q', 'completed'))).toBeLessThanOrEqual(90 * 86400);
 
       // The global mirror is retained on the same schedule as the per-queue keys.
-      expect(await ttlOf(dayHashKey(GLOBAL_QUEUE, 'completed', day))).toBeLessThanOrEqual(
+      expect(await ttlOf(testKeys.day(GLOBAL_QUEUE, 'completed', day))).toBeLessThanOrEqual(
         2 * 86400
       );
-      expect(await ttlOf(hourHashKey(GLOBAL_QUEUE, 'completed', day))).toBeGreaterThan(2 * 86400);
+      expect(await ttlOf(testKeys.hour(GLOBAL_QUEUE, 'completed', day))).toBeGreaterThan(2 * 86400);
     });
   });
 
   describe('totals retention', () => {
     const shortStore = () =>
-      new HistoryStore({ redis, retention: { minutes: 2, hours: 2, days: 2 } });
+      new HistoryStore({ redis, keys: testKeys, retention: { minutes: 2, hours: 2, days: 2 } });
     const minuteOn = (offsetDays: number) => minute + offsetDays * 1440;
 
     afterEach(async () => {
-      const keys = await redis.keys(`${NAMESPACE}:Q*:completed:*`);
-      const globals = await redis.keys(`${NAMESPACE}:${GLOBAL_QUEUE}:completed:*`);
+      const keys = await redis.keys(`${DEFAULT_NAMESPACE}:Q*:completed:*`);
+      const globals = await redis.keys(`${DEFAULT_NAMESPACE}:${GLOBAL_QUEUE}:completed:*`);
       if (keys.length + globals.length > 0) {
         await redis.del(...keys, ...globals);
       }
@@ -215,7 +224,7 @@ describe('HistoryStore', () => {
         await store.upsertMinute('Q', 'completed', minuteOn(offset), 1);
       }
 
-      const days = await redis.hkeys(totalsHashKey('Q', 'completed'));
+      const days = await redis.hkeys(testKeys.totals('Q', 'completed'));
 
       expect(days.sort()).toEqual([1, 2, 3].map((o) => minuteToDay(minuteOn(o))));
       expect(days).not.toContain(day);
@@ -227,7 +236,7 @@ describe('HistoryStore', () => {
       await store.upsertMinute('Q2', 'completed', minuteOn(0), 1);
       await store.upsertMinute('Q', 'completed', minuteOn(3), 1);
 
-      const days = await redis.hkeys(totalsHashKey(GLOBAL_QUEUE, 'completed'));
+      const days = await redis.hkeys(testKeys.totals(GLOBAL_QUEUE, 'completed'));
 
       expect(days).toEqual([minuteToDay(minuteOn(3))]);
     });
@@ -237,14 +246,14 @@ describe('HistoryStore', () => {
       await store.upsertMinute('Q', 'completed', minuteOn(0), 1);
       // Backdate a day that is already outside the window. A same-day write must not
       // create a new day field, so the stale entry survives until the next day rolls in.
-      await redis.hset(totalsHashKey('Q', 'completed'), '1999-01-01', 5);
+      await redis.hset(testKeys.totals('Q', 'completed'), '1999-01-01', 5);
       await store.upsertMinute('Q', 'completed', minuteOn(0) + 1, 1);
 
-      expect(await redis.hexists(totalsHashKey('Q', 'completed'), '1999-01-01')).toBe(1);
+      expect(await redis.hexists(testKeys.totals('Q', 'completed'), '1999-01-01')).toBe(1);
 
       await store.upsertMinute('Q', 'completed', minuteOn(1), 1);
 
-      expect(await redis.hexists(totalsHashKey('Q', 'completed'), '1999-01-01')).toBe(0);
+      expect(await redis.hexists(testKeys.totals('Q', 'completed'), '1999-01-01')).toBe(0);
     });
 
     it('trims a backlog larger than one HDEL batch', async () => {
@@ -253,12 +262,12 @@ describe('HistoryStore', () => {
       for (let i = 0; i < 400; i++) {
         backlog[minuteToDay(minuteOn(-400 + i))] = '1';
       }
-      await redis.hset(totalsHashKey('Q', 'completed'), backlog);
+      await redis.hset(testKeys.totals('Q', 'completed'), backlog);
 
       await store.upsertMinute('Q', 'completed', minuteOn(0), 1);
 
       // 400 stale days collapse to the retention window: the cutoff day and everything after.
-      expect((await redis.hkeys(totalsHashKey('Q', 'completed'))).sort()).toEqual([
+      expect((await redis.hkeys(testKeys.totals('Q', 'completed'))).sort()).toEqual([
         minuteToDay(minuteOn(-2)),
         minuteToDay(minuteOn(-1)),
         day,

--- a/packages/metrics/tests/LatencySampler.spec.ts
+++ b/packages/metrics/tests/LatencySampler.spec.ts
@@ -3,10 +3,12 @@ import { Queue, Worker } from 'bullmq';
 import { Redis } from 'ioredis';
 import * as histogram from '../src/histogram';
 import { vectorTotal } from '../src/histogram';
-import { NAMESPACE, minuteToDay } from '../src/keys';
+import { DEFAULT_NAMESPACE, metricsKeys, minuteToDay } from '../src/keys';
 import { LatencySampler } from '../src/LatencySampler';
 import { LatencyStore } from '../src/LatencyStore';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 const QUEUE = 'LatencySamplerQueue';
 
@@ -27,17 +29,27 @@ describe('LatencySampler', () => {
   });
 
   beforeEach(async () => {
-    const mine = await redis.keys(`${NAMESPACE}:${QUEUE}*`);
+    const mine = await redis.keys(`${DEFAULT_NAMESPACE}:${QUEUE}*`);
     if (mine.length > 0) {
       await redis.del(...mine);
     }
     queue = new Queue(QUEUE, { connection });
     await queue.obliterate({ force: true }).catch(() => undefined);
     adapter = new BullMQAdapter(queue);
-    store = new LatencyStore({ redis, retention: { minutes: 7, hours: 90, days: 90 } });
+    store = new LatencyStore({
+      redis,
+      keys: testKeys,
+      retention: { minutes: 7, hours: 90, days: 90 },
+    });
     // Margin 0 so a job that just finished is in range. The margin's own behaviour gets
     // its own test below rather than slowing every other case by five seconds.
-    sampler = new LatencySampler({ redis, store, tickMs: 60_000, safetyMarginMs: 0 });
+    sampler = new LatencySampler({
+      redis,
+      keys: testKeys,
+      store,
+      tickMs: 60_000,
+      safetyMarginMs: 0,
+    });
   });
 
   afterEach(async () => {
@@ -182,6 +194,7 @@ describe('LatencySampler', () => {
     // very edge of now. With a wide margin nothing recent is in range yet.
     const guarded = new LatencySampler({
       redis,
+      keys: testKeys,
       store,
       tickMs: 60_000,
       safetyMarginMs: 30_000,
@@ -201,7 +214,13 @@ describe('LatencySampler', () => {
   });
 
   it('still samples on a cold start when the tick is shorter than the safety margin', async () => {
-    const tight = new LatencySampler({ redis, store, tickMs: 1000, safetyMarginMs: 1000 });
+    const tight = new LatencySampler({
+      redis,
+      keys: testKeys,
+      store,
+      tickMs: 1000,
+      safetyMarginMs: 1000,
+    });
     await processJobs(3, 20);
     await new Promise((resolve) => setTimeout(resolve, 1100));
     await tight.sample(adapter);
@@ -213,7 +232,13 @@ describe('LatencySampler', () => {
 
   it('lets only one of two concurrent samplers write', async () => {
     await processJobs(4, 20);
-    const other = new LatencySampler({ redis, store, tickMs: 60_000, safetyMarginMs: 0 });
+    const other = new LatencySampler({
+      redis,
+      keys: testKeys,
+      store,
+      tickMs: 60_000,
+      safetyMarginMs: 0,
+    });
     await Promise.all([sampler.sample(adapter), other.sample(adapter)]);
 
     const day = minuteToDay(Date.now() / 60000);
@@ -277,6 +302,7 @@ describe('LatencySampler', () => {
     const seen: { error: unknown; queue: string }[] = [];
     const failing = new LatencySampler({
       redis: { set: () => Promise.reject(boom) } as never,
+      keys: testKeys,
       store,
       tickMs: 60_000,
       onError: (error, queueName) => seen.push({ error, queue: queueName }),
@@ -290,6 +316,7 @@ describe('LatencySampler', () => {
   it('stays contained when onError itself throws', async () => {
     const failing = new LatencySampler({
       redis: { set: () => Promise.reject(new Error('redis is gone')) } as never,
+      keys: testKeys,
       store,
       tickMs: 60_000,
       onError: () => {

--- a/packages/metrics/tests/LatencyStore.spec.ts
+++ b/packages/metrics/tests/LatencyStore.spec.ts
@@ -1,8 +1,16 @@
 import { Redis } from 'ioredis';
 import { emptyVector } from '../src/histogram';
-import { GLOBAL_QUEUE, NAMESPACE, minuteToDay, minuteToHour, totalsHashKey } from '../src/keys';
+import {
+  DEFAULT_NAMESPACE,
+  GLOBAL_QUEUE,
+  metricsKeys,
+  minuteToDay,
+  minuteToHour,
+} from '../src/keys';
 import { LatencyStore } from '../src/LatencyStore';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 const QUEUE = 'LatencyStoreQueue';
 // Own day, far from the other suites, because the global rollup is shared.
@@ -14,7 +22,11 @@ describe('LatencyStore', () => {
 
   beforeAll(() => {
     redis = new Redis(connection);
-    store = new LatencyStore({ redis, retention: { minutes: 7, hours: 90, days: 90 } });
+    store = new LatencyStore({
+      redis,
+      keys: testKeys,
+      retention: { minutes: 7, hours: 90, days: 90 },
+    });
   });
 
   afterAll(async () => {
@@ -22,8 +34,8 @@ describe('LatencyStore', () => {
   });
 
   beforeEach(async () => {
-    const mine = await redis.keys(`${NAMESPACE}:${QUEUE}*`);
-    const globals = await redis.keys(`${NAMESPACE}:${GLOBAL_QUEUE}:*:2019-08-*`);
+    const mine = await redis.keys(`${DEFAULT_NAMESPACE}:${QUEUE}*`);
+    const globals = await redis.keys(`${DEFAULT_NAMESPACE}:${GLOBAL_QUEUE}:*:2019-08-*`);
     if (mine.length + globals.length > 0) {
       await redis.del(...mine, ...globals);
     }
@@ -32,8 +44,8 @@ describe('LatencyStore', () => {
     // the fields this spec writes, so sibling suites sharing the global rollup are untouched.
     const day = minuteToDay(BASE_MINUTE);
     for (const metric of ['runtime', 'waittime', 'queueage']) {
-      await redis.hdel(totalsHashKey(GLOBAL_QUEUE, metric), day);
-      await redis.hdel(totalsHashKey(QUEUE, metric), day);
+      await redis.hdel(testKeys.totals(GLOBAL_QUEUE, metric), day);
+      await redis.hdel(testKeys.totals(QUEUE, metric), day);
     }
   });
 
@@ -109,8 +121,8 @@ describe('LatencyStore', () => {
     const hour = minuteToHour(BASE_MINUTE);
     const day = minuteToDay(BASE_MINUTE);
     const otherQueue = `${QUEUE}Other`;
-    const otherHourKey = `${NAMESPACE}:${otherQueue}:queueage:hour:${day}`;
-    const otherTotalsKey = totalsHashKey(otherQueue, 'queueage');
+    const otherHourKey = `${DEFAULT_NAMESPACE}:${otherQueue}:queueage:hour:${day}`;
+    const otherTotalsKey = testKeys.totals(otherQueue, 'queueage');
 
     await redis.del(otherHourKey, otherTotalsKey);
 
@@ -139,8 +151,8 @@ describe('LatencyStore', () => {
     vector[0] = 1;
     await store.addSamples(QUEUE, 'runtime', hour, vector);
 
-    const hourTtl = await redis.ttl(`${NAMESPACE}:${QUEUE}:runtime:hour:${day}`);
-    const totalsTtl = await redis.ttl(`${NAMESPACE}:${QUEUE}:runtime:totals`);
+    const hourTtl = await redis.ttl(`${DEFAULT_NAMESPACE}:${QUEUE}:runtime:hour:${day}`);
+    const totalsTtl = await redis.ttl(`${DEFAULT_NAMESPACE}:${QUEUE}:runtime:totals`);
     expect(hourTtl).toBeGreaterThan(0);
     expect(totalsTtl).toBeGreaterThan(0);
   });

--- a/packages/metrics/tests/MetricsRecorder.spec.ts
+++ b/packages/metrics/tests/MetricsRecorder.spec.ts
@@ -3,10 +3,12 @@ import type { MetricsType } from '@bull-board/api/typings/app';
 import { MetricsTime, Queue, Worker } from 'bullmq';
 import { Redis } from 'ioredis';
 import { vectorTotal } from '../src/histogram';
-import { GLOBAL_QUEUE, NAMESPACE, dayHashKey, minuteToDay, totalsHashKey } from '../src/keys';
+import { DEFAULT_NAMESPACE, GLOBAL_QUEUE, metricsKeys, minuteToDay } from '../src/keys';
 import { LatencyStore } from '../src/LatencyStore';
 import { DEFAULT_RETENTION, MetricsRecorder, resolveRetention } from '../src/MetricsRecorder';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 /**
  * `queue.obliterate()` (afterEach) only clears BullMQ's own keyspace, never this
@@ -16,7 +18,7 @@ import { connection } from './connection';
  * assertions -- so wipe a queue's history keys before each test that relies on one.
  */
 async function resetHistory(redis: Redis, name: string) {
-  const keys = await redis.keys(`${NAMESPACE}:${name}:*`);
+  const keys = await redis.keys(`${DEFAULT_NAMESPACE}:${name}:*`);
   if (keys.length > 0) {
     await redis.del(...keys);
   }
@@ -132,10 +134,10 @@ describe('MetricsRecorder', () => {
     }
     let storedSum = 0;
     for (const day of days) {
-      const v = await redis.hget(totalsHashKey(name, 'completed'), day);
+      const v = await redis.hget(testKeys.totals(name, 'completed'), day);
       storedSum += Number(v) || 0;
       // global mirrors the single-queue total here
-      const g = await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day);
+      const g = await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day);
       expect(Number(g) || 0).toBeGreaterThanOrEqual(Number(v) || 0);
     }
 
@@ -143,7 +145,7 @@ describe('MetricsRecorder', () => {
     expect(storedSum).toBeGreaterThan(0);
 
     const anyDay = [...days][0];
-    const dayHash = await redis.hgetall(dayHashKey(name, 'completed', anyDay));
+    const dayHash = await redis.hgetall(testKeys.day(name, 'completed', anyDay));
     expect(Object.keys(dayHash).length).toBeGreaterThan(0);
   });
 
@@ -164,13 +166,13 @@ describe('MetricsRecorder', () => {
     const recorder = new MetricsRecorder({ queues: [adapter], connection: redis });
 
     await recorder.snapshot();
-    const snapshot1 = await redis.hgetall(totalsHashKey(name, 'completed'));
+    const snapshot1 = await redis.hgetall(testKeys.totals(name, 'completed'));
 
     // No-ops: `recorder`'s in-memory `lastMinute` cursor is already warm, so these never
     // reach HistoryStore.upsertMinute at all.
     await recorder.snapshot();
     await recorder.snapshot();
-    const warmSnapshot = await redis.hgetall(totalsHashKey(name, 'completed'));
+    const warmSnapshot = await redis.hgetall(testKeys.totals(name, 'completed'));
     recorder.stop();
     expect(warmSnapshot).toEqual(snapshot1);
 
@@ -180,7 +182,7 @@ describe('MetricsRecorder', () => {
     // just the recorder's cursor gate.
     const freshRecorder = new MetricsRecorder({ queues: [adapter], connection: redis });
     await freshRecorder.snapshot();
-    const snapshot2 = await redis.hgetall(totalsHashKey(name, 'completed'));
+    const snapshot2 = await redis.hgetall(testKeys.totals(name, 'completed'));
     freshRecorder.stop();
 
     expect(snapshot2).toEqual(snapshot1);
@@ -204,13 +206,13 @@ describe('MetricsRecorder', () => {
     const recorder = new MetricsRecorder({ queues: () => registered, connection: redis });
 
     await recorder.snapshot();
-    expect(await redis.hgetall(totalsHashKey(adapter.getName(), 'completed'))).toEqual({});
+    expect(await redis.hgetall(testKeys.totals(adapter.getName(), 'completed'))).toEqual({});
 
     registered.push(adapter);
     await recorder.snapshot();
     recorder.stop();
 
-    const totals = await redis.hgetall(totalsHashKey(adapter.getName(), 'completed'));
+    const totals = await redis.hgetall(testKeys.totals(adapter.getName(), 'completed'));
     const stored = Object.values(totals).reduce((sum, value) => sum + Number(value), 0);
     expect(stored).toBeGreaterThan(0);
   });
@@ -254,7 +256,7 @@ describe('MetricsRecorder', () => {
     }
     let storedSum = 0;
     for (const day of days) {
-      const v = await redis.hget(totalsHashKey(name, 'failed'), day);
+      const v = await redis.hget(testKeys.totals(name, 'failed'), day);
       storedSum += Number(v) || 0;
     }
 
@@ -295,7 +297,7 @@ describe('MetricsRecorder', () => {
     const storedFailures = async () => {
       let sum = 0;
       for (const day of days) {
-        sum += Number(await redis.hget(totalsHashKey(name, 'failed'), day)) || 0;
+        sum += Number(await redis.hget(testKeys.totals(name, 'failed'), day)) || 0;
       }
       return sum;
     };
@@ -356,7 +358,7 @@ describe('MetricsRecorder', () => {
       const globalBefore: Record<string, number> = {};
       for (const day of days) {
         globalBefore[day] =
-          Number(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)) || 0;
+          Number(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)) || 0;
       }
 
       const recorder = new MetricsRecorder({ queues: [adapterA, adapterB], connection: redis });
@@ -367,10 +369,10 @@ describe('MetricsRecorder', () => {
       let sumB = 0;
       let globalDelta = 0;
       for (const day of days) {
-        sumA += Number(await redis.hget(totalsHashKey(nameA, 'completed'), day)) || 0;
-        sumB += Number(await redis.hget(totalsHashKey(nameB, 'completed'), day)) || 0;
+        sumA += Number(await redis.hget(testKeys.totals(nameA, 'completed'), day)) || 0;
+        sumB += Number(await redis.hget(testKeys.totals(nameB, 'completed'), day)) || 0;
         const globalAfter =
-          Number(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)) || 0;
+          Number(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)) || 0;
         globalDelta += globalAfter - globalBefore[day];
       }
 
@@ -404,7 +406,7 @@ describe('MetricsRecorder', () => {
     await expect(recorder.snapshot()).resolves.not.toThrow();
     recorder.stop();
 
-    const totals = await redis.hgetall(totalsHashKey(name, 'completed'));
+    const totals = await redis.hgetall(testKeys.totals(name, 'completed'));
     expect(totals).toEqual({});
   });
 
@@ -446,7 +448,7 @@ describe('MetricsRecorder', () => {
     });
 
     afterEach(async () => {
-      const keys = await scratch.keys(`${NAMESPACE}:*`);
+      const keys = await scratch.keys(`${DEFAULT_NAMESPACE}:*`);
       if (keys.length > 0) {
         await scratch.del(...keys);
       }
@@ -489,7 +491,7 @@ describe('MetricsRecorder', () => {
       const stored: number[] = [];
       for (const day of [minuteToDay(newestMinute), minuteToDay(newestMinute - MINUTES_PER_DAY)]) {
         stored.push(
-          ...Object.keys(await scratch.hgetall(dayHashKey(name, 'completed', day))).map(Number)
+          ...Object.keys(await scratch.hgetall(testKeys.day(name, 'completed', day))).map(Number)
         );
       }
 
@@ -509,8 +511,8 @@ describe('MetricsRecorder', () => {
       const newestMinute = Math.floor(now / 60000) - 1;
       const staleDay = minuteToDay(newestMinute - 3 * MINUTES_PER_DAY);
 
-      await scratch.hset(totalsHashKey(name, 'completed'), staleDay, '500');
-      await scratch.hset(totalsHashKey(GLOBAL_QUEUE, 'completed'), staleDay, '500');
+      await scratch.hset(testKeys.totals(name, 'completed'), staleDay, '500');
+      await scratch.hset(testKeys.totals(GLOBAL_QUEUE, 'completed'), staleDay, '500');
 
       const data = Array.from({ length: 4 * MINUTES_PER_DAY }, () => 1);
       const recorder = new MetricsRecorder({
@@ -521,8 +523,8 @@ describe('MetricsRecorder', () => {
       await recorder.snapshot();
       recorder.stop();
 
-      expect(await scratch.hget(totalsHashKey(name, 'completed'), staleDay)).toBe('500');
-      expect(await scratch.exists(dayHashKey(name, 'completed', staleDay))).toBe(0);
+      expect(await scratch.hget(testKeys.totals(name, 'completed'), staleDay)).toBe('500');
+      expect(await scratch.exists(testKeys.day(name, 'completed', staleDay))).toBe(0);
     });
   });
 
@@ -583,7 +585,7 @@ describe('MetricsRecorder', () => {
         const retention = recorder.retention;
         recorder.stop();
 
-        const store = new LatencyStore({ redis, retention });
+        const store = new LatencyStore({ redis, keys: testKeys, retention });
         const day = minuteToDay(Math.floor(Date.now() / 60000));
         const runtimeByDay = await store.readRange(name, 'runtime', 'day', [day]);
 
@@ -627,7 +629,7 @@ describe('MetricsRecorder', () => {
         const retention = recorder.retention;
         recorder.stop();
 
-        const store = new LatencyStore({ redis, retention });
+        const store = new LatencyStore({ redis, keys: testKeys, retention });
         const day = minuteToDay(Math.floor(Date.now() / 60000));
         const runtimeByDay = await store.readRange(name, 'runtime', 'day', [day]);
 

--- a/packages/metrics/tests/RedisMetricsHistoryProvider.spec.ts
+++ b/packages/metrics/tests/RedisMetricsHistoryProvider.spec.ts
@@ -1,10 +1,12 @@
 import { Redis } from 'ioredis';
 import { emptyVector } from '../src/histogram';
 import { HistoryStore } from '../src/HistoryStore';
-import { GLOBAL_QUEUE, dayHashKey, hourHashKey, minuteToDay, totalsHashKey } from '../src/keys';
+import { DEFAULT_NAMESPACE, GLOBAL_QUEUE, metricsKeys, minuteToDay } from '../src/keys';
 import { LatencyStore, QUEUE_AGE_METRIC } from '../src/LatencyStore';
 import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 describe('RedisMetricsHistoryProvider', () => {
   let redis: Redis;
@@ -25,19 +27,23 @@ describe('RedisMetricsHistoryProvider', () => {
     const keys: string[] = [];
     for (const day of days) {
       keys.push(
-        dayHashKey(QUEUE, 'completed', day),
-        dayHashKey(GLOBAL_QUEUE, 'completed', day),
-        hourHashKey(QUEUE, 'completed', day),
-        hourHashKey(GLOBAL_QUEUE, 'completed', day)
+        testKeys.day(QUEUE, 'completed', day),
+        testKeys.day(GLOBAL_QUEUE, 'completed', day),
+        testKeys.hour(QUEUE, 'completed', day),
+        testKeys.hour(GLOBAL_QUEUE, 'completed', day)
       );
     }
-    keys.push(totalsHashKey(QUEUE, 'completed'), totalsHashKey(GLOBAL_QUEUE, 'completed'));
+    keys.push(testKeys.totals(QUEUE, 'completed'), testKeys.totals(GLOBAL_QUEUE, 'completed'));
     await redis.del(...keys);
   }
 
   beforeEach(async () => {
     redis = new Redis(connection);
-    store = new HistoryStore({ redis, retention: { minutes: 90, hours: 90, days: 90 } });
+    store = new HistoryStore({
+      redis,
+      keys: testKeys,
+      retention: { minutes: 90, hours: 90, days: 90 },
+    });
     await cleanAll();
 
     await store.upsertMinute(QUEUE, 'completed', d1m, 3);
@@ -161,9 +167,9 @@ describe('RedisMetricsHistoryProvider', () => {
 
     beforeEach(async () => {
       await redis.del(
-        dayHashKey(HUGE_RANGE_QUEUE, 'completed', minuteToDay(seededMinute)),
-        hourHashKey(HUGE_RANGE_QUEUE, 'completed', minuteToDay(seededMinute)),
-        totalsHashKey(HUGE_RANGE_QUEUE, 'completed')
+        testKeys.day(HUGE_RANGE_QUEUE, 'completed', minuteToDay(seededMinute)),
+        testKeys.hour(HUGE_RANGE_QUEUE, 'completed', minuteToDay(seededMinute)),
+        testKeys.totals(HUGE_RANGE_QUEUE, 'completed')
       );
       await store.upsertMinute(HUGE_RANGE_QUEUE, 'completed', seededMinute, 42);
     });
@@ -211,11 +217,11 @@ describe('RedisMetricsHistoryProvider', () => {
     const zeroMinute = Date.UTC(2021, 6, 1, 3, 0) / 60000; // 2021-07-01 03:00 UTC
 
     async function resetKeys(): Promise<void> {
-      const keys: string[] = noDataDays.map((day) => dayHashKey(NO_DATA_QUEUE, 'completed', day));
+      const keys: string[] = noDataDays.map((day) => testKeys.day(NO_DATA_QUEUE, 'completed', day));
       keys.push(
-        totalsHashKey(NO_DATA_QUEUE, 'completed'),
-        dayHashKey(STORED_ZERO_QUEUE, 'completed', zeroDay),
-        totalsHashKey(STORED_ZERO_QUEUE, 'completed')
+        testKeys.totals(NO_DATA_QUEUE, 'completed'),
+        testKeys.day(STORED_ZERO_QUEUE, 'completed', zeroDay),
+        testKeys.totals(STORED_ZERO_QUEUE, 'completed')
       );
       await redis.del(...keys);
     }
@@ -239,7 +245,7 @@ describe('RedisMetricsHistoryProvider', () => {
       // field ends up holding '0', which must count as "recorded", not "missing".
       await store.upsertMinute(STORED_ZERO_QUEUE, 'completed', zeroMinute, 5);
       await store.upsertMinute(STORED_ZERO_QUEUE, 'completed', zeroMinute, 0);
-      expect(await redis.hget(totalsHashKey(STORED_ZERO_QUEUE, 'completed'), zeroDay)).toBe('0');
+      expect(await redis.hget(testKeys.totals(STORED_ZERO_QUEUE, 'completed'), zeroDay)).toBe('0');
 
       const points = await provider.getHistory({
         queue: STORED_ZERO_QUEUE,
@@ -263,13 +269,13 @@ describe('RedisMetricsHistoryProvider', () => {
 
     async function resetLatencyKeys(): Promise<void> {
       await redis.del(
-        hourHashKey(QUEUE, 'runtime', LATENCY_DAY),
-        hourHashKey(GLOBAL_QUEUE, 'runtime', LATENCY_DAY),
-        hourHashKey(QUEUE, QUEUE_AGE_METRIC, QUEUE_AGE_DAY)
+        testKeys.hour(QUEUE, 'runtime', LATENCY_DAY),
+        testKeys.hour(GLOBAL_QUEUE, 'runtime', LATENCY_DAY),
+        testKeys.hour(QUEUE, QUEUE_AGE_METRIC, QUEUE_AGE_DAY)
       );
-      await redis.hdel(totalsHashKey(QUEUE, 'runtime'), LATENCY_DAY);
-      await redis.hdel(totalsHashKey(GLOBAL_QUEUE, 'runtime'), LATENCY_DAY);
-      await redis.hdel(totalsHashKey(QUEUE, QUEUE_AGE_METRIC), QUEUE_AGE_DAY);
+      await redis.hdel(testKeys.totals(QUEUE, 'runtime'), LATENCY_DAY);
+      await redis.hdel(testKeys.totals(GLOBAL_QUEUE, 'runtime'), LATENCY_DAY);
+      await redis.hdel(testKeys.totals(QUEUE, QUEUE_AGE_METRIC), QUEUE_AGE_DAY);
     }
 
     beforeEach(resetLatencyKeys);
@@ -279,6 +285,7 @@ describe('RedisMetricsHistoryProvider', () => {
       const hour = Math.floor(Date.UTC(2019, 8, 2, 12, 0, 0) / 3600000);
       const latencyStore = new LatencyStore({
         redis,
+        keys: testKeys,
         retention: { minutes: 7, hours: 90, days: 90 },
       });
       const vector = emptyVector();
@@ -317,6 +324,7 @@ describe('RedisMetricsHistoryProvider', () => {
       const hour = Math.floor(Date.UTC(2019, 8, 4, 9, 0, 0) / 3600000);
       const latencyStore = new LatencyStore({
         redis,
+        keys: testKeys,
         retention: { minutes: 7, hours: 90, days: 90 },
       });
       await latencyStore.recordQueueAge(QUEUE, hour, 4_200);
@@ -343,13 +351,13 @@ describe('RedisMetricsHistoryProvider', () => {
 
     async function resetRangeKeys(): Promise<void> {
       await redis.del(
-        hourHashKey(QUEUE, 'runtime', RANGE_DAY_A),
-        hourHashKey(QUEUE, 'runtime', RANGE_DAY_B),
-        hourHashKey(GLOBAL_QUEUE, 'runtime', RANGE_DAY_A),
-        hourHashKey(GLOBAL_QUEUE, 'runtime', RANGE_DAY_B)
+        testKeys.hour(QUEUE, 'runtime', RANGE_DAY_A),
+        testKeys.hour(QUEUE, 'runtime', RANGE_DAY_B),
+        testKeys.hour(GLOBAL_QUEUE, 'runtime', RANGE_DAY_A),
+        testKeys.hour(GLOBAL_QUEUE, 'runtime', RANGE_DAY_B)
       );
-      await redis.hdel(totalsHashKey(QUEUE, 'runtime'), RANGE_DAY_A, RANGE_DAY_B);
-      await redis.hdel(totalsHashKey(GLOBAL_QUEUE, 'runtime'), RANGE_DAY_A, RANGE_DAY_B);
+      await redis.hdel(testKeys.totals(QUEUE, 'runtime'), RANGE_DAY_A, RANGE_DAY_B);
+      await redis.hdel(testKeys.totals(GLOBAL_QUEUE, 'runtime'), RANGE_DAY_A, RANGE_DAY_B);
     }
 
     beforeEach(resetRangeKeys);
@@ -358,6 +366,7 @@ describe('RedisMetricsHistoryProvider', () => {
     it('merges several days into one point whose percentile differs from any individual day', async () => {
       const latencyStore = new LatencyStore({
         redis,
+        keys: testKeys,
         retention: { minutes: 7, hours: 90, days: 90 },
       });
 

--- a/packages/metrics/tests/bullmq-matrix/helpers.ts
+++ b/packages/metrics/tests/bullmq-matrix/helpers.ts
@@ -1,5 +1,5 @@
 import { Redis } from 'ioredis';
-import { NAMESPACE } from '../../src/keys';
+import { DEFAULT_NAMESPACE } from '../../src/keys';
 
 export { connection } from '../connection';
 
@@ -29,7 +29,7 @@ export function uniqueName(prefix: string): string {
 }
 
 export async function resetHistory(redis: Redis, name: string): Promise<void> {
-  const keys = await redis.keys(`${NAMESPACE}:${name}*`);
+  const keys = await redis.keys(`${DEFAULT_NAMESPACE}:${name}*`);
   if (keys.length > 0) {
     await redis.del(...keys);
   }

--- a/packages/metrics/tests/bullmq-matrix/postgres.spec.ts
+++ b/packages/metrics/tests/bullmq-matrix/postgres.spec.ts
@@ -2,11 +2,13 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { Queue, Worker } from 'bullmq';
 import { Redis } from 'ioredis';
 import { HistoryStore } from '../../src/HistoryStore';
-import { minuteToDay, NAMESPACE } from '../../src/keys';
+import { DEFAULT_NAMESPACE, metricsKeys, minuteToDay } from '../../src/keys';
 import { LatencySampler } from '../../src/LatencySampler';
 import { LatencyStore } from '../../src/LatencyStore';
 import { MetricsRecorder } from '../../src/MetricsRecorder';
 import { assertResolvedMajor, connection, resetHistory, uniqueName, waitFor } from './helpers';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 const POSTGRES_URL = process.env.POSTGRES_URL;
 const RETENTION = { minutes: 7, hours: 90, days: 90 };
@@ -114,7 +116,7 @@ if (!POSTGRES_URL) {
       await recorder.snapshot();
       recorder.stop();
 
-      const store = new HistoryStore({ redis, retention: RETENTION });
+      const store = new HistoryStore({ redis, keys: testKeys, retention: RETENTION });
       const today = minuteToDay(Date.now() / 60000);
       expect(await store.readDailyTotalsRaw(name, 'completed', [today])).toEqual([null]);
     });
@@ -126,13 +128,14 @@ if (!POSTGRES_URL) {
 
       const sampler = new LatencySampler({
         redis,
-        store: new LatencyStore({ redis, retention: RETENTION }),
+        keys: testKeys,
+        store: new LatencyStore({ redis, keys: testKeys, retention: RETENTION }),
         tickMs: 60000,
         safetyMarginMs: 0,
       });
       await sampler.sample(adapter);
 
-      expect(await redis.keys(`${NAMESPACE}:${name}*`)).toEqual([]);
+      expect(await redis.keys(`${DEFAULT_NAMESPACE}:${name}*`)).toEqual([]);
     });
   });
 }

--- a/packages/metrics/tests/bullmq-matrix/redis.spec.ts
+++ b/packages/metrics/tests/bullmq-matrix/redis.spec.ts
@@ -3,11 +3,13 @@ import { MetricsTime, Queue, Worker } from 'bullmq';
 import { Redis } from 'ioredis';
 import { vectorTotal } from '../../src/histogram';
 import { HistoryStore } from '../../src/HistoryStore';
-import { minuteToDay } from '../../src/keys';
+import { DEFAULT_NAMESPACE, metricsKeys, minuteToDay } from '../../src/keys';
 import { LatencySampler } from '../../src/LatencySampler';
 import { LatencyStore } from '../../src/LatencyStore';
 import { MetricsRecorder } from '../../src/MetricsRecorder';
 import { assertResolvedMajor, connection, resetHistory, uniqueName, waitFor } from './helpers';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 const RETENTION = { minutes: 7, hours: 90, days: 90 };
 
@@ -68,7 +70,7 @@ describe('Redis-backed queues', () => {
     await recorder.snapshot();
     recorder.stop();
 
-    const store = new HistoryStore({ redis, retention: RETENTION });
+    const store = new HistoryStore({ redis, keys: testKeys, retention: RETENTION });
     const today = minuteToDay(Date.now() / 60000);
     const [stored] = await store.readDailyTotalsRaw(name, 'completed', [today]);
     expect(Number(stored)).toBeGreaterThanOrEqual(3);
@@ -77,8 +79,14 @@ describe('Redis-backed queues', () => {
   it('samples job durations into the latency store', async () => {
     await runJobs(3, 3, false);
 
-    const store = new LatencyStore({ redis, retention: RETENTION });
-    const sampler = new LatencySampler({ redis, store, tickMs: 60000, safetyMarginMs: 0 });
+    const store = new LatencyStore({ redis, keys: testKeys, retention: RETENTION });
+    const sampler = new LatencySampler({
+      redis,
+      keys: testKeys,
+      store,
+      tickMs: 60000,
+      safetyMarginMs: 0,
+    });
     await sampler.sample(adapter);
 
     const today = minuteToDay(Date.now() / 60000);

--- a/packages/metrics/tests/cluster.spec.ts
+++ b/packages/metrics/tests/cluster.spec.ts
@@ -1,0 +1,221 @@
+import { Cluster } from 'ioredis';
+import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
+import { HistoryStore } from '../src/HistoryStore';
+import { GLOBAL_QUEUE, metricsKeys, minuteToDay, resolveNamespace } from '../src/keys';
+import { LatencyStore } from '../src/LatencyStore';
+import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
+import { clusterNodes } from './connection';
+
+const RETENTION = { minutes: 7, hours: 90, days: 90 };
+const MS_PER_MINUTE = 60000;
+const QUEUES = ['alpha', 'beta', 'gamma'];
+const PER_QUEUE_MINUTES = 20;
+
+if (!clusterNodes) {
+  describe.skip('Redis Cluster (skipped: REDIS_CLUSTER_NODES is not set)', () => {
+    it('needs a cluster to talk to', () => undefined);
+  });
+} else {
+  describe('Redis Cluster', () => {
+    let cluster: Cluster;
+    let prefix: string;
+    let namespace: string;
+    let minute: number;
+    let day: string;
+
+    beforeAll(async () => {
+      cluster = new Cluster(clusterNodes!, { redisOptions: { protocol: 2 } });
+      await cluster.ping();
+    });
+
+    afterAll(async () => {
+      await cluster.quit();
+    });
+
+    beforeEach(async () => {
+      prefix = `bull-board:metrics:test:${Math.random().toString(36).slice(2, 10)}`;
+      namespace = resolveNamespace(prefix, true);
+      minute = Math.floor(Date.now() / MS_PER_MINUTE);
+      day = minuteToDay(minute);
+    });
+
+    afterEach(async () => {
+      await Promise.all(
+        cluster.nodes('master').map(async (node) => {
+          const keys = await node.keys(`${namespace}:*`);
+          if (keys.length > 0) {
+            await node.unlink(...keys);
+          }
+        })
+      );
+    });
+
+    function store(): HistoryStore {
+      return new HistoryStore({
+        redis: cluster,
+        keys: metricsKeys(namespace),
+        retention: RETENTION,
+      });
+    }
+
+    async function seed(): Promise<void> {
+      const history = store();
+      const latency = new LatencyStore({
+        redis: cluster,
+        keys: metricsKeys(namespace),
+        retention: RETENTION,
+      });
+      for (const queue of QUEUES) {
+        for (let i = 0; i < PER_QUEUE_MINUTES; i++) {
+          await history.upsertMinute(queue, 'completed', minute - i, i + 1);
+        }
+        await latency.addSamples(queue, 'runtime', Math.floor(minute / 60), [1, 2, 3]);
+        await latency.recordQueueAge(queue, Math.floor(minute / 60), 4321);
+      }
+    }
+
+    it('writes a queue and the cross-queue rollup in one EVAL without CROSSSLOT', async () => {
+      await expect(store().upsertMinute('alpha', 'completed', minute, 5)).resolves.toBeUndefined();
+
+      const keys = metricsKeys(namespace);
+      expect(await cluster.hget(keys.day('alpha', 'completed', day), String(minute))).toBe('5');
+      expect(await cluster.hget(keys.day(GLOBAL_QUEUE, 'completed', day), String(minute))).toBe(
+        '5'
+      );
+      expect(await cluster.hget(keys.totals(GLOBAL_QUEUE, 'completed'), day)).toBe('5');
+    });
+
+    it('merges latency histograms and the queue-age gauge across slots', async () => {
+      const latency = new LatencyStore({
+        redis: cluster,
+        keys: metricsKeys(namespace),
+        retention: RETENTION,
+      });
+      const hour = Math.floor(minute / 60);
+
+      await expect(
+        latency.addSamples('alpha', 'runtime', hour, [1, 2, 3])
+      ).resolves.toBeUndefined();
+      await expect(latency.recordQueueAge('alpha', hour, 4321)).resolves.toBeUndefined();
+
+      expect(await latency.readQueueAge(GLOBAL_QUEUE, 'day', [day])).toEqual({ [day]: 4321 });
+    });
+
+    it('puts the whole namespace in one slot, which is what keeps the EVALs legal', async () => {
+      await seed();
+
+      const holders = await Promise.all(
+        cluster.nodes('master').map(async (node) => (await node.keys(`${namespace}:*`)).length)
+      );
+
+      expect(holders.filter((count) => count > 0)).toHaveLength(1);
+    });
+
+    it('reports the same footprint on every call, not one arbitrary master', async () => {
+      await seed();
+      const admin = new MetricsHistoryAdmin({ connection: cluster, prefix });
+
+      const runs = [];
+      for (let i = 0; i < 10; i++) {
+        runs.push((await admin.stats()).keys);
+      }
+
+      const expected = (
+        await Promise.all(
+          cluster.nodes('master').map(async (node) => (await node.keys(`${namespace}:*`)).length)
+        )
+      ).reduce((sum, count) => sum + count, 0);
+
+      expect(expected).toBeGreaterThan(0);
+      expect(runs).toEqual(Array.from({ length: 10 }, () => expected));
+    });
+
+    it('purges one queue and takes it back out of the cross-queue rollup', async () => {
+      await seed();
+      const admin = new MetricsHistoryAdmin({ connection: cluster, prefix });
+      const keys = metricsKeys(namespace);
+      const before = Number(await cluster.hget(keys.totals(GLOBAL_QUEUE, 'completed'), day));
+      const alpha = Number(await cluster.hget(keys.totals('alpha', 'completed'), day));
+
+      const result = await admin.purge({ queue: 'alpha' });
+
+      expect(result.keysDeleted).toBeGreaterThan(0);
+      expect(await cluster.exists(keys.totals('alpha', 'completed'))).toBe(0);
+      expect(Number(await cluster.hget(keys.totals(GLOBAL_QUEUE, 'completed'), day))).toBe(
+        before - alpha
+      );
+    });
+
+    it('purges everything the recorder wrote', async () => {
+      await seed();
+      const admin = new MetricsHistoryAdmin({ connection: cluster, prefix });
+
+      await admin.purge();
+
+      expect((await admin.stats()).keys).toBe(0);
+    });
+
+    it('serves the charts the board reads', async () => {
+      await seed();
+      const provider = new RedisMetricsHistoryProvider({
+        connection: cluster,
+        prefix,
+        retention: RETENTION,
+      });
+      const perQueue = PER_QUEUE_MINUTES * ((PER_QUEUE_MINUTES + 1) / 2);
+
+      const queue = await provider.getHistory({
+        queue: 'alpha',
+        metric: 'completed',
+        granularity: 'day',
+        from: Date.now() - MS_PER_MINUTE * PER_QUEUE_MINUTES,
+        to: Date.now(),
+      });
+      const global = await provider.getHistory({
+        metric: 'completed',
+        granularity: 'day',
+        from: Date.now() - MS_PER_MINUTE * PER_QUEUE_MINUTES,
+        to: Date.now(),
+      });
+      const latency = await provider.getLatency({
+        queue: 'alpha',
+        metric: 'runtime',
+        granularity: 'day',
+        percentiles: [95],
+        from: Date.now() - MS_PER_MINUTE * PER_QUEUE_MINUTES,
+        to: Date.now(),
+      });
+
+      expect(queue.at(-1)?.value).toBe(perQueue);
+      expect(global.at(-1)?.value).toBe(perQueue * QUEUES.length);
+      expect(latency.at(-1)?.count).toBe(6);
+    });
+
+    it('keeps two prefixes on one cluster from seeing each other', async () => {
+      const other = `${prefix}:second`;
+      await store().upsertMinute('alpha', 'completed', minute, 5);
+      await new HistoryStore({
+        redis: cluster,
+        keys: metricsKeys(resolveNamespace(other, true)),
+        retention: RETENTION,
+      }).upsertMinute('alpha', 'completed', minute, 9);
+
+      const mine = await new MetricsHistoryAdmin({ connection: cluster, prefix }).stats();
+      const theirs = await new MetricsHistoryAdmin({ connection: cluster, prefix: other }).stats();
+
+      expect(mine.queues.map((q) => q.queue).sort()).toEqual([GLOBAL_QUEUE, 'alpha']);
+      expect(await cluster.hget(metricsKeys(namespace).totals('alpha', 'completed'), day)).toBe(
+        '5'
+      );
+      expect(
+        await cluster.hget(
+          metricsKeys(resolveNamespace(other, true)).totals('alpha', 'completed'),
+          day
+        )
+      ).toBe('9');
+      expect(theirs.keys).toBeGreaterThan(0);
+
+      await new MetricsHistoryAdmin({ connection: cluster, prefix: other }).purge();
+    });
+  });
+}

--- a/packages/metrics/tests/connection.spec.ts
+++ b/packages/metrics/tests/connection.spec.ts
@@ -1,5 +1,5 @@
 import { Redis } from 'ioredis';
-import { isRedisClient } from '../src/connection';
+import { isClient, isCluster } from '../src/connection';
 import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
 
 const connection = {
@@ -31,11 +31,20 @@ describe('telling a client from connection options', () => {
     const foreign = clientFromASecondIoredisCopy();
 
     expect(foreign instanceof Redis).toBe(false);
-    expect(isRedisClient(foreign)).toBe(true);
+    expect(isClient(foreign)).toBe(true);
   });
 
   it('recognises our own client', () => {
-    expect(isRedisClient(real)).toBe(true);
+    expect(isClient(real)).toBe(true);
+    expect(isCluster(real)).toBe(false);
+  });
+
+  it('tells a cluster client from a standalone one', () => {
+    const cluster = { hgetall: async () => ({}), nodes: () => [] } as unknown as Redis;
+
+    expect(isClient(cluster)).toBe(true);
+    expect(isCluster(cluster)).toBe(true);
+    expect(isCluster(connection)).toBe(false);
   });
 
   it.each([
@@ -43,7 +52,7 @@ describe('telling a client from connection options', () => {
     ['an empty object', {}],
     ['a url-less options bag', { db: 3, keyPrefix: 'x:' }],
   ])('treats %s as options rather than a client', (_label, options) => {
-    expect(isRedisClient(options)).toBe(false);
+    expect(isClient(options)).toBe(false);
   });
 
   it('adopts an injected client instead of opening a second connection to localhost', () => {

--- a/packages/metrics/tests/connection.ts
+++ b/packages/metrics/tests/connection.ts
@@ -17,3 +17,16 @@ export const connection = {
   port: +(process.env.REDIS_PORT || 6379),
   db: process.env.REDIS_TEST_DB ? +process.env.REDIS_TEST_DB : TEST_DBS + 1 - worker,
 };
+
+// The cluster spec needs a real cluster, so it skips loudly without one. Its keys are scoped
+// by a per-test prefix rather than by database: a cluster has only database 0.
+const parsedClusterNodes = (process.env.REDIS_CLUSTER_NODES || '')
+  .split(',')
+  .map((entry) => entry.trim())
+  .filter(Boolean)
+  .map((entry) => {
+    const [host, port] = entry.split(':');
+    return { host, port: Number(port) };
+  });
+
+export const clusterNodes = parsedClusterNodes.length > 0 ? parsedClusterNodes : null;

--- a/packages/metrics/tests/e2e.spec.ts
+++ b/packages/metrics/tests/e2e.spec.ts
@@ -2,10 +2,12 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { MetricsTime, Queue, Worker } from 'bullmq';
 import { Redis } from 'ioredis';
 import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
-import { GLOBAL_QUEUE, NAMESPACE, minuteToDay, totalsHashKey } from '../src/keys';
+import { DEFAULT_NAMESPACE, GLOBAL_QUEUE, metricsKeys, minuteToDay } from '../src/keys';
 import { MetricsRecorder } from '../src/MetricsRecorder';
 import { RedisMetricsHistoryProvider } from '../src/RedisMetricsHistoryProvider';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 const E2E_QUEUE = 'MetricsE2ELatencyQueue';
 
@@ -15,7 +17,7 @@ const E2E_QUEUE = 'MetricsE2ELatencyQueue';
  * real, non-isolated Redis to keep exact-equality assertions valid.
  */
 async function resetHistory(redis: Redis, name: string) {
-  const keys = await redis.keys(`${NAMESPACE}:${name}:*`);
+  const keys = await redis.keys(`${DEFAULT_NAMESPACE}:${name}:*`);
   if (keys.length > 0) {
     await redis.del(...keys);
   }
@@ -98,7 +100,7 @@ describe('metrics e2e (recorder -> provider round trip)', () => {
     const globalBefore: Record<string, number> = {};
     for (const day of days) {
       globalBefore[day] =
-        Number(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)) || 0;
+        Number(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)) || 0;
     }
 
     const recorder = new MetricsRecorder({ queues: [adapter], connection: redis });
@@ -127,7 +129,7 @@ describe('metrics e2e (recorder -> provider round trip)', () => {
     // this is the only queue contributing to this run's slice of the global hash.
     let globalDelta = 0;
     for (const day of days) {
-      const after = Number(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)) || 0;
+      const after = Number(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)) || 0;
       globalDelta += after - (globalBefore[day] ?? 0);
     }
     expect(globalDelta).toBe(finalizedSum);
@@ -156,7 +158,7 @@ describe('metrics e2e (recorder -> provider round trip)', () => {
     expect(afterPurge).toEqual([]);
 
     for (const day of days) {
-      const after = Number(await redis.hget(totalsHashKey(GLOBAL_QUEUE, 'completed'), day)) || 0;
+      const after = Number(await redis.hget(testKeys.totals(GLOBAL_QUEUE, 'completed'), day)) || 0;
       expect(after).toBe(globalBefore[day] ?? 0);
     }
 

--- a/packages/metrics/tests/footprint.spec.ts
+++ b/packages/metrics/tests/footprint.spec.ts
@@ -2,9 +2,11 @@ import { Redis } from 'ioredis';
 import { emptyVector } from '../src/histogram';
 import { MetricsHistoryAdmin } from '../src/HistoryAdmin';
 import { HistoryStore } from '../src/HistoryStore';
-import { GLOBAL_QUEUE, NAMESPACE } from '../src/keys';
+import { DEFAULT_NAMESPACE, GLOBAL_QUEUE, metricsKeys } from '../src/keys';
 import { LatencyStore } from '../src/LatencyStore';
 import { connection } from './connection';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 const MINUTES_PER_DAY = 1440;
 const KB = 1024;
@@ -28,11 +30,12 @@ describe('storage footprint', () => {
   const QUEUE = 'FootprintQueue';
   const BASE_MINUTE = Date.UTC(2019, 5, 1) / 60000;
 
-  const store = () => new HistoryStore({ redis, retention: { minutes: 90, hours: 90, days: 90 } });
+  const store = () =>
+    new HistoryStore({ redis, keys: testKeys, retention: { minutes: 90, hours: 90, days: 90 } });
 
   async function clear(): Promise<void> {
-    const mine = await redis.keys(`${NAMESPACE}:${QUEUE}*`);
-    const globals = await redis.keys(`${NAMESPACE}:${GLOBAL_QUEUE}:*:2019-06-*`);
+    const mine = await redis.keys(`${DEFAULT_NAMESPACE}:${QUEUE}*`);
+    const globals = await redis.keys(`${DEFAULT_NAMESPACE}:${GLOBAL_QUEUE}:*:2019-06-*`);
     if (mine.length + globals.length > 0) {
       await redis.del(...mine, ...globals);
     }
@@ -149,7 +152,11 @@ describe('storage footprint', () => {
   });
 
   it('keeps a full day of both latency histograms inside the documented band', async () => {
-    const latency = new LatencyStore({ redis, retention: { minutes: 90, hours: 90, days: 90 } });
+    const latency = new LatencyStore({
+      redis,
+      keys: testKeys,
+      retention: { minutes: 90, hours: 90, days: 90 },
+    });
     const baseHour = Math.floor((BASE_MINUTE * 60000) / 3600000);
 
     for (let hour = 0; hour < 24; hour++) {

--- a/packages/metrics/tests/keys.spec.ts
+++ b/packages/metrics/tests/keys.spec.ts
@@ -1,12 +1,14 @@
 import {
+  DEFAULT_NAMESPACE,
   GLOBAL_QUEUE,
-  NAMESPACE,
-  dayHashKey,
   dayRange,
   dayToStartMs,
+  metricsKeys,
   minuteToDay,
-  totalsHashKey,
+  resolveNamespace,
 } from '../src/keys';
+
+const testKeys = metricsKeys(DEFAULT_NAMESPACE);
 
 describe('keys', () => {
   it('derives the UTC day from a minute index', () => {
@@ -16,10 +18,24 @@ describe('keys', () => {
   });
 
   it('builds namespaced keys', () => {
-    expect(dayHashKey('MyQueue', 'completed', '2021-01-01')).toBe(
-      `${NAMESPACE}:MyQueue:completed:2021-01-01`
+    expect(testKeys.day('MyQueue', 'completed', '2021-01-01')).toBe(
+      `${DEFAULT_NAMESPACE}:MyQueue:completed:2021-01-01`
     );
-    expect(totalsHashKey(GLOBAL_QUEUE, 'failed')).toBe(`${NAMESPACE}:__global__:failed:totals`);
+    expect(testKeys.totals(GLOBAL_QUEUE, 'failed')).toBe(
+      `${DEFAULT_NAMESPACE}:__global__:failed:totals`
+    );
+  });
+
+  it('builds every key off the namespace it was given', () => {
+    const scoped = metricsKeys('{tenant-a}');
+    expect(scoped.day('Q', 'completed', '2021-01-01')).toBe('{tenant-a}:Q:completed:2021-01-01');
+    expect(scoped.hour('Q', 'completed', '2021-01-01')).toBe(
+      '{tenant-a}:Q:completed:hour:2021-01-01'
+    );
+    expect(scoped.totals('Q', 'completed')).toBe('{tenant-a}:Q:completed:totals');
+    expect(scoped.lease('Q')).toBe('{tenant-a}:Q:latency:lease');
+    expect(scoped.watermark('Q')).toBe('{tenant-a}:Q:latency:watermark');
+    expect(scoped.scanPattern).toBe('{tenant-a}:*');
   });
 
   it('lists inclusive UTC day range', () => {
@@ -42,5 +58,32 @@ describe('keys', () => {
 
   it('round-trips day to UTC midnight ms', () => {
     expect(dayToStartMs('2021-01-01')).toBe(Date.UTC(2021, 0, 1));
+  });
+});
+
+describe('resolveNamespace', () => {
+  it('leaves a standalone namespace exactly as it was', () => {
+    expect(resolveNamespace(undefined, false)).toBe(DEFAULT_NAMESPACE);
+    expect(resolveNamespace('staging:metrics', false)).toBe('staging:metrics');
+  });
+
+  it('hash-tags a clustered namespace so one EVAL cannot cross a slot', () => {
+    expect(resolveNamespace(undefined, true)).toBe(`{${DEFAULT_NAMESPACE}}`);
+    expect(resolveNamespace('staging:metrics', true)).toBe('{staging:metrics}');
+  });
+
+  it("keeps the caller's own hash tag, so they choose the slot", () => {
+    expect(resolveNamespace('{tenant-a}:metrics', true)).toBe('{tenant-a}:metrics');
+    expect(resolveNamespace('metrics:{tenant-a}', true)).toBe('metrics:{tenant-a}');
+  });
+
+  it('wraps a prefix whose braces Redis would not read as a tag', () => {
+    expect(resolveNamespace('metrics:{}', true)).toBe('{metrics:{}}');
+    expect(resolveNamespace('me{trics', true)).toBe('{me{trics}');
+  });
+
+  it('tolerates a trailing colon, which is how the namespace is usually written', () => {
+    expect(resolveNamespace('staging:metrics:', false)).toBe('staging:metrics');
+    expect(resolveNamespace('', false)).toBe(DEFAULT_NAMESPACE);
   });
 });

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -208,7 +208,7 @@ That registers `RedisMetricsHistoryProvider` on the Redis connection the dashboa
 
 It also writes. A `MetricsRecorder` runs in the CLI process and once a minute copies each queue's completed and failed counters into long-retention buckets, then samples wait time, run time and the age of the oldest waiting job. The recorder follows discovery rather than a fixed list: a queue that shows up between rescans starts recording on the next tick, and one that disappears stops. No restart either way.
 
-`--history-retention-days` sets how long history is kept, 90 days by default. It moves the hourly and daily windows only and leaves minute-level detail at 7 days, since that tier holds essentially all the bytes. Per-tier retention, the snapshot interval and turning latency sampling off go in the config file under a `history` key:
+`--history-retention-days` sets how long history is kept, 90 days by default. It moves the hourly and daily windows only and leaves minute-level detail at 7 days, since that tier holds essentially all the bytes. Per-tier retention, the key namespace, the snapshot interval and turning latency sampling off go in the config file under a `history` key:
 
 ```js
 // bull-board.config.js
@@ -216,6 +216,7 @@ module.exports = {
   redis: 'redis://localhost:6379',
   history: {
     enabled: true,
+    prefix: 'bull-board:metrics',
     retention: { minutes: 7, hours: 90, days: 90 },
     latency: false,
     snapshotIntervalMs: 60000,
@@ -225,7 +226,7 @@ module.exports = {
 
 ### What it writes
 
-Recording writes to the same Redis your queues live in, under the `bull-board:metrics:` namespace, and never touches a key Bull or BullMQ owns. Redis TTLs enforce retention, so there's nothing to prune by hand. [Storage footprint](/recipes/historical-metrics#storage-footprint) has the measured numbers; the short version is roughly 1.1 MB per queue for the counters at the default retention plus about 250 KB for latency, and an idle queue costs nothing.
+Recording writes to the same Redis your queues live in, under the `bull-board:metrics:` namespace, and never touches a key Bull or BullMQ owns. Set `history.prefix` in the config file to move that namespace, which is what keeps two boards on one Redis from sharing a history. Redis TTLs enforce retention, so there's nothing to prune by hand. [Storage footprint](/recipes/historical-metrics#storage-footprint) has the measured numbers; the short version is roughly 1.1 MB per queue for the counters at the default retention plus about 250 KB for latency, and an idle queue costs nothing.
 
 `--read-only` stops the writing and keeps the reading, so the board serves whatever another process has recorded. That's what you want when your workers already run a `MetricsRecorder` of their own and the CLI is only there to look at the result. The config file can ask for the opposite with `history: { record: true }` alongside `--read-only`, for a board that mustn't touch your queues but does own its history.
 

--- a/website/docs/recipes/historical-metrics.md
+++ b/website/docs/recipes/historical-metrics.md
@@ -117,7 +117,13 @@ const recorder = new MetricsRecorder({
 });
 ```
 
-Retention is enforced by Redis itself, so old buckets expire on their own and there's nothing to prune by hand. Buckets are UTC-aligned, and every key the recorder writes is namespaced under `bull-board:metrics:`, so it can't collide with BullMQ's own keys.
+Retention is enforced by Redis itself, so old buckets expire on their own and there's nothing to prune by hand. Buckets are UTC-aligned, and every key the recorder writes is namespaced under `bull-board:metrics:`, so it can't collide with BullMQ's own keys. Pass `prefix` to move that namespace, which is what separates two boards sharing one Redis:
+
+```ts
+const recorder = new MetricsRecorder({ queues, connection, prefix: 'staging:metrics' });
+```
+
+Give the provider and any `MetricsHistoryAdmin` the same prefix. A provider pointed at a namespace nothing writes to reports empty history rather than an error, so a mismatch looks like a board that never recorded anything.
 
 On shutdown, call `recorder.stop()`. It clears the snapshot interval and, if the recorder created its own Redis connection internally, closes it too. If you passed in your own `Redis` instance, `stop()` leaves that connection alone, so it's a safe no-op to call either way.
 
@@ -249,7 +255,7 @@ const stats = await admin.stats();
 
 `stats()` reports the real Redis footprint (`MEMORY USAGE` per key), split by tier and by queue, largest first, with the cross-queue rollup listed as `__global__`. Measurements go out in pipelined batches, so a namespace of a few thousand keys costs a couple of dozen round trips rather than a few thousand. It still reads every history key though, so treat it as an ops call rather than something to poll.
 
-`purge()` deletes stored history. It's scoped to the `bull-board:metrics:` namespace and driven by `SCAN`, so it never blocks Redis and never touches your queues' own keys:
+`purge()` deletes stored history. It's scoped to the recorder's namespace and driven by `SCAN`, so it never blocks Redis and never touches your queues' own keys. Against a cluster both calls scan every master, because `SCAN` carries no key for the client to route by and would otherwise answer from one arbitrary node:
 
 ```ts
 await admin.purge();                                    // everything
@@ -297,6 +303,28 @@ Each row in that table carries a bar scaled against the busiest queue and split 
 ![The dedicated Metrics history page showing cross-queue throughput](/screenshots/historical-metrics-page.png)
 
 Leave `historyProvider` unset and none of this appears; the board behaves exactly as it did before.
+
+## Redis Cluster
+
+Hand `connection` a `Cluster` and the recorder, the provider and the admin all work. One detail of the key layout is worth knowing before you turn it on.
+
+Each snapshot writes a queue's three tiers and the three `__global__` rollup tiers in one `EVAL`. That single script is what makes the write idempotent at every resolution at once: it computes the delta against the minute already stored and applies it everywhere, so a restart or a second recorder re-snapshotting the same window adds nothing. Redis Cluster rejects a multi-key command whose keys fall in different slots, so those six keys have to share one.
+
+The namespace therefore carries a [hash tag](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) whenever the connection is a cluster: `bull-board:metrics` is written as `{bull-board:metrics}`, and a `prefix` of your own is wrapped the same way unless it already contains a `{...}` tag, in which case yours is used as given and picks the slot.
+
+```ts
+new MetricsRecorder({ queues, connection: cluster });                          // {bull-board:metrics}
+new MetricsRecorder({ queues, connection: cluster, prefix: 'staging' });       // {staging}
+new MetricsRecorder({ queues, connection: cluster, prefix: '{eu}:metrics' });  // {eu}:metrics
+```
+
+One slot means a single master holds the history for the whole board. That is the cost of keeping the cross-queue rollup correct on write instead of recomputing it on every read, and it is small: the numbers in [Storage footprint](#storage-footprint) are the whole of it, roughly 50 MB at 200 busy queues, plus one `EVAL` per queue per metric per minute.
+
+Standalone keys are untagged and unchanged, so an existing deployment keeps the history it has. Nothing carries across from a standalone Redis to a cluster, since the key names differ.
+
+Latency sampling reads BullMQ's own keys over the same connection, so your queues need the hash-tagged prefix BullMQ already requires in cluster mode (`new Queue(name, { prefix: '{bull}' })`). Without one a queue's keys scatter across slots and the sampler's pipelines are rejected; it swallows that error to protect the counter snapshot, so pass `onLatencyError` if you want to see it.
+
+The [CLI](/guide/cli) and the Docker image cannot reach a cluster at all: they build a plain client from a URL or from Sentinel. Cluster support there is a separate piece of work.
 
 ## Scope
 


### PR DESCRIPTION
> **First of three, review and merge this one first.** #1437 and #1438 are branched off it, so
> until it lands they show its commit in their diff as well. I rebase and force-push each of them
> as soon as the one below it merges, so they only ever wait on the previous review.
>
> 1. **→ this one** #1436 `fix(metrics)` Redis Cluster support and a `prefix` option. Closes #1432.
> 2.    #1437 `feat(cli)` `--cluster` for the CLI and the Docker image. Needs the `prefix`
>    option from #1436.
> 3.    #1438 `fix(api)` the board's Redis stats panel on a cluster. Independent code, stacked
>    only for the test cluster #1436 adds.

Closes #1432.

`@bull-board/metrics` cannot run against a Redis Cluster, for two reasons rather than one. The issue reports the first; the second is that `stats()` and `purge()` silently read one random master.

## What changes

**Cluster writes.** The rollup scripts write a queue's tiers and the `__global__` tiers in a single `EVAL`, which a cluster rejects across slots. The namespace now carries a Redis hash tag when the connection is a `Cluster`, so `bull-board:metrics` is written `{bull-board:metrics}`. Standalone keys are unchanged.

**Cluster reads.** `MetricsHistoryAdmin.scan()` used `SCAN`, which carries no key, so ioredis routed it to an arbitrary master. It now scans every master.

**`prefix` option** on `MetricsRecorder`, `RedisMetricsHistoryProvider` and `MetricsHistoryAdmin`, which is the multitenancy half of the issue. A caller's own `{...}` tag is respected as given. The CLI gets the same as `history.prefix` in the config file.

**`MetricsConnection` accepts a `Cluster`.** It always did at runtime, which is why this surfaced as a Redis error rather than a type error.

Internally the key builders moved into a `metricsKeys(namespace)` factory each store holds, so a missed call site is a compile error instead of one key quietly crossing a slot boundary.

## Testing

`docker-compose.redis.yml` gains a three-master `redis-cluster` service, and `tests/cluster.spec.ts` skips loudly without `REDIS_CLUSTER_NODES`, the same way the PostgreSQL cases handle `POSTGRES_URL`. Both halves were confirmed to fail without the fix: reverting the hash tag turns all eight cases red with `CROSSSLOT Keys in request don't hash to the same slot`, and reverting only the scan fan-out reddens the two that depend on it.

## Notes

The whole namespace lands on one master by design. Sharding per queue would mean splitting `UPSERT_MINUTE` into two `EVAL`s, and a crash between them would drop that minute's delta from the rollup permanently. The cost is the footprint already documented, roughly 50 MB at 200 busy queues.

#1437 stacks on this and adds `--cluster` to the CLI and the Docker image, so the same works without embedding bull-board in an app.


