### PR TITLE
fix(api): report the whole cluster in redis stats, not one arbitrary node

### DIFF
--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -21,6 +21,7 @@ import {
 import { DATASTORES } from '../constants/datastores';
 import { STATUSES } from '../constants/statuses';
 import { BaseAdapter } from './base';
+import { clusterInfo, isCluster } from './clusterInfo';
 
 /** The `:w:<name>` suffix BullMQ appends to the connection name of a named worker. */
 const WORKER_NAME_SEPARATOR = ':w:';
@@ -76,7 +77,11 @@ export class BullMQAdapter extends BaseAdapter {
 
   public async getRedisInfo(): Promise<string | null> {
     const client = await this.resolveRedisClient();
-    return client ? client.info() : null;
+    if (!client) {
+      return null;
+    }
+
+    return isCluster(client) ? clusterInfo(client) : client.info();
   }
 
   private async resolveRedisClient(): Promise<RedisClient | null> {

--- a/packages/api/src/queueAdapters/clusterInfo.ts
+++ b/packages/api/src/queueAdapters/clusterInfo.ts
@@ -1,0 +1,63 @@
+interface ClusterLike {
+  nodes(role: 'master'): { info(): Promise<string> }[];
+}
+
+const ADDITIVE_FIELDS = [
+  'used_memory',
+  'used_memory_peak',
+  'maxmemory',
+  'total_system_memory',
+  'connected_clients',
+  'blocked_clients',
+];
+
+const MINIMUM_FIELDS = ['uptime_in_seconds', 'uptime_in_days'];
+
+export function isCluster(client: unknown): client is ClusterLike {
+  return typeof (client as Partial<ClusterLike>)?.nodes === 'function';
+}
+
+function parseFields(info: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const line of info.split(/\r?\n/)) {
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+    const separator = line.indexOf(':');
+    if (separator > 0) {
+      fields.set(line.slice(0, separator), line.slice(separator + 1));
+    }
+  }
+
+  return fields;
+}
+
+// INFO carries no key, so a cluster client answers it from an arbitrary node: one node's
+// memory and client counts, flipping to another node's on the next poll. Hence the merge.
+export async function clusterInfo(client: ClusterLike): Promise<string | null> {
+  const masters = client.nodes('master');
+  if (masters.length === 0) {
+    return null;
+  }
+
+  const parsed = (await Promise.all(masters.map((node) => node.info()))).map(parseFields);
+  const merged = new Map(parsed[0]);
+
+  for (const field of ADDITIVE_FIELDS) {
+    const values = parsed.map((fields) => Number(fields.get(field))).filter(Number.isFinite);
+    if (values.length > 0) {
+      merged.set(field, String(values.reduce((sum, value) => sum + value, 0)));
+    }
+  }
+
+  for (const field of MINIMUM_FIELDS) {
+    const values = parsed.map((fields) => Number(fields.get(field))).filter(Number.isFinite);
+    if (values.length > 0) {
+      merged.set(field, String(Math.min(...values)));
+    }
+  }
+
+  merged.set('cluster_known_nodes', String(masters.length));
+
+  return [...merged].map(([field, value]) => `${field}:${value}`).join('\r\n');
+}

--- a/packages/api/tests/api/cluster.spec.ts
+++ b/packages/api/tests/api/cluster.spec.ts
@@ -1,0 +1,140 @@
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { Queue, Worker } from 'bullmq';
+import { Cluster } from 'ioredis';
+import request from 'supertest';
+
+const CLUSTER_NODES = process.env.REDIS_CLUSTER_NODES || '';
+// BullMQ needs a hash-tagged prefix on a cluster, so one queue's keys stay in one slot.
+const PREFIX = '{board-cluster}';
+
+if (!CLUSTER_NODES) {
+  describe.skip('Board on a Redis Cluster (skipped: REDIS_CLUSTER_NODES is not set)', () => {
+    it('needs a cluster to talk to', () => undefined);
+  });
+} else {
+  describe('Board on a Redis Cluster', () => {
+    let cluster: Cluster;
+    let queue: Queue;
+    let worker: Worker | undefined;
+    let name: string;
+
+    beforeAll(async () => {
+      cluster = new Cluster(
+        CLUSTER_NODES.split(',').map((entry) => {
+          const [host, port] = entry.split(':');
+
+          return { host, port: Number(port) };
+        }),
+        { redisOptions: { maxRetriesPerRequest: null } }
+      );
+      await cluster.ping();
+    }, 30000);
+
+    afterAll(async () => {
+      await cluster.quit();
+    });
+
+    beforeEach(async () => {
+      name = `cluster-board-${process.pid}-${Date.now()}`;
+      queue = new Queue(name, { connection: cluster as never, prefix: PREFIX });
+      await queue.waitUntilReady();
+    });
+
+    afterEach(async () => {
+      await worker?.close();
+      worker = undefined;
+      await queue.obliterate({ force: true }).catch(() => undefined);
+      await queue.close();
+    });
+
+    function board() {
+      const serverAdapter = new ExpressAdapter();
+      createBullBoard({ queues: [new BullMQAdapter(queue)], serverAdapter });
+
+      return request(serverAdapter.getRouter());
+    }
+
+    it('serves the queue, its counts and its jobs', async () => {
+      await queue.addBulk([
+        { name: 'a', data: { i: 1 } },
+        { name: 'b', data: { i: 2 } },
+      ]);
+
+      const res = await board().get('/api/queues').expect(200);
+
+      const served = res.body.queues.find((entry: { name: string }) => entry.name === name);
+      expect(served.counts.waiting).toBe(2);
+
+      const waiting = await board()
+        .get('/api/queues')
+        .query({ activeQueue: name, status: 'waiting' })
+        .expect(200);
+
+      expect(
+        waiting.body.queues.find((entry: { name: string }) => entry.name === name).jobs
+      ).toHaveLength(2);
+    });
+
+    it('adds, retries and removes a job through the API', async () => {
+      await board()
+        .post(`/api/queues/${encodeURIComponent(name)}/add`)
+        .send({ name: 'added', data: { hello: 'world' } })
+        .expect(200);
+
+      worker = new Worker(
+        name,
+        async (): Promise<unknown> => {
+          throw new Error('boom');
+        },
+        {
+          connection: cluster as never,
+          prefix: PREFIX,
+        }
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const failed = await queue.getFailed();
+      expect(failed).toHaveLength(1);
+      await worker.close();
+      worker = undefined;
+
+      await board()
+        .put(`/api/queues/${encodeURIComponent(name)}/${failed[0].id}/retry`)
+        .expect(204);
+
+      expect(await (await queue.getJob(failed[0].id!))!.getState()).toBe('waiting');
+      await board()
+        .put(`/api/queues/${encodeURIComponent(name)}/pause`)
+        .expect(200);
+
+      expect(await queue.isPaused()).toBe(true);
+    });
+
+    it('reports the whole cluster in the stats panel, not one arbitrary node', async () => {
+      const responses = await Promise.all(
+        Array.from({ length: 5 }, () => board().get('/api/redis/stats').expect(200))
+      );
+      const bodies = responses.map((res) => res.body);
+
+      expect(bodies[0].backend).toBe('redis');
+      expect(bodies[0].mode).toBe('cluster');
+      expect(new Set(bodies.map((body) => body.memory.used)).size).toBeGreaterThan(0);
+      expect(new Set(bodies.map((body) => body.clients.connected)).size).toBe(1);
+
+      const perNode = await Promise.all(
+        cluster.nodes('master').map(async (node) => {
+          const info = await node.info();
+
+          return Number(/used_memory:(\d+)/.exec(info)?.[1] ?? 0);
+        })
+      );
+      const total = perNode.reduce((sum, used) => sum + used, 0);
+      const largest = Math.max(...perNode);
+
+      expect(bodies[0].memory.used).toBeGreaterThan(largest);
+      expect(bodies[0].memory.used).toBeCloseTo(total, -7);
+    });
+  });
+}

--- a/packages/api/tests/queueAdapters/clusterInfo.spec.ts
+++ b/packages/api/tests/queueAdapters/clusterInfo.spec.ts
@@ -1,0 +1,103 @@
+import { clusterInfo, isCluster } from '../../src/queueAdapters/clusterInfo';
+
+function node(fields: Record<string, string | number>) {
+  return {
+    info: async () =>
+      ['# Server', ...Object.entries(fields).map(([key, value]) => `${key}:${value}`)].join('\r\n'),
+  };
+}
+
+function fakeCluster(...nodes: ReturnType<typeof node>[]) {
+  return { nodes: () => nodes };
+}
+
+function parse(info: string | null): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of (info ?? '').split('\r\n')) {
+    const at = line.indexOf(':');
+    if (at > 0) out[line.slice(0, at)] = line.slice(at + 1);
+  }
+
+  return out;
+}
+
+describe('clusterInfo', () => {
+  it('tells a cluster client from a plain one', () => {
+    expect(isCluster({ nodes: () => [] })).toBe(true);
+    expect(isCluster({ info: async () => '' })).toBe(false);
+    expect(isCluster(null)).toBe(false);
+  });
+
+  it('sums the fields that only describe the cluster once added up', async () => {
+    const merged = parse(
+      await clusterInfo(
+        fakeCluster(
+          node({
+            used_memory: 100,
+            used_memory_peak: 150,
+            connected_clients: 3,
+            blocked_clients: 1,
+          }),
+          node({
+            used_memory: 200,
+            used_memory_peak: 250,
+            connected_clients: 4,
+            blocked_clients: 0,
+          }),
+          node({
+            used_memory: 300,
+            used_memory_peak: 350,
+            connected_clients: 5,
+            blocked_clients: 2,
+          })
+        )
+      )
+    );
+
+    expect(merged.used_memory).toBe('600');
+    expect(merged.used_memory_peak).toBe('750');
+    expect(merged.connected_clients).toBe('12');
+    expect(merged.blocked_clients).toBe('3');
+  });
+
+  it('reports the youngest node as the uptime, since the cluster is only as old as that', async () => {
+    const merged = parse(
+      await clusterInfo(
+        fakeCluster(
+          node({ uptime_in_seconds: 90000, uptime_in_days: 1 }),
+          node({ uptime_in_seconds: 120, uptime_in_days: 0 })
+        )
+      )
+    );
+
+    expect(merged.uptime_in_seconds).toBe('120');
+    expect(merged.uptime_in_days).toBe('0');
+  });
+
+  it('keeps the fields every node agrees on, and counts the masters', async () => {
+    const merged = parse(
+      await clusterInfo(
+        fakeCluster(
+          node({ redis_version: '7.4.1', redis_mode: 'cluster', os: 'Linux', used_memory: 10 }),
+          node({ redis_version: '7.4.1', redis_mode: 'cluster', os: 'Linux', used_memory: 20 })
+        )
+      )
+    );
+
+    expect(merged.redis_version).toBe('7.4.1');
+    expect(merged.redis_mode).toBe('cluster');
+    expect(merged.os).toBe('Linux');
+    expect(merged.cluster_known_nodes).toBe('2');
+  });
+
+  it('skips a field no node reports rather than writing NaN', async () => {
+    const merged = parse(await clusterInfo(fakeCluster(node({ used_memory: 10 }))));
+
+    expect(merged).not.toHaveProperty('maxmemory');
+    expect(merged.used_memory).toBe('10');
+  });
+
+  it('answers null when the client knows of no master', async () => {
+    expect(await clusterInfo(fakeCluster())).toBeNull();
+  });
+});

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -209,7 +209,7 @@ Point `--prefix` at the same string, braces included. Discovery scans every mast
 
 Only BullMQ queues are served. Bull 3 builds its keys without a hash tag and its Lua touches several at once, so on a cluster every command it issues is a `CROSSSLOT` away from failing; such a queue is skipped with a warning naming it, rather than shown on the board with every action broken. BullMQ queues on the same cluster are unaffected.
 
-[`--history`](#historical-metrics) works, storing everything under a single hash slot so its rollup script stays legal. The [historical metrics recipe](/recipes/historical-metrics#redis-cluster) covers what that means for the key layout.
+The Redis stats panel reports the cluster as a whole, summing memory and client counts across the masters. [`--history`](#historical-metrics) works, storing everything under a single hash slot so its rollup script stays legal. The [historical metrics recipe](/recipes/historical-metrics#redis-cluster) covers what that means for the key layout.
 
 ## Basic auth
 

--- a/website/docs/recipes/historical-metrics.md
+++ b/website/docs/recipes/historical-metrics.md
@@ -324,6 +324,8 @@ Standalone keys are untagged and unchanged, so an existing deployment keeps the 
 
 Latency sampling reads BullMQ's own keys over the same connection, so your queues need the hash-tagged prefix BullMQ already requires in cluster mode (`new Queue(name, { prefix: '{bull}' })`). Without one a queue's keys scatter across slots and the sampler's pipelines are rejected; it swallows that error to protect the counter snapshot, so pass `onLatencyError` if you want to see it.
 
+The board's own Redis stats panel is cluster-aware too: memory and client counts are summed across the masters and the uptime is the youngest node's, rather than reporting whichever node `INFO` happened to reach.
+
 The [CLI](/guide/cli#redis-cluster) and the Docker image reach a cluster with `--cluster`, and `--history` works there the same way.
 
 ## Scope


### PR DESCRIPTION
Last of the Redis Cluster set, and the only one that affects the board itself rather than the metrics package or the CLI.

#1436 and #1437 are both merged, so the stack is gone and this is rebased onto current `master`: one commit, 6 files. The three-master cluster its tests need is already in `docker-compose.redis.yml` and already wired into CI.

`INFO` carries no key, so a cluster client has no slot to route it by and ioredis answers it from an arbitrary node. `BullMQAdapter.getRedisInfo()` feeds the board's Redis stats panel straight from that, so on a cluster the panel shows one node's memory, client count, uptime and port as if they were the whole cluster's, and switches to a different node's on the next poll. Eight consecutive calls against a three-master cluster came back from two different nodes:

```
getRedisInfo x8: answered by 2 distinct node(s): 7101/56372345 7102/957d1234
```

This is the same bug class as the `SCAN` one in #1436, and it predates that PR: it affects anyone pointing bull-board at a cluster-backed queue, with or without `@bull-board/metrics`.

## What changes

`getRedisInfo()` now merges `INFO` from every master when the client is a cluster. The additive fields (`used_memory`, `used_memory_peak`, `maxmemory`, `total_system_memory`, `connected_clients`, `blocked_clients`) are summed, uptime is the youngest node's, since the cluster is only as old as that, and everything the nodes agree on (version, mode, os) comes from the first. The result is still an `INFO` payload, so `redisStats.ts` and everything downstream keep parsing it unchanged, and `cluster_known_nodes` is set so the master count is available.

Standalone connections are untouched: they take the same `client.info()` path as before.

## Testing

`tests/queueAdapters/clusterInfo.spec.ts` covers the merge as a pure function, so it runs everywhere rather than only where a cluster exists: summing, the uptime minimum, agreed fields, a field no node reports, and an empty master list.

`tests/api/cluster.spec.ts` drives a real board over a real three-master cluster, skipped without `REDIS_CLUSTER_NODES` like the other cluster specs: serving a queue with its counts and jobs, adding, retrying and pausing through the API, and the stats panel reporting a total larger than any single node's and stable across repeated polls.

Reverting the merge turns that last case red (`Expected: > 3863280, Received: 3853496`, the arbitrary node's own memory) and leaves the other two green.
