### PR TITLE
feat(cli): connect to a Redis Cluster

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -86,7 +86,7 @@ jobs:
             || { echo "::error::OpenAPI artifacts are stale. Run 'yarn workspace @bull-board/api openapi' and commit the result."; exit 1; }
       # A cluster cannot be a `services:` entry: it needs three servers brought up and then
       # joined, which that block has no way to express. Without REDIS_CLUSTER_NODES the
-      # metrics cluster spec skips itself.
+      # metrics and CLI cluster specs skip themselves.
       - name: Start Redis Cluster
         run: |
           docker compose -f docker-compose.redis.yml up -d redis-cluster

--- a/packages/cli/src/config/connection.ts
+++ b/packages/cli/src/config/connection.ts
@@ -2,19 +2,26 @@ import type { RedisOptions } from 'ioredis';
 import type { FlagValues } from './flags';
 import type { FileConfig } from './types';
 
+export interface Address {
+  host: string;
+  port: number;
+}
+
 export type ConnectionConfig =
   | { mode: 'url'; url: string; options: RedisOptions }
   | { mode: 'sentinel'; options: RedisOptions }
+  | { mode: 'cluster'; nodes: Address[]; options: RedisOptions }
   | { mode: 'options'; options: RedisOptions };
 
 const DEFAULT_REDIS_URL = 'redis://localhost:6379';
 const DEFAULT_SENTINEL_PORT = 26379;
+const DEFAULT_REDIS_PORT = 6379;
 
 function firstDefined<T>(...values: Array<T | undefined>): T | undefined {
   return values.find((value) => value !== undefined && value !== '');
 }
 
-function parseSentinel(entry: string): { host: string; port: number } {
+function parseAddress(entry: string, label: string, defaultPort: number): Address {
   // A bare IPv6 literal is all colons, so bracket it before the URL parser sees a port.
   const bracketed =
     !entry.startsWith('[') && entry.indexOf(':') !== entry.lastIndexOf(':') ? `[${entry}]` : entry;
@@ -23,23 +30,27 @@ function parseSentinel(entry: string): { host: string; port: number } {
   try {
     parsed = new URL(`redis://${bracketed}`);
   } catch {
-    throw new Error(`Invalid sentinel address "${entry}": expected host or host:port.`);
+    throw new Error(`Invalid ${label} address "${entry}": expected host or host:port.`);
   }
 
-  const port = parsed.port === '' ? DEFAULT_SENTINEL_PORT : Number(parsed.port);
+  const port = parsed.port === '' ? defaultPort : Number(parsed.port);
   if (!parsed.hostname || parsed.pathname || parsed.search || port === 0) {
-    throw new Error(`Invalid sentinel address "${entry}": expected host or host:port.`);
+    throw new Error(`Invalid ${label} address "${entry}": expected host or host:port.`);
   }
 
-  return { host: parsed.hostname.replace(/^\[|\]$/g, ''), port };
+  return { host: unbracket(parsed.hostname), port };
 }
 
-function parseSentinels(value: string): RedisOptions['sentinels'] {
+function unbracket(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+}
+
+function parseAddresses(value: string, label: string, defaultPort: number): Address[] {
   return value
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean)
-    .map(parseSentinel);
+    .map((entry) => parseAddress(entry, label, defaultPort));
 }
 
 function assertUsableUrl(url: string): void {
@@ -110,10 +121,28 @@ export function resolveConnection({
   const explicitUrl = firstDefined(flags.redis, env.BULL_BOARD_REDIS_URL);
   const sentinelList = firstDefined(flags.sentinel, env.BULL_BOARD_SENTINELS);
   const sentinelName = firstDefined(flags['sentinel-name'], env.BULL_BOARD_SENTINEL_NAME);
+  const clusterList = firstDefined(flags.cluster, env.BULL_BOARD_CLUSTER_NODES);
   const credentials = credentialOptions({ flags, env });
 
-  if (sentinelList && explicitUrl) {
-    throw new Error('Use either a Redis URL or --sentinel, not both.');
+  const modes = [
+    explicitUrl && 'a Redis URL',
+    sentinelList && '--sentinel',
+    clusterList && '--cluster',
+  ].filter(Boolean);
+  if (modes.length > 1) {
+    throw new Error(`Use only one of ${modes.slice(0, -1).join(', ')} and ${modes.at(-1)}.`);
+  }
+
+  if (clusterList) {
+    if (credentials.options.db !== undefined) {
+      throw new Error('--redis-db cannot be used with --cluster: a cluster only has database 0.');
+    }
+
+    return {
+      mode: 'cluster',
+      nodes: parseAddresses(clusterList, 'cluster node', DEFAULT_REDIS_PORT),
+      options: credentials.options,
+    };
   }
 
   if (sentinelList) {
@@ -124,7 +153,7 @@ export function resolveConnection({
     return {
       mode: 'sentinel',
       options: {
-        sentinels: parseSentinels(sentinelList),
+        sentinels: parseAddresses(sentinelList, 'sentinel', DEFAULT_SENTINEL_PORT),
         name: sentinelName,
         ...credentials.options,
       },
@@ -144,7 +173,7 @@ export function resolveConnection({
 
   if (credentials.names.length > 0) {
     throw new Error(
-      `${credentials.names.join(', ')} cannot be combined with a Redis URL. Put credentials in the URL itself, or connect through --sentinel.`
+      `${credentials.names.join(', ')} cannot be combined with a Redis URL. Put credentials in the URL itself, or connect through --sentinel or --cluster.`
     );
   }
 

--- a/packages/cli/src/config/flags.ts
+++ b/packages/cli/src/config/flags.ts
@@ -5,6 +5,7 @@ export const FLAG_OPTIONS = {
   sentinel: { type: 'string' },
   'sentinel-name': { type: 'string' },
   'sentinel-password': { type: 'string' },
+  cluster: { type: 'string' },
   'redis-username': { type: 'string' },
   'redis-password': { type: 'string' },
   'redis-db': { type: 'string' },

--- a/packages/cli/src/connectionState.ts
+++ b/packages/cli/src/connectionState.ts
@@ -11,20 +11,26 @@ export type ConnectionState =
 export function describeConnection(connection: ConnectionConfig): string {
   if (connection.mode === 'url') return maskRedisUrl(connection.url);
 
+  if (connection.mode === 'cluster') {
+    return `cluster://${connection.nodes.map(formatAddress).join(',')}`;
+  }
+
   const { name, sentinels, host, port, path } = connection.options;
   if (sentinels) {
     const addresses = sentinels
-      .map((sentinel) => {
-        const host = sentinel.host ?? 'localhost';
-
-        return `${host.includes(':') ? `[${host}]` : host}:${sentinel.port ?? 26379}`;
-      })
+      .map((sentinel) =>
+        formatAddress({ host: sentinel.host ?? 'localhost', port: sentinel.port ?? 26379 })
+      )
       .join(',');
 
     return `sentinel://${name}@${addresses}`;
   }
 
   return path ?? `redis://${host ?? 'localhost'}:${port ?? 6379}`;
+}
+
+function formatAddress({ host, port }: { host: string; port: number }): string {
+  return `${host.includes(':') ? `[${host}]` : host}:${port}`;
 }
 
 export function maskRedisUrl(redisUrl: string): string {

--- a/packages/cli/src/discovery/index.ts
+++ b/packages/cli/src/discovery/index.ts
@@ -1,4 +1,4 @@
-import type { Redis } from 'ioredis';
+import type { RedisClient } from '../redisClient';
 import { scanKeys } from './scan';
 
 export interface DiscoveredQueue {
@@ -27,7 +27,7 @@ function queueNameOf(key: string, prefix: string, marker: string): string | null
 }
 
 async function discoverInPrefix(
-  client: Redis,
+  client: RedisClient,
   prefix: string,
   found: Map<string, DiscoveredQueue>
 ): Promise<void> {
@@ -50,7 +50,7 @@ async function discoverInPrefix(
 }
 
 export async function discoverQueues(
-  client: Redis,
+  client: RedisClient,
   prefixes: string[]
 ): Promise<DiscoveredQueue[]> {
   const found = new Map<string, DiscoveredQueue>();
@@ -76,7 +76,7 @@ export async function discoverQueues(
 
 /** Explicitly named queues skip the scan; only their library still has to be established. */
 export async function probeQueues(
-  client: Redis,
+  client: RedisClient,
   prefix: string,
   names: string[]
 ): Promise<DiscoveredQueue[]> {

--- a/packages/cli/src/discovery/scan.ts
+++ b/packages/cli/src/discovery/scan.ts
@@ -1,15 +1,17 @@
-import type { Redis } from 'ioredis';
+import { scanTargets, type RedisClient } from '../redisClient';
 
 export async function scanKeys(
-  client: Redis,
+  client: RedisClient,
   pattern: string,
   onKey: (key: string) => void
 ): Promise<void> {
-  let cursor = '0';
+  for (const target of scanTargets(client)) {
+    let cursor = '0';
 
-  do {
-    const [next, keys] = await client.scan(cursor, 'MATCH', pattern, 'COUNT', 500);
-    cursor = next;
-    keys.forEach(onKey);
-  } while (cursor !== '0');
+    do {
+      const [next, keys] = await target.scan(cursor, 'MATCH', pattern, 'COUNT', 500);
+      cursor = next;
+      keys.forEach(onKey);
+    } while (cursor !== '0');
+  }
 }

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -11,8 +11,10 @@ Options:
       --sentinel-name <n> Redis master group name, required with --sentinel
       --sentinel-password <pass>
                           Password for the sentinel nodes themselves
+      --cluster <list>    Comma separated cluster host:port list, port [6379]
       --redis-username <name>
                           Username for the Redis nodes behind the sentinels
+                          or in the cluster
       --redis-password <pass>
                           Password for the Redis nodes behind the sentinels
       --redis-db <n>      Database to select behind the sentinels
@@ -51,15 +53,22 @@ throughput, latency and queue age into Redis under the bull-board:metrics:
 namespace once a minute. --read-only stops the recording but keeps serving
 whatever another process has recorded.
 
+--cluster connects to a Redis Cluster, taking a comma-separated list of
+startup nodes. Only BullMQ queues are served: Bull 3 builds keys without a
+hash tag, so on a cluster its commands fail, and such queues are skipped with
+a warning rather than shown broken. --history works, storing everything under
+one hash slot so its rollup script stays legal.
+
 --sentinel connects through Redis Sentinel instead of a URL, and the two are
 mutually exclusive. ioredis resolves the current master through the sentinels
 listed and follows a failover on its own, so queue reads, the Bull subscriber
 and --history recording all move with it. The credential flags above apply to
-sentinel mode only; with a Redis URL, put credentials in the URL itself.
+sentinel and cluster mode only; with a Redis URL, put credentials in the URL
+itself.
 
 Environment variables mirror every flag, for example BULL_BOARD_REDIS_URL,
-BULL_BOARD_SENTINELS, BULL_BOARD_SENTINEL_NAME, BULL_BOARD_PORT,
-BULL_BOARD_READ_ONLY.
+BULL_BOARD_SENTINELS, BULL_BOARD_SENTINEL_NAME, BULL_BOARD_CLUSTER_NODES,
+BULL_BOARD_PORT, BULL_BOARD_READ_ONLY.
 
 Examples:
   bull-board
@@ -67,4 +76,5 @@ Examples:
   bull-board --prefix tenant-a,tenant-b --read-only
   bull-board --user admin --password secret --host 0.0.0.0
   bull-board --sentinel s1:26379,s2:26379 --sentinel-name mymaster
+  bull-board --cluster n1:7000,n2:7000,n3:7000
 `;

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -1,9 +1,9 @@
 import type { BaseAdapter } from '@bull-board/api/baseAdapter';
 import type { MetricsHistoryProvider } from '@bull-board/api/typings/app';
 import { MetricsRecorder, RedisMetricsHistoryProvider } from '@bull-board/metrics';
-import type { Redis } from 'ioredis';
 import type { HistoryConfig } from './config/types';
 import { describeError } from './describeError';
+import type { RedisClient } from './redisClient';
 
 export interface HistoryRuntime {
   provider: MetricsHistoryProvider;
@@ -12,7 +12,7 @@ export interface HistoryRuntime {
 }
 
 export interface HistoryDeps {
-  client: Redis;
+  client: RedisClient;
   config: HistoryConfig;
   onWarning(message: string): void;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,12 @@
 import { createBullBoard } from '@bull-board/api';
 import { ExpressAdapter } from '@bull-board/express';
-import { Redis } from 'ioredis';
 import type { CliConfig } from './config/types';
 import { describeConnection, RETRY_INTERVAL_MS, type ConnectionState } from './connectionState';
 import { describeError } from './describeError';
 import { discoverQueues, probeQueues } from './discovery';
 import { createHistory, warnIfCountersUnavailable } from './history';
 import { createQueueFactory } from './queueFactory';
+import { createRedisClient } from './redisClient';
 import { QueueRegistry } from './registry';
 import { startServer } from './server';
 
@@ -72,10 +72,7 @@ export async function run(
       : { retryStrategy: () => RETRY_INTERVAL_MS }),
     ...config.connection.options,
   };
-  const client =
-    config.connection.mode === 'url'
-      ? new Redis(config.connection.url, redisOptions)
-      : new Redis(redisOptions);
+  const client = createRedisClient(config.connection, redisOptions, config.noRetry);
   const redisLabel = describeConnection(config.connection);
   let attemptError: Error | undefined;
   client.on('error', (error: Error) => {

--- a/packages/cli/src/queueFactory.ts
+++ b/packages/cli/src/queueFactory.ts
@@ -6,6 +6,7 @@ import { Queue as BullMQQueue } from 'bullmq';
 import type { Redis } from 'ioredis';
 import { describeError } from './describeError';
 import type { DiscoveredQueue } from './discovery';
+import { isCluster, type RedisClient } from './redisClient';
 import type { QueueHandle } from './registry';
 
 type BullRedisClient = ReturnType<NonNullable<BullQueue.QueueOptions['createClient']>>;
@@ -15,18 +16,18 @@ type BullMQConnection = NonNullable<ConstructorParameters<typeof BullMQQueue>[1]
 // both declare their client against a different copy of ioredis than the one the CLI holds. Same
 // client at runtime, two nominally distinct declarations. BullMQ 6 takes ioredis as an optional
 // peer and needs no cast.
-const asBullClient = (redis: Redis) => redis as unknown as BullRedisClient;
-const asBullMQConnection = (redis: Redis) => redis as unknown as BullMQConnection;
+const asBullClient = (redis: RedisClient) => redis as unknown as BullRedisClient;
+const asBullMQConnection = (redis: RedisClient) => redis as unknown as BullMQConnection;
 
 export interface QueueFactoryDeps {
-  client: Redis;
+  client: RedisClient;
   readOnly: boolean;
   queueOptions: Record<string, Partial<QueueAdapterOptions>>;
   onWarning(message: string): void;
 }
 
 export interface QueueFactory {
-  createQueue(discovered: DiscoveredQueue): QueueHandle;
+  createQueue(discovered: DiscoveredQueue): QueueHandle | null;
   close(): Promise<void>;
 }
 
@@ -37,8 +38,25 @@ export function createQueueFactory({
   onWarning,
 }: QueueFactoryDeps): QueueFactory {
   let bullSubscriber: Redis | undefined;
+  const clustered = isCluster(client);
+  const warnedAboutBull = new Set<string>();
 
-  function createQueue(discovered: DiscoveredQueue): QueueHandle {
+  function createQueue(discovered: DiscoveredQueue): QueueHandle | null {
+    // Bull 3 builds its keys without a hash tag and its Lua touches several at once, so on a
+    // cluster every command it issues is a CROSSSLOT away from failing. Skipping it beats
+    // showing a queue whose every action errors.
+    if (clustered && discovered.lib === 'bull') {
+      if (!warnedAboutBull.has(discovered.name)) {
+        warnedAboutBull.add(discovered.name);
+        onWarning(
+          `Skipping Bull queue "${discovered.name}": Bull 3 does not support Redis Cluster. ` +
+            'BullMQ queues on the same cluster are unaffected.'
+        );
+      }
+
+      return null;
+    }
+
     // QueueAdapterOptions.prefix is a display-name prefix, not the Redis key prefix.
     const options: Partial<QueueAdapterOptions> = {
       ...queueOptions[discovered.name],
@@ -68,7 +86,7 @@ export function createQueueFactory({
         if (type === 'client') return asBullClient(client);
         // Bull rejects a subscriber that has enableReadyCheck or maxRetriesPerRequest set.
         if (!bullSubscriber) {
-          bullSubscriber = client.duplicate({
+          bullSubscriber = (client as Redis).duplicate({
             enableReadyCheck: false,
             maxRetriesPerRequest: null,
           });

--- a/packages/cli/src/redisClient.ts
+++ b/packages/cli/src/redisClient.ts
@@ -1,0 +1,31 @@
+import { Cluster, Redis } from 'ioredis';
+import type { ConnectionConfig } from './config/connection';
+
+export type RedisClient = Redis | Cluster;
+
+export function isCluster(client: RedisClient): client is Cluster {
+  return typeof (client as Partial<Cluster>).nodes === 'function';
+}
+
+/** SCAN carries no key, so a cluster client would answer from one arbitrary master. */
+export function scanTargets(client: RedisClient): RedisClient[] {
+  return isCluster(client) ? client.nodes('master') : [client];
+}
+
+export function createRedisClient(
+  connection: ConnectionConfig,
+  redisOptions: Record<string, unknown>,
+  noRetry: boolean
+): RedisClient {
+  if (connection.mode === 'cluster') {
+    return new Cluster(connection.nodes, {
+      lazyConnect: true,
+      redisOptions,
+      ...(noRetry ? { clusterRetryStrategy: () => null } : {}),
+    });
+  }
+
+  return connection.mode === 'url'
+    ? new Redis(connection.url, redisOptions)
+    : new Redis(redisOptions);
+}

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -13,7 +13,7 @@ export interface BoardApi {
 
 export interface QueueRegistryDeps {
   board: BoardApi;
-  createQueue(queue: DiscoveredQueue): QueueHandle;
+  createQueue(queue: DiscoveredQueue): QueueHandle | null;
   onWarning(message: string): void;
 }
 
@@ -49,7 +49,7 @@ export class QueueRegistry {
     for (const [key, queue] of wanted) {
       if (this.live.has(key)) continue;
 
-      let handle: QueueHandle;
+      let handle: QueueHandle | null;
       try {
         handle = this.deps.createQueue(queue);
       } catch (error) {
@@ -58,6 +58,7 @@ export class QueueRegistry {
         );
         continue;
       }
+      if (!handle) continue;
 
       this.live.set(key, handle);
       this.deps.board.addQueue(handle.adapter);

--- a/packages/cli/tests/cli.spec.ts
+++ b/packages/cli/tests/cli.spec.ts
@@ -6,13 +6,17 @@ import { join } from 'node:path';
 import type { Readable } from 'node:stream';
 import BullQueue from 'bull';
 import { Queue as BullMQQueue } from 'bullmq';
-import { Redis } from 'ioredis';
+import { Cluster, Redis } from 'ioredis';
 import { startFakeSentinel } from './fakeSentinel';
 
 const REDIS_HOST = process.env.REDIS_HOST || 'localhost';
 const REDIS_PORT = process.env.REDIS_PORT || '6379';
 const REDIS_URL = `redis://${REDIS_HOST}:${REDIS_PORT}`;
 const redisOptions = { host: REDIS_HOST, port: +REDIS_PORT };
+
+const CLUSTER_NODES = process.env.REDIS_CLUSTER_NODES || '';
+
+type BullMQConnection = NonNullable<ConstructorParameters<typeof BullMQQueue>[1]>['connection'];
 
 const CLI_ROOT = join(__dirname, '..');
 const BIN_PATH = join(CLI_ROOT, 'dist', 'bin.js');
@@ -289,6 +293,148 @@ describe('cli', () => {
       await queue.close();
       await sentinel.close();
     }
+  });
+
+  const describeCluster = CLUSTER_NODES ? describe : describe.skip;
+
+  describeCluster('against a Redis Cluster', () => {
+    // BullMQ requires a hash-tagged prefix in cluster mode, so one queue's keys stay in one
+    // slot. The board reads whatever prefix it is pointed at.
+    const CLUSTER_PREFIX = '{bull-cluster-e2e}';
+    // Built in beforeAll rather than here: jest evaluates a skipped describe's body, so a
+    // client created at collection time would connect even with no cluster to connect to.
+    let cluster: Cluster;
+    let clusterConnection: { prefix: string; connection: BullMQConnection };
+
+    beforeAll(async () => {
+      cluster = new Cluster(
+        CLUSTER_NODES.split(',').map((entry) => {
+          const [host, port] = entry.split(':');
+
+          return { host, port: Number(port) };
+        }),
+        { redisOptions: { maxRetriesPerRequest: null } }
+      );
+      await cluster.ping();
+      // Bull and BullMQ pin their own ioredis, so their declarations are nominally distinct
+      // from the one this spec holds. Same client at runtime, as `queueFactory` casts it too.
+      clusterConnection = {
+        prefix: CLUSTER_PREFIX,
+        connection: cluster as unknown as BullMQConnection,
+      };
+    }, 30000);
+
+    afterAll(async () => {
+      await cluster?.quit();
+    });
+
+    it('serves a BullMQ queue discovered across every master', async () => {
+      const queueName = unique('cluster-disc');
+      const queue = new BullMQQueue(queueName, clusterConnection);
+      await queue.add('seed', {});
+
+      try {
+        const cli = await startCli([
+          '--cluster',
+          CLUSTER_NODES,
+          '--prefix',
+          CLUSTER_PREFIX,
+          '--scan-interval',
+          '0',
+          '--port',
+          '0',
+        ]);
+
+        try {
+          const response = await fetch(`${cli.url}/api/queues`);
+          const body = (await response.json()) as {
+            queues: Array<{ name: string; counts: Record<string, number> }>;
+          };
+
+          expect(response.status).toBe(200);
+          expect(body.queues.find((entry) => entry.name === queueName)?.counts.waiting).toBe(1);
+        } finally {
+          await cli.stop();
+        }
+      } finally {
+        await queue.obliterate({ force: true });
+        await queue.close();
+      }
+    });
+
+    it('records history into the cluster and reports it back', async () => {
+      const queueName = unique('cluster-history');
+      const queue = new BullMQQueue(queueName, clusterConnection);
+      await queue.add('seed', {});
+
+      try {
+        const cli = await startCli([
+          '--cluster',
+          CLUSTER_NODES,
+          '--prefix',
+          CLUSTER_PREFIX,
+          '--history',
+          '--scan-interval',
+          '0',
+          '--port',
+          '0',
+        ]);
+
+        try {
+          const deadline = Date.now() + 10000;
+          let keys = 0;
+          while (Date.now() < deadline && keys === 0) {
+            const response = await fetch(`${cli.url}/api/metrics/history/usage`);
+            keys = ((await response.json()) as { keys: number }).keys;
+            if (keys === 0) await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+
+          expect(keys).toBeGreaterThan(0);
+        } finally {
+          await cli.stop();
+        }
+      } finally {
+        await queue.obliterate({ force: true });
+        await queue.close();
+        await Promise.all(
+          cluster.nodes('master').map(async (node) => {
+            const keys = await node.keys('{bull-board:metrics}:*');
+
+            return keys.length > 0 ? node.unlink(...keys) : 0;
+          })
+        );
+      }
+    });
+
+    it('skips a Bull 3 queue rather than serving one whose every command would fail', async () => {
+      const queueName = unique('cluster-bull3');
+      await cluster.set(`${CLUSTER_PREFIX}:${queueName}:id`, '0');
+
+      try {
+        const cli = await startCli([
+          '--cluster',
+          CLUSTER_NODES,
+          '--prefix',
+          CLUSTER_PREFIX,
+          '--scan-interval',
+          '0',
+          '--port',
+          '0',
+        ]);
+
+        try {
+          const response = await fetch(`${cli.url}/api/queues`);
+          const body = (await response.json()) as { queues: Array<{ name: string }> };
+
+          expect(body.queues.map((entry) => entry.name)).not.toContain(queueName);
+          expect(cli.stdout() + cli.stderr()).toContain(`Skipping Bull queue "${queueName}"`);
+        } finally {
+          await cli.stop();
+        }
+      } finally {
+        await cluster.del(`${CLUSTER_PREFIX}:${queueName}:id`);
+      }
+    });
   });
 
   it('discovers a BullMQ queue and a Bull queue through the real binary', async () => {
@@ -707,7 +853,7 @@ describe('cli', () => {
       ]);
 
       expect(code).not.toBe(0);
-      expect(stderr).toMatch(/not both/);
+      expect(stderr).toMatch(/Use only one of a Redis URL and --sentinel/);
     });
 
     it('exits non-zero and points at --help for an unknown flag', async () => {

--- a/packages/cli/tests/connection.spec.ts
+++ b/packages/cli/tests/connection.spec.ts
@@ -112,6 +112,65 @@ describe('resolveConnection', () => {
     }
   );
 
+  it('builds cluster nodes from a host list, defaulting the port to 6379', () => {
+    expect(resolve(['--cluster', 'a.example:7001, b.example'])).toEqual({
+      mode: 'cluster',
+      nodes: [
+        { host: 'a.example', port: 7001 },
+        { host: 'b.example', port: 6379 },
+      ],
+      options: {},
+    });
+  });
+
+  it('reads cluster nodes from the environment', () => {
+    const connection = resolve([], {
+      BULL_BOARD_CLUSTER_NODES: 'a.example:7001,b.example:7002',
+    } as NodeJS.ProcessEnv);
+
+    expect(connection).toMatchObject({ mode: 'cluster' });
+  });
+
+  it('passes data node credentials through to the cluster', () => {
+    expect(
+      resolve([
+        '--cluster',
+        'a.example:7001',
+        '--redis-username',
+        'reader',
+        '--redis-password',
+        'secret',
+      ])
+    ).toMatchObject({
+      mode: 'cluster',
+      options: { username: 'reader', password: 'secret' },
+    });
+  });
+
+  it('brackets an IPv6 cluster node the same way a sentinel one is', () => {
+    expect(resolve(['--cluster', '::1'])).toMatchObject({
+      nodes: [{ host: '::1', port: 6379 }],
+    });
+  });
+
+  it('rejects an unparseable cluster node', () => {
+    expect(() => resolve(['--cluster', 'a.example:nope'])).toThrow(
+      'Invalid cluster node address "a.example:nope"'
+    );
+  });
+
+  it('rejects a database selection, which a cluster does not have', () => {
+    expect(() => resolve(['--cluster', 'a.example', '--redis-db', '3'])).toThrow(
+      '--redis-db cannot be used with --cluster'
+    );
+  });
+
+  it('rejects a cluster alongside sentinels', () => {
+    expect(() =>
+      resolve(['--cluster', 'a.example', '--sentinel', 'b.example', '--sentinel-name', 'm'])
+    ).toThrow('Use only one of --sentinel and --cluster.');
+  });
+
   it('rejects an explicit Redis URL alongside sentinels', () => {
     expect(() =>
       resolve([
@@ -122,7 +181,7 @@ describe('resolveConnection', () => {
         '--sentinel-name',
         'm',
       ])
-    ).toThrow('Use either a Redis URL or --sentinel, not both.');
+    ).toThrow('Use only one of a Redis URL and --sentinel.');
   });
 
   it('rejects credential flags alongside a Redis URL, which would silently ignore them', () => {

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -68,6 +68,8 @@ Standalone keys are untagged and unchanged, so nothing moves for an existing dep
 
 Latency sampling reads BullMQ's own keys through the same connection, so your queues need the hash-tagged prefix BullMQ already asks for in cluster mode (`new Queue(name, { prefix: '{bull}' })`). Without it the sampler's pipelines span slots; it swallows that error, so pass `onLatencyError` to see it.
 
+The CLI and the Docker image reach a cluster with `--cluster`, where `--history` works the same way.
+
 ## Job latency
 
 Alongside the completed/failed counters, the recorder tracks two histograms per queue: wait time (`processedOn - timestamp`, how long a job sat before a worker picked it up) and run time (`finishedOn - processedOn`, how long the handler took). They diagnose different problems, so they're kept separate rather than combined into one number.

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -41,8 +41,10 @@ Options:
       --sentinel-name <n> Redis master group name, required with --sentinel
       --sentinel-password <pass>
                           Password for the sentinel nodes themselves
+      --cluster <list>    Comma separated cluster host:port list, port [6379]
       --redis-username <name>
                           Username for the Redis nodes behind the sentinels
+                          or in the cluster
       --redis-password <pass>
                           Password for the Redis nodes behind the sentinels
       --redis-db <n>      Database to select behind the sentinels
@@ -77,6 +79,7 @@ Every flag has an environment variable equivalent, so you can configure the CLI 
 | `--sentinel` | `BULL_BOARD_SENTINELS` |
 | `--sentinel-name` | `BULL_BOARD_SENTINEL_NAME` |
 | `--sentinel-password` | `BULL_BOARD_SENTINEL_PASSWORD` |
+| `--cluster` | `BULL_BOARD_CLUSTER_NODES` |
 | `--redis-username` | `BULL_BOARD_REDIS_USERNAME` |
 | `--redis-password` | `BULL_BOARD_REDIS_PASSWORD` |
 | `--redis-db` | `BULL_BOARD_REDIS_DB` |
@@ -185,6 +188,28 @@ module.exports = {
 ```
 
 That is the way to reach TLS to the sentinel nodes, `natMap` for a NAT-ed cluster, `preferredSlaves`, or a custom `sentinelRetryStrategy`. The object form is not limited to Sentinel: a plain `{ host, port, tls }` works too, wherever a URL is awkward. Credential flags still apply on top of an object, so a password can stay in the environment instead of the file.
+
+## Redis Cluster
+
+`--cluster` takes a comma-separated list of startup nodes and connects through them, the way `--redis` and `--sentinel` do for their topologies. ioredis discovers the rest of the cluster from any node that answers, so listing two or three is enough:
+
+```sh
+npx @bull-board/cli --cluster n1:7000,n2:7000,n3:7000 --prefix '{bull}'
+```
+
+`--redis-username` and `--redis-password` apply here as they do in sentinel mode. `--redis-db` does not: a cluster only has database 0, and passing it is an error rather than a silent no-op.
+
+Your queues need the hash-tagged prefix BullMQ already asks for in cluster mode, so one queue's keys stay in one slot:
+
+```ts
+new Queue('mailer', { connection, prefix: '{bull}' });
+```
+
+Point `--prefix` at the same string, braces included. Discovery scans every master rather than one, since `SCAN` carries no key for the client to route by.
+
+Only BullMQ queues are served. Bull 3 builds its keys without a hash tag and its Lua touches several at once, so on a cluster every command it issues is a `CROSSSLOT` away from failing; such a queue is skipped with a warning naming it, rather than shown on the board with every action broken. BullMQ queues on the same cluster are unaffected.
+
+[`--history`](#historical-metrics) works, storing everything under a single hash slot so its rollup script stays legal. The [historical metrics recipe](/recipes/historical-metrics#redis-cluster) covers what that means for the key layout.
 
 ## Basic auth
 
@@ -296,5 +321,7 @@ curl -s http://127.0.0.1:3000/api/queues | jq '.queues[] | {name, counts, isPaus
 ## What it doesn't do yet
 
 Discovery only reads Redis. BullMQ v6 queues backed by PostgreSQL aren't found or servable through the CLI; use a server adapter in your own app for those, see the [PostgreSQL backend recipe](/recipes/postgres-backend).
+
+Bull 3 queues aren't servable on a Redis Cluster, since Bull builds its keys without a hash tag. They're skipped with a warning; BullMQ queues on the same cluster work normally.
 
 `--prefix` also doesn't take wildcards. A queue's Redis key and its name can both contain colons, so there's no reliable way to guess where a wildcard prefix ends and the queue name begins. List the prefixes you need explicitly instead, for example `--prefix bull,tenant-a,tenant-b`.

--- a/website/docs/recipes/historical-metrics.md
+++ b/website/docs/recipes/historical-metrics.md
@@ -324,7 +324,7 @@ Standalone keys are untagged and unchanged, so an existing deployment keeps the 
 
 Latency sampling reads BullMQ's own keys over the same connection, so your queues need the hash-tagged prefix BullMQ already requires in cluster mode (`new Queue(name, { prefix: '{bull}' })`). Without one a queue's keys scatter across slots and the sampler's pipelines are rejected; it swallows that error to protect the counter snapshot, so pass `onLatencyError` if you want to see it.
 
-The [CLI](/guide/cli) and the Docker image cannot reach a cluster at all: they build a plain client from a URL or from Sentinel. Cluster support there is a separate piece of work.
+The [CLI](/guide/cli#redis-cluster) and the Docker image reach a cluster with `--cluster`, and `--history` works there the same way.
 
 ## Scope
 


### PR DESCRIPTION
Follows #1436, now merged, which made `@bull-board/metrics` work on a cluster. This does the same for the CLI and the Docker image, so the "cluster support is library-only" caveat in that PR goes away.

Rebased onto `master`, so the diff below is now this one commit and 17 files. #1438, which was stacked behind this branch, has been rebased onto `master` as well and no longer depends on it, so the two can be merged in either order.

## What changes

`--cluster` takes a comma-separated list of startup nodes, alongside `--redis` and `--sentinel` and mutually exclusive with both. `BULL_BOARD_CLUSTER_NODES` mirrors it. Node addresses are parsed by the same helper the sentinel list uses, including the IPv6 bracketing, with the port defaulting to 6379.

```sh
npx @bull-board/cli --cluster n1:7000,n2:7000,n3:7000 --prefix '{bull}'
```

Discovery scans every master rather than one, for the same reason the metrics admin had to: `SCAN` carries no key, so ioredis routes it to an arbitrary node.

`--redis-username` and `--redis-password` apply as they do in sentinel mode. `--redis-db` is rejected, since a cluster only has database 0 and passing it would otherwise be a silent no-op.

**Bull 3 queues are skipped, with a warning naming the queue.** Bull builds its keys without a hash tag and its Lua touches several at once, so on a cluster every command it issues fails with `CROSSSLOT`. Showing the queue and letting each action error is worse than not showing it. BullMQ queues on the same cluster are unaffected.

## Testing

Three cases in `packages/cli/tests/cli.spec.ts`, against the real three-master cluster #1436 added to `docker-compose.redis.yml`, skipped without `REDIS_CLUSTER_NODES`: a BullMQ queue discovered and served, `--history` recording into the cluster and reporting usage back, and a Bull 3 queue skipped rather than served. Plus config-level cases for parsing, credentials, IPv6, the rejected `--redis-db` and the mode conflicts.

Verified by hand as well: the CLI serves a BullMQ queue off the cluster, and `--history` writes `{bull-board:metrics}:...` keys and answers `/api/metrics/history/usage` with a footprint gathered from all three masters.

CLI suite: 142 pass with a cluster, 139 pass and 3 skip without one.
