### PR TITLE
fix(api): name flow nodes as the board registered them

### DIFF
--- a/packages/api/src/handlers/jobFlow.ts
+++ b/packages/api/src/handlers/jobFlow.ts
@@ -58,13 +58,13 @@ function countDependencies(dependencies: FlowNode['dependencies']): number {
   );
 }
 
-function toFlowNode(node: JobNode): FlowNode {
+function toFlowNode(node: JobNode, resolveQueueName: (job: Job) => string): FlowNode {
   return {
     id: node.job.id as string,
     name: node.job.name,
     progress: node.job.progress,
     state: 'unknown',
-    queueName: node.job.queueName,
+    queueName: resolveQueueName(node.job),
     children: [],
   };
 }
@@ -89,14 +89,15 @@ function nodeBudget({ depth, maxChildren }: FlowWindow): number {
 
 async function simplifyTree(
   root: JobNode | null | undefined,
-  window: FlowWindow
+  window: FlowWindow,
+  resolveQueueName: (job: Job) => string
 ): Promise<FlowNode | null> {
   if (!root || !root.job.id) {
     return null;
   }
 
   const budget = nodeBudget(window);
-  const rootNode = toFlowNode(root);
+  const rootNode = toFlowNode(root, resolveQueueName);
   const hydrated: [Job, FlowNode][] = [[root.job, rootNode]];
   const vanished = new Map<FlowNode, number>();
   let frontier: [JobNode, FlowNode][] = [[root, rootNode]];
@@ -118,7 +119,7 @@ async function simplifyTree(
           continue;
         }
 
-        const childNode = toFlowNode(child);
+        const childNode = toFlowNode(child, resolveQueueName);
         target.children.push(childNode);
         hydrated.push([child.job, childNode]);
         frontier.push([child, childNode]);
@@ -155,7 +156,8 @@ async function getJobFlow(
     return emptyNodeResponse(jobId!);
   }
 
-  const { findFlowRoot, getFlowTree } = await import('../providers/flow'); // required to allow separation between bull & bullMQ
+  const { buildBoardQueueNameResolver, findFlowRoot, getFlowTree } =
+    await import('../providers/flow'); // required to allow separation between bull & bullMQ
   const root =
     req.query.root === 'node'
       ? { queueName: queue.getName(), jobId: jobId as string }
@@ -167,7 +169,8 @@ async function getJobFlow(
 
   const window = readFlowWindow(req.query);
   const flowTree = await getFlowTree(req.queues, root.queueName, root.jobId, window);
-  const rootSimplified = await simplifyTree(flowTree, window);
+  const resolveQueueName = buildBoardQueueNameResolver(req.queues);
+  const rootSimplified = await simplifyTree(flowTree, window, resolveQueueName);
 
   return {
     status: 200,

--- a/packages/api/src/providers/flow.ts
+++ b/packages/api/src/providers/flow.ts
@@ -1,4 +1,4 @@
-import type { FlowProducer, Job, JobNode } from 'bullmq';
+import type { Job, JobNode } from 'bullmq';
 import { BullMQAdapter } from '../queueAdapters/bullMQ';
 import { BullBoardQueues } from '../types';
 
@@ -11,26 +11,23 @@ function findBullMQAdapter(queues: BullBoardQueues): BullMQAdapter | null {
   return null;
 }
 
-// The producer comes from the flow root's own adapter, so on a board mixing backends or
-// connections the tree is read from the datastore it lives in. The first bullmq adapter is
-// only a fallback for a root whose queue is not registered on the board.
-function getFlowProducer(queues: BullBoardQueues, queueName: string): Promise<FlowProducer | null> {
-  const adapter = buildQueueNameLookup(queues).get(queueName) ?? findBullMQAdapter(queues);
-  return adapter ? adapter.getFlowProducer() : Promise.resolve(null);
+function findBoardAdapter(queues: BullBoardQueues, boardQueueName: string): BullMQAdapter | null {
+  const adapter = queues.get(boardQueueName);
+  return adapter?.type === 'bullmq' ? (adapter as unknown as BullMQAdapter) : null;
 }
 
-/**
- * Builds a lookup from raw BullMQ queue name to adapter.
- * Rebuilt on each call to stay consistent with dynamic queue changes.
- */
-function buildQueueNameLookup(queues: BullBoardQueues): Map<string, BullMQAdapter> {
+// Keyed by the qualified `prefix:name`, which is what a job's `opts.parent.queue` carries and the
+// only form that tells two board entries running one queue name under two prefixes apart.
+function buildQueueLookup(queues: BullBoardQueues): Map<string, BullMQAdapter> {
   const lookup = new Map<string, BullMQAdapter>();
+
   for (const adapter of queues.values()) {
     if (adapter.type === 'bullmq') {
       const bmq = adapter as unknown as BullMQAdapter;
-      lookup.set(bmq.getName(), bmq);
+      lookup.set(bmq.getQueueQualifiedName(), bmq);
     }
   }
+
   return lookup;
 }
 
@@ -39,52 +36,59 @@ export interface FlowWindow {
   maxChildren: number;
 }
 
+// A queue is registered on the board under `prefix` + the name BullMQ knows it by, and job URLs
+// and every other route are keyed by that rather than by the name a job reports.
+export function buildBoardQueueNameResolver(queues: BullBoardQueues): (job: Job) => string {
+  const lookup = buildQueueLookup(queues);
+  return (job) => lookup.get(job.queueQualifiedName)?.getName() ?? job.queueName;
+}
+
+// The producer comes from the flow root's own adapter, so on a board mixing backends or
+// connections the tree is read from the datastore it lives in. The first bullmq adapter is
+// only a fallback for a root whose queue is not registered on the board.
 export async function getFlowTree(
   queues: BullBoardQueues,
-  queueName: string,
+  boardQueueName: string,
   jobId: string,
   window: FlowWindow
 ): Promise<JobNode | null> {
-  const producer = await getFlowProducer(queues, queueName);
+  const adapter = findBoardAdapter(queues, boardQueueName);
+  const producer = await (adapter ?? findBullMQAdapter(queues))?.getFlowProducer();
   if (!producer) return null;
 
   return await producer
-    .getFlow({ queueName, id: jobId, depth: window.depth, maxChildren: window.maxChildren })
+    .getFlow({
+      queueName: adapter?.getQueueName() ?? boardQueueName,
+      id: jobId,
+      depth: window.depth,
+      maxChildren: window.maxChildren,
+    })
     .catch(() => null);
-}
-
-function simplifyQueueName(queueName: string, lookup: Map<string, BullMQAdapter>): string {
-  const simpleQueueName = Array.from(lookup.keys()).find(
-    (key) => queueName === key || queueName.endsWith(':' + key)
-  );
-  return simpleQueueName || queueName;
 }
 
 /**
  * Traverses the parent chain of a job across queues to find the flow root.
- * Returns the raw BullMQ queue name and job ID of the root, or null if
+ * Returns the board queue name and job ID of the root, or null if
  * no flow root can be determined.
  */
 export async function findFlowRoot(
   queues: BullBoardQueues,
   job: Job
 ): Promise<{ queueName: string; jobId: string } | null> {
-  const lookup = buildQueueNameLookup(queues);
+  const lookup = buildQueueLookup(queues);
   let currJob = job;
+  let currAdapter = lookup.get(job.queueQualifiedName);
+
   while (currJob) {
-    const currQueueName = simplifyQueueName(currJob.queueName, lookup);
     const parent = currJob.opts?.parent;
     if (!parent?.id || !parent?.queue) {
       if (!currJob.id) {
         return null;
       }
-      return { queueName: currQueueName, jobId: currJob.id };
+      return { queueName: currAdapter?.getName() ?? currJob.queueName, jobId: currJob.id };
     }
 
-    const parentQueueName = parent.queue;
-    const simpleParentQueueName = simplifyQueueName(parentQueueName, lookup);
-    const parentAdapter = simpleParentQueueName ? lookup.get(simpleParentQueueName) : null;
-
+    const parentAdapter = lookup.get(parent.queue);
     if (!parentAdapter) {
       return null;
     }
@@ -95,6 +99,7 @@ export async function findFlowRoot(
     }
 
     currJob = parentJob as Job;
+    currAdapter = parentAdapter;
   }
 
   return null;

--- a/packages/api/src/queueAdapters/bullMQ.ts
+++ b/packages/api/src/queueAdapters/bullMQ.ts
@@ -118,7 +118,7 @@ export class BullMQAdapter extends BaseAdapter {
   }
 
   public getName(): string {
-    return `${this.prefix}${this.queue.name}`;
+    return `${this.prefix}${this.getQueueName()}`;
   }
 
   public async getWorkers(): Promise<QueueWorker[] | null> {
@@ -404,6 +404,14 @@ export class BullMQAdapter extends BaseAdapter {
 
   public getQueuePrefix(): string | undefined {
     return this.queue.opts?.prefix;
+  }
+
+  public getQueueName(): string {
+    return this.queue.name;
+  }
+
+  public getQueueQualifiedName(): string {
+    return this.queue.qualifiedName;
   }
 
   /**

--- a/packages/api/tests/api/job-flow.spec.ts
+++ b/packages/api/tests/api/job-flow.spec.ts
@@ -445,6 +445,93 @@ describe('Job flow', () => {
     expect(res.body).toEqual({ nodeId: childJobId, flowRoot: null, isFlowNode: false });
   });
 
+  describe('with a board prefix', () => {
+    const boardPrefix = 'Category.';
+
+    function setupPrefixedBoard() {
+      createBullBoard({
+        queues: [
+          new BullMQAdapter(parentQueue, { prefix: boardPrefix }),
+          new BullMQAdapter(childQueue, { prefix: boardPrefix }),
+        ],
+        serverAdapter,
+      });
+      return request(serverAdapter.getRouter());
+    }
+
+    it('walks up to the flow root and names every node as the board does', async () => {
+      const tree = await flowProducer.add({
+        name: 'root',
+        queueName: parentQueue.name,
+        children: [{ name: 'leaf', queueName: childQueue.name, data: {} }],
+      });
+      const agent = setupPrefixedBoard();
+
+      const res = await agent
+        .get(`/api/queues/${boardPrefix}${childQueue.name}/${tree.children![0].job.id}/flow`)
+        .expect(200);
+
+      expect(res.body.isFlowNode).toBe(true);
+      expect(res.body.flowRoot.id).toBe(tree.job.id);
+      expect(res.body.flowRoot.queueName).toBe(`${boardPrefix}${parentQueue.name}`);
+      expect(res.body.flowRoot.children[0].queueName).toBe(`${boardPrefix}${childQueue.name}`);
+    });
+
+    it('roots the tree at the requested job when root=node', async () => {
+      const tree = await addChain();
+      const middleJobId = tree.children![0].job.id;
+      const agent = setupPrefixedBoard();
+
+      const res = await agent
+        .get(`/api/queues/${boardPrefix}${childQueue.name}/${middleJobId}/flow?root=node`)
+        .expect(200);
+
+      expect(res.body.flowRoot.id).toBe(middleJobId);
+      expect(res.body.flowRoot.queueName).toBe(`${boardPrefix}${childQueue.name}`);
+      expect(res.body.flowRoot.children[0].name).toBe('leaf');
+    });
+  });
+
+  it('keeps flow nodes on the right board entry when two tenants share a queue name', async () => {
+    const sharedName = `FlowTenant-${process.env.JEST_WORKER_ID}-${run}`;
+    const tenantA = new Queue(sharedName, { connection, prefix: 'tenant-a' });
+    const tenantB = new Queue(sharedName, { connection, prefix: 'tenant-b' });
+    const tenantBFlow = new FlowProducer({ connection, prefix: 'tenant-b' });
+
+    try {
+      await tenantA.obliterate({ force: true }).catch(() => {});
+      await tenantB.obliterate({ force: true }).catch(() => {});
+
+      const tree = await tenantBFlow.add({
+        name: 'root',
+        queueName: sharedName,
+        children: [{ name: 'leaf', queueName: sharedName, data: {} }],
+      });
+
+      createBullBoard({
+        queues: [
+          new BullMQAdapter(tenantA, { prefix: 'tenant-a:' }),
+          new BullMQAdapter(tenantB, { prefix: 'tenant-b:' }),
+        ],
+        serverAdapter,
+      });
+
+      const res = await request(serverAdapter.getRouter())
+        .get(`/api/queues/tenant-b:${sharedName}/${tree.children![0].job.id}/flow`)
+        .expect(200);
+
+      expect(res.body.flowRoot.id).toBe(tree.job.id);
+      expect(res.body.flowRoot.queueName).toBe(`tenant-b:${sharedName}`);
+      expect(res.body.flowRoot.children[0].queueName).toBe(`tenant-b:${sharedName}`);
+    } finally {
+      await tenantA.obliterate({ force: true }).catch(() => {});
+      await tenantB.obliterate({ force: true }).catch(() => {});
+      await tenantBFlow.close();
+      await tenantA.close();
+      await tenantB.close();
+    }
+  });
+
   it('returns a non-flow response for a Bull queue, which has no flows', async () => {
     const bullQueue = new Bull('FlowBull', { redis: connection });
     bullQueue.on('error', () => {});

--- a/packages/api/tests/bullmq-matrix/flow.spec.ts
+++ b/packages/api/tests/bullmq-matrix/flow.spec.ts
@@ -135,6 +135,27 @@ describe(`Job flow on bullmq@${EXPECTED_MAJOR}`, () => {
     expect(narrow.body.flowRoot.truncated).toBe(true);
   });
 
+  it('names flow nodes the way a prefixed board registered them', async () => {
+    const tree = await addFlow();
+    const boardPrefix = 'Category.';
+    const serverAdapter = new ExpressAdapter();
+    createBullBoard({
+      queues: [
+        new BullMQAdapter(parentQueue, { prefix: boardPrefix }),
+        new BullMQAdapter(childQueue, { prefix: boardPrefix }),
+      ],
+      serverAdapter,
+    });
+
+    const res = await request(serverAdapter.getRouter())
+      .get(`/api/queues/${boardPrefix}${childQueue.name}/${tree.children![0].job.id}/flow`)
+      .expect(200);
+
+    expect(res.body.flowRoot.id).toBe(tree.job.id);
+    expect(res.body.flowRoot.queueName).toBe(`${boardPrefix}${parentQueue.name}`);
+    expect(res.body.flowRoot.children[0].queueName).toBe(`${boardPrefix}${childQueue.name}`);
+  });
+
   it('roots the tree at the requested job when root=node', async () => {
     const tree = await addNestedFlow();
     const middleJobId = tree.children!.find((c) => c.job.name === 'middle')!.job.id;

--- a/packages/api/tests/bullmq-matrix/postgres.spec.ts
+++ b/packages/api/tests/bullmq-matrix/postgres.spec.ts
@@ -147,6 +147,37 @@ if (!runnable) {
       }
     });
 
+    it('names flow nodes the way a prefixed board registered them', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { FlowProducer, createPostgresBackend } = require('bullmq');
+      const producer = new FlowProducer({ connection: POSTGRES_URL }, createPostgresBackend);
+      const boardPrefix = 'Category.';
+
+      try {
+        const tree = await producer.add({
+          name: 'root',
+          queueName: queue.name,
+          children: [{ name: 'leaf', queueName: queue.name, data: {} }],
+        });
+
+        const serverAdapter = new ExpressAdapter();
+        createBullBoard({
+          queues: [new BullMQAdapter(queue, { prefix: boardPrefix })],
+          serverAdapter,
+        });
+
+        const res = await request(serverAdapter.getRouter())
+          .get(`/api/queues/${boardPrefix}${queue.name}/${tree.children![0].job.id}/flow`)
+          .expect(200);
+
+        expect(res.body.flowRoot.id).toBe(tree.job.id);
+        expect(res.body.flowRoot.queueName).toBe(`${boardPrefix}${queue.name}`);
+        expect(res.body.flowRoot.children[0].queueName).toBe(`${boardPrefix}${queue.name}`);
+      } finally {
+        await producer.close();
+      }
+    });
+
     it('resolves redis-backed flows even when a postgres queue is registered first', async () => {
       const redisQueue = new Queue(uniqueName('redis-flow'), { connection });
       const producer = new FlowProducer({ connection });


### PR DESCRIPTION
Fixes #1444.

A queue is registered on the board under `adapter.getName()`, which is the adapter's `prefix` followed by the queue name, and that is what every route param and every link in the UI is keyed by. BullMQ knows nothing about that prefix: a job reports `queueName` as the bare name, and `opts.parent.queue` as the qualified `redisPrefix:name`. The flow provider built its adapter lookup keyed by the board name and then matched BullMQ's names against it, so as soon as an adapter had a `prefix`, nothing matched.

Two failures followed. Walking a child job up to its flow root could not resolve the parent's adapter, so the endpoint answered `flowRoot: null` and the job looked like it had no flow at all. Where the tree did render, which is opening the root job itself since that needs no parent lookup, every node carried the bare queue name, so the details panel fetched `/api/queues/my_queue/<id>`, got a 404 and reported the job as gone, and "Open this job" pointed at a queue that does not exist on the board. `root=node` broke the other way round, passing the prefixed board name straight into `producer.getFlow()`, which finds nothing stored under that name.

The lookup is now keyed by the queue's qualified name, which is the exact form `opts.parent.queue` carries. That also settles the multi-tenant setup the NestJS docs describe, where one queue name runs under two Redis prefixes and two board prefixes, and the old bare-name match would have picked whichever adapter was registered first. `getFlowTree` takes a board name and translates it back to the raw name for BullMQ, `findFlowRoot` returns a board name, and every node in the response goes through `buildBoardQueueNameResolver`. The UI needed no change.

Both screenshots are the same board, registered as `new BullMQAdapter(queue, { prefix: 'Category.' })`, opened on the flow's root job with a child node selected.

Before, the nodes are labelled `my_queue` and `my_chunks`, and the selected child reports "This job is no longer in its queue":

![Flow view before the fix](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-flow-board-queue-names/.pr-assets/flow-prefix-before.png)

After, the nodes carry the names the board registered, and the child resolves:

![Flow view after the fix](https://raw.githubusercontent.com/Stosiu/bull-board/pr-assets-flow-board-queue-names/.pr-assets/flow-prefix-after.png)

Three cases cover it in `tests/api/job-flow.spec.ts`: a prefixed board resolving the root from a child job and naming every node as the board does, `root=node` under a prefix, and two tenants sharing one queue name under different Redis prefixes. One more sits in `tests/bullmq-matrix/flow.spec.ts` so both BullMQ majors exercise it, and one in `tests/bullmq-matrix/postgres.spec.ts`, because a v6 PostgreSQL backend's qualified name is just the bare queue name rather than `prefix:name`. Each of them was confirmed failing against the current code before the fix landed. The full workspace suite passes, including the BullMQ v5 floor and v6 projects with `POSTGRES_URL` set.
